### PR TITLE
[codex] fix canvas local image recovery

### DIFF
--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/ProjectCanvasPageStageScene.test.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/ProjectCanvasPageStageScene.test.tsx
@@ -2696,6 +2696,67 @@ describe('ProjectCanvasPageStageScene WebGL integration seam', () => {
     expect(imageInteractionOverlayProps.get(item.id)?.suppressImagePreview).toBe(false)
   })
 
+  it('keeps unselected fallback images visible through the DOM placeholder proxy', async () => {
+    const item = createImageItem('image-fallback-unselected')
+    item.image = undefined
+    webglReady = true
+    webglLoadedIds = new Set()
+    webglResidentIds = new Set()
+
+    render(
+      <ProjectCanvasPageStageScene
+        {...createBaseProps([item])}
+        tool="select"
+        selectedIds={new Set()}
+      />
+    )
+
+    await waitFor(() => {
+      expect(canvasPlaceholderProps.has(item.id)).toBe(true)
+    })
+
+    const root = screen.getByTestId('project-canvas-stage-root')
+    expect(root).toHaveAttribute('data-project-canvas-fallback-image-count', '1')
+    expect(root).toHaveAttribute('data-project-canvas-unloaded-fallback-image-count', '1')
+    expect(imageInteractionOverlayProps.has(item.id)).toBe(false)
+    expect(canvasPlaceholderProps.get(item.id)?.isSelected).toBe(false)
+    expect(canvasPlaceholderProps.get(item.id)?.renderMode).toBe('dom-placeholder-proxy')
+    expect(canvasPlaceholderProps.get(item.id)?.visualVariant).toBe('image-fallback')
+  })
+
+  it('keeps multi-selected fallback images visible while a large selection rect is present', async () => {
+    const imageItem = createImageItem('image-fallback-multi-selected')
+    const shapeItem = createAnnotationItem('shape-fallback-multi-selected')
+    shapeItem.x = 900
+    webglReady = true
+    webglLoadedIds = new Set()
+    webglResidentIds = new Set()
+
+    render(
+      <ProjectCanvasPageStageScene
+        {...createBaseProps([imageItem, shapeItem])}
+        tool="select"
+        selectedIds={new Set([imageItem.id, shapeItem.id])}
+        selectionRect={{
+          startX: 40,
+          startY: 60,
+          x: 40,
+          y: 60,
+          w: 920,
+          h: 180
+        }}
+      />
+    )
+
+    await waitFor(() => {
+      expect(canvasPlaceholderProps.has(imageItem.id)).toBe(true)
+    })
+
+    expect(imageInteractionOverlayProps.has(imageItem.id)).toBe(false)
+    expect(canvasPlaceholderProps.get(imageItem.id)?.isSelected).toBe(true)
+    expect(canvasPlaceholderProps.get(imageItem.id)?.visualVariant).toBe('image-fallback')
+  })
+
   it('routes a selected fallback image through the DOM image interaction overlay', async () => {
     const item = createImageItem('image-placeholder-dom')
     const handleTransformEnd = vi.fn()

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/ProjectCanvasPageStageScene.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/ProjectCanvasPageStageScene.tsx
@@ -1233,6 +1233,7 @@ export default function ProjectCanvasPageStageScene(props: any) {
           (!webglImageLayerReady ||
             imageFallbackReason === 'failed' ||
             imageFallbackReason === 'unsupported')
+        const activeRuntimeRoute = runtimeRoute ?? 'fallback-image-proxy'
         if (
           shouldUseDenseWebglImageProxyBudget &&
           !shouldKeepFallbackProxy &&
@@ -1246,7 +1247,7 @@ export default function ProjectCanvasPageStageScene(props: any) {
           ? 'placeholder-hit-proxy'
           : resolveProjectCanvasImageInteractionMode({
               item: renderableItem.item,
-              runtimeRoute: runtimeRoute ?? 'fallback-image-proxy',
+              runtimeRoute: activeRuntimeRoute,
               tool,
               isSingleSelected: isSingleSelectedImage
             })
@@ -2561,17 +2562,21 @@ export default function ProjectCanvasPageStageScene(props: any) {
         }
 
         if (item.type === 'image') {
-          const imageRuntimeRoute = getImageRuntimeRoute(item as CanvasImageItem)
+          const imageItem = item as CanvasImageItem
+          const imageRuntimeRoute = getImageRuntimeRoute(imageItem)
           const imageFallbackReason = imageFallbackReasonById.get(item.id)
+          const canRenderImagePreview =
+            Boolean(imageItem.image) || (tool === 'select' && !!imageItem.src)
           const imageProxyVisualVariant =
-            imageRuntimeRoute === 'webgl-primary' || imageFallbackReason === 'unloaded'
+            imageRuntimeRoute === 'webgl-primary' ||
+            (!canRenderImagePreview && imageFallbackReason === 'unloaded')
               ? 'transparent'
               : 'image-fallback'
           return (
             <CanvasItemPlaceholder
               key={item.id}
               canvasContainerRef={canvasContainerRef}
-              item={item as CanvasImageItem}
+              item={imageItem}
               isSelected={isSelected}
               isDraggable={tool === 'select' && !(item as CanvasImageItem).locked}
               allowPointerPassthrough={tool === 'hand'}

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasAssetIntakeHelpers.test.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasAssetIntakeHelpers.test.ts
@@ -84,6 +84,7 @@ describe('canvasAssetIntakeHelpers', () => {
   const originalToBlob = HTMLCanvasElement.prototype.toBlob
   const originalToDataURL = HTMLCanvasElement.prototype.toDataURL
   const originalCreateObjectURL = URL.createObjectURL
+  const originalRevokeObjectURL = URL.revokeObjectURL
   const originalCreateImageBitmap = globalThis.createImageBitmap
   const originalApi = window.api
 
@@ -118,6 +119,7 @@ describe('canvasAssetIntakeHelpers', () => {
   afterEach(() => {
     window.Image = originalImageCtor
     URL.createObjectURL = originalCreateObjectURL
+    URL.revokeObjectURL = originalRevokeObjectURL
     Object.defineProperty(globalThis, 'createImageBitmap', {
       configurable: true,
       writable: true,
@@ -336,6 +338,79 @@ describe('canvasAssetIntakeHelpers', () => {
     })
   })
 
+  it('rehydrates persisted local images through svcFs when local-media image loading is blocked', async () => {
+    const readImageFromPath = vi.fn(async () => ({
+      image: new Uint8Array([1, 2, 3, 4]),
+      filename: 'reference.png'
+    }))
+    const createObjectUrl = vi.fn(() => 'blob:recovered-local-image')
+    const revokeObjectUrl = vi.fn()
+    URL.createObjectURL = createObjectUrl as unknown as typeof URL.createObjectURL
+    URL.revokeObjectURL = revokeObjectUrl as unknown as typeof URL.revokeObjectURL
+
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      writable: true,
+      value: {
+        svcFs: {
+          readImageFromPath
+        }
+      }
+    })
+
+    const loadedImage = createImage(640, 360)
+    const loadImageFromSrc = vi.fn(async (src: string) => {
+      if (src === 'local-media:///C:/assets/reference.png') {
+        throw new Error('blocked local-media')
+      }
+      if (src === 'blob:recovered-local-image') {
+        return {
+          img: loadedImage,
+          width: 640,
+          height: 360
+        }
+      }
+
+      throw new Error(`Unexpected source load: ${src}`)
+    })
+
+    const item: CanvasImageItem = {
+      id: 'image-local-1',
+      type: 'image',
+      src: 'local-media:///C:/assets/reference.png',
+      fileName: 'reference.png',
+      x: 0,
+      y: 0,
+      width: 320,
+      height: 180,
+      rotation: 0,
+      scaleX: 1,
+      scaleY: 1,
+      zIndex: 1,
+      locked: false,
+      hasAlpha: false,
+      sizeBytes: 4
+    }
+
+    const hydrated = await hydrateCanvasImageItemForCanvas({
+      item,
+      loadImageFromSrc,
+      maxPreviewSide: CANVAS_IMAGE_PROXY_MAX_SIDE
+    })
+
+    expect(readImageFromPath).toHaveBeenCalledWith({ fullPath: 'C:/assets/reference.png' })
+    expect(loadImageFromSrc).toHaveBeenNthCalledWith(1, 'local-media:///C:/assets/reference.png')
+    expect(loadImageFromSrc).toHaveBeenNthCalledWith(2, 'blob:recovered-local-image')
+    expect(revokeObjectUrl).toHaveBeenCalledWith('blob:recovered-local-image')
+    expect(hydrated).toMatchObject({
+      id: 'image-local-1',
+      src: 'local-media:///C:/assets/reference.png',
+      image: loadedImage,
+      sourceWidth: 640,
+      sourceHeight: 360
+    })
+  })
+
   it('rehydrates local images from warm thumbnail cache without loading the source image', async () => {
     const sourceIdentity = buildCanvasImageSourceIdentity({
       canonicalPath: 'C:/assets/reference.png',
@@ -444,6 +519,100 @@ describe('canvasAssetIntakeHelpers', () => {
 
     expect(loadImageFromSrc).toHaveBeenCalledTimes(1)
     expect(loadImageFromSrc).toHaveBeenCalledWith('local-media:///cache/reference/512.webp')
+    expect(hydrated).toMatchObject({
+      id: 'image-reference-1',
+      src: 'local-media:///C:/assets/reference.png',
+      image: thumbnailImage,
+      thumbnailSet
+    })
+  })
+
+  it('recovers warm thumbnail previews through svcFs when local-media loading is blocked', async () => {
+    const sourceIdentity = buildCanvasImageSourceIdentity({
+      canonicalPath: 'C:/assets/reference.png',
+      sizeBytes: 4096,
+      lastModifiedMs: 123456
+    })
+    expect(sourceIdentity).not.toBeNull()
+
+    const thumbnailSet = createCanvasThumbnailSet({
+      identity: sourceIdentity!,
+      levels: ([128, 256, 512, 1024, 2048] as const).map((maxSide) => ({
+        maxSide,
+        src: `local-media:///cache/reference/${maxSide}.webp`,
+        filename: `${maxSide}.webp`,
+        mimeType: 'image/webp',
+        width: maxSide,
+        height: maxSide / 2,
+        sizeBytes: maxSide
+      })),
+      now: new Date('2026-05-02T00:00:00.000Z')
+    })
+    const readImageFromPath = vi.fn(async () => ({
+      image: new Uint8Array([1, 2, 3, 4]),
+      filename: '512.webp'
+    }))
+    const createObjectUrl = vi.fn(() => 'blob:recovered-thumbnail')
+    const revokeObjectUrl = vi.fn()
+    URL.createObjectURL = createObjectUrl as unknown as typeof URL.createObjectURL
+    URL.revokeObjectURL = revokeObjectUrl as unknown as typeof URL.revokeObjectURL
+
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      writable: true,
+      value: {
+        svcCanvasThumbnail: {
+          readThumbnailManifest: vi.fn(async () => ({
+            manifest: canvasThumbnailManifestFromSet(thumbnailSet)
+          }))
+        },
+        svcFs: {
+          readImageFromPath
+        }
+      }
+    })
+
+    const thumbnailImage = createImage(512, 256)
+    const loadImageFromSrc = vi.fn(async (src: string) => {
+      if (src === 'local-media:///cache/reference/512.webp') {
+        throw new Error('blocked thumbnail')
+      }
+      if (src === 'blob:recovered-thumbnail') {
+        return {
+          img: thumbnailImage,
+          width: 512,
+          height: 256
+        }
+      }
+
+      throw new Error(`Unexpected source load: ${src}`)
+    })
+
+    const item: CanvasImageItem = {
+      id: 'image-reference-1',
+      type: 'image',
+      src: 'local-media:///C:/assets/reference.png',
+      fileName: 'reference.png',
+      sourceIdentity: sourceIdentity!,
+      x: 0,
+      y: 0,
+      width: 1024,
+      height: 512,
+      rotation: 0,
+      scaleX: 1,
+      scaleY: 1,
+      zIndex: 1,
+      locked: false,
+      sourceWidth: 4096,
+      sourceHeight: 2048
+    }
+
+    const hydrated = await hydrateCanvasImageItemForCanvas({ item, loadImageFromSrc })
+
+    expect(readImageFromPath).toHaveBeenCalledWith({ fullPath: 'cache/reference/512.webp' })
+    expect(loadImageFromSrc).toHaveBeenNthCalledWith(1, 'local-media:///cache/reference/512.webp')
+    expect(loadImageFromSrc).toHaveBeenNthCalledWith(2, 'blob:recovered-thumbnail')
+    expect(revokeObjectUrl).toHaveBeenCalledWith('blob:recovered-thumbnail')
     expect(hydrated).toMatchObject({
       id: 'image-reference-1',
       src: 'local-media:///C:/assets/reference.png',

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasAssetIntakeHelpers.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasAssetIntakeHelpers.ts
@@ -6,6 +6,10 @@ import { normalizeFileMimeType } from '@renderer/utils/fileDisplay'
 import { isCanvasThumbnailSetFresh, pickBestCanvasThumbnailLevel } from './canvasThumbnailCache'
 import { ensureCanvasThumbnailSet, readWarmCanvasThumbnailSet } from './canvasThumbnailWorkerClient'
 import type { CanvasImageSourceIdentity, CanvasImageThumbnailSet } from './canvasThumbnailTypes'
+import {
+  createCanvasLocalImageObjectUrl,
+  readCanvasLocalImageBlobFromSource
+} from './canvasLocalImageSource'
 
 export const CANVAS_IMAGE_PROXY_MAX_SIDE = 2048
 export const CANVAS_IMAGE_PROXY_SMALL_BATCH_MAX_SIDE = 1024
@@ -496,13 +500,27 @@ async function createComfyImageObjectUrl(item: CanvasImageItem): Promise<string 
 async function loadHydratableCanvasImageSource(
   item: CanvasImageItem,
   loadImageFromSrcFn: (src: string) => Promise<LoadedCanvasImage>
-): Promise<{ src: string; loaded: LoadedCanvasImage } | null> {
+): Promise<{ src: string; loaded: LoadedCanvasImage; revokeSrc?: string } | null> {
   try {
     return {
       src: item.src,
       loaded: await loadImageFromSrcFn(item.src)
     }
   } catch {
+    const recoveredLocalSrc = await createCanvasLocalImageObjectUrl(item.src, item.fileName)
+    if (recoveredLocalSrc) {
+      try {
+        return {
+          src: item.src,
+          loaded: await loadImageFromSrcFn(recoveredLocalSrc),
+          revokeSrc: recoveredLocalSrc
+        }
+      } catch (error) {
+        URL.revokeObjectURL(recoveredLocalSrc)
+        console.warn('[Canvas] Failed to hydrate recovered local image source:', item.id, error)
+      }
+    }
+
     const recoveredSrc = await createComfyImageObjectUrl(item)
     if (!recoveredSrc || recoveredSrc === item.src) {
       return null
@@ -593,6 +611,11 @@ async function resolveCanvasImageThumbnailSourceBlob({
     return sourceFile
   }
 
+  const localBlob = await readCanvasLocalImageBlobFromSource(src)
+  if (localBlob) {
+    return localBlob
+  }
+
   if (typeof fetch !== 'function' || !canFetchCanvasImageThumbnailSource(src)) {
     return null
   }
@@ -661,6 +684,28 @@ export async function resolveCanvasImageThumbnailDisplayAsset({
       thumbnailSet: resolvedThumbnailSet
     }
   } catch (error) {
+    const recoveredThumbnailSrc = await createCanvasLocalImageObjectUrl(
+      thumbnailLevel.src,
+      thumbnailLevel.filename
+    )
+    if (recoveredThumbnailSrc) {
+      try {
+        const { img } = await loadImageFromSrcFn(recoveredThumbnailSrc)
+        return {
+          image: img,
+          thumbnailSet: resolvedThumbnailSet
+        }
+      } catch (recoveredError) {
+        console.warn(
+          '[Canvas] Failed to load recovered thumbnail preview image:',
+          thumbnailLevel.src,
+          recoveredError
+        )
+      } finally {
+        URL.revokeObjectURL(recoveredThumbnailSrc)
+      }
+    }
+
     console.warn('[Canvas] Failed to load thumbnail preview image:', thumbnailLevel.src, error)
     return null
   }
@@ -799,5 +844,9 @@ export async function hydrateCanvasImageItemForCanvas(
   } catch {
     console.warn('[Canvas] Failed to hydrate imported image, skipping:', item.id)
     return null
+  } finally {
+    if (resolvedSource.revokeSrc) {
+      URL.revokeObjectURL(resolvedSource.revokeSrc)
+    }
   }
 }

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasLocalImageSource.test.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasLocalImageSource.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  createCanvasLocalImageObjectUrl,
+  resolveCanvasLocalFilePathFromSource
+} from './canvasLocalImageSource'
+
+describe('canvasLocalImageSource', () => {
+  const originalApi = window.api
+  const originalCreateObjectURL = URL.createObjectURL
+
+  afterEach(() => {
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      writable: true,
+      value: originalApi
+    })
+    URL.createObjectURL = originalCreateObjectURL
+    vi.restoreAllMocks()
+  })
+
+  it('resolves canonical and browser-normalized local media URLs to file paths', () => {
+    expect(resolveCanvasLocalFilePathFromSource('local-media:///C:/Users/me/image.png')).toBe(
+      'C:/Users/me/image.png'
+    )
+    expect(resolveCanvasLocalFilePathFromSource('local-media://c/Users/me/image.png')).toBe(
+      'c:/Users/me/image.png'
+    )
+    expect(resolveCanvasLocalFilePathFromSource('file:///C:/Users/me/image.png')).toBe(
+      'C:/Users/me/image.png'
+    )
+  })
+
+  it('creates a blob URL from a local image path through svcFs', async () => {
+    const image = new Uint8Array([1, 2, 3, 4])
+    const readImageFromPath = vi.fn(async () => ({ image, filename: '无标题(95).png' }))
+    const createObjectUrl = vi.fn((_blob: Blob) => 'blob:local-image')
+    URL.createObjectURL = createObjectUrl as unknown as typeof URL.createObjectURL
+
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      writable: true,
+      value: {
+        svcFs: {
+          readImageFromPath
+        }
+      }
+    })
+
+    const objectUrl = await createCanvasLocalImageObjectUrl(
+      'local-media://c/Users/17290/Desktop/%E6%96%B0%E5%BB%BA%E6%96%87%E4%BB%B6%E5%A4%B9/%E6%97%A0%E6%A0%87%E9%A2%98(95).png'
+    )
+
+    expect(objectUrl).toBe('blob:local-image')
+    expect(readImageFromPath).toHaveBeenCalledWith({
+      fullPath: 'c:/Users/17290/Desktop/新建文件夹/无标题(95).png'
+    })
+    expect((createObjectUrl.mock.calls[0]?.[0] as Blob | undefined)?.type).toBe('image/png')
+  })
+})

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasLocalImageSource.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasLocalImageSource.ts
@@ -1,0 +1,111 @@
+import { normalizeFileMimeType } from '@renderer/utils/fileDisplay'
+
+function decodePathPart(value: string): string {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
+}
+
+function normalizeLocalPath(value: string): string {
+  const decoded = decodePathPart(value).replace(/\\/g, '/')
+  if (/^\/[a-zA-Z]:($|\/)/.test(decoded)) {
+    return decoded.slice(1)
+  }
+
+  return decoded.replace(/^\/+/, '')
+}
+
+export function resolveCanvasLocalFilePathFromSource(sourceUrl: string): string | null {
+  const normalized = sourceUrl.trim()
+  if (!normalized) {
+    return null
+  }
+
+  try {
+    const url = new URL(normalized)
+    if (url.protocol !== 'local-media:' && url.protocol !== 'file:') {
+      return null
+    }
+
+    if (url.hostname) {
+      const hostname = decodePathPart(url.hostname)
+      const pathname = normalizeLocalPath(url.pathname)
+      if (/^[a-zA-Z]$/.test(hostname)) {
+        return `${hostname}:/${pathname}`
+      }
+
+      return `//${hostname}${url.pathname ? `/${pathname}` : ''}`
+    }
+
+    return normalizeLocalPath(url.pathname)
+  } catch {
+    // Fall through to prefix handling for partially escaped legacy URLs.
+  }
+
+  if (normalized.startsWith('local-media:///')) {
+    return normalizeLocalPath(normalized.slice('local-media:///'.length))
+  }
+
+  if (normalized.startsWith('local-media://')) {
+    const rest = normalizeLocalPath(normalized.slice('local-media://'.length))
+    const driveMatch = rest.match(/^([a-zA-Z])\/(.+)$/)
+    if (driveMatch) {
+      return `${driveMatch[1]}:/${driveMatch[2]}`
+    }
+
+    return rest
+  }
+
+  if (normalized.startsWith('file:///')) {
+    return normalizeLocalPath(normalized.slice('file:///'.length))
+  }
+
+  if (normalized.startsWith('file://')) {
+    const rest = normalizeLocalPath(normalized.slice('file://'.length))
+    const driveMatch = rest.match(/^([a-zA-Z])\/(.+)$/)
+    if (driveMatch) {
+      return `${driveMatch[1]}:/${driveMatch[2]}`
+    }
+
+    return rest
+  }
+
+  return null
+}
+
+export function canReadCanvasLocalImageSource(sourceUrl: string): boolean {
+  return Boolean(
+    resolveCanvasLocalFilePathFromSource(sourceUrl) &&
+    typeof window !== 'undefined' &&
+    window.api?.svcFs?.readImageFromPath
+  )
+}
+
+export async function readCanvasLocalImageBlobFromSource(
+  sourceUrl: string,
+  fileName?: string
+): Promise<Blob | null> {
+  const fullPath = resolveCanvasLocalFilePathFromSource(sourceUrl)
+  if (!fullPath || typeof window === 'undefined' || !window.api?.svcFs?.readImageFromPath) {
+    return null
+  }
+
+  try {
+    const { image, filename } = await window.api.svcFs.readImageFromPath({ fullPath })
+    const mimeType = normalizeFileMimeType(fileName ?? filename ?? fullPath, undefined, 'image/png')
+    return new Blob([image as BlobPart], { type: mimeType })
+  } catch (error) {
+    console.warn('[Canvas] Failed to read local image source:', fullPath, error)
+    return null
+  }
+}
+
+export async function createCanvasLocalImageObjectUrl(
+  sourceUrl: string,
+  fileName?: string
+): Promise<string | null> {
+  const blob = await readCanvasLocalImageBlobFromSource(sourceUrl, fileName)
+  return blob ? URL.createObjectURL(blob) : null
+}

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/CanvasImageDomPreview.test.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/CanvasImageDomPreview.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { render, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import CanvasImageDomPreview, {
@@ -9,6 +9,9 @@ import type { CanvasImageItem } from '../types'
 
 const originalGetContext = HTMLCanvasElement.prototype.getContext
 const originalDevicePixelRatio = window.devicePixelRatio
+const originalCreateObjectURL = URL.createObjectURL
+const originalRevokeObjectURL = URL.revokeObjectURL
+const originalApi = window.api
 
 function createImage(width: number, height: number) {
   const image = document.createElement('img')
@@ -57,10 +60,18 @@ function mockCanvas2DContext() {
 
 afterEach(() => {
   HTMLCanvasElement.prototype.getContext = originalGetContext
+  URL.createObjectURL = originalCreateObjectURL
+  URL.revokeObjectURL = originalRevokeObjectURL
+  Object.defineProperty(window, 'api', {
+    configurable: true,
+    writable: true,
+    value: originalApi
+  })
   Object.defineProperty(window, 'devicePixelRatio', {
     configurable: true,
     value: originalDevicePixelRatio
   })
+  vi.restoreAllMocks()
 })
 
 describe('CanvasImageDomPreview', () => {
@@ -159,6 +170,45 @@ describe('CanvasImageDomPreview', () => {
       'data-canvas-source-image-preview',
       'true'
     )
+  })
+
+  it('materializes local source previews through svcFs before rendering the image', async () => {
+    const readImageFromPath = vi.fn(async () => ({
+      image: new Uint8Array([1, 2, 3, 4]),
+      filename: 'huge.png'
+    }))
+    const createObjectUrl = vi.fn(() => 'blob:materialized-preview')
+    const revokeObjectUrl = vi.fn()
+    URL.createObjectURL = createObjectUrl as unknown as typeof URL.createObjectURL
+    URL.revokeObjectURL = revokeObjectUrl as unknown as typeof URL.revokeObjectURL
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      writable: true,
+      value: {
+        svcFs: {
+          readImageFromPath
+        }
+      }
+    })
+
+    const { unmount } = render(
+      <CanvasImageDomPreview
+        item={createItem({ image: undefined as unknown as CanvasImageItem['image'] })}
+        previewMode="high-res-source"
+        sourceImagePreview
+        stageScale={1}
+      />
+    )
+
+    expect(document.querySelector('img')).toBeNull()
+    await waitFor(() => {
+      expect(document.querySelector('img')?.getAttribute('src')).toBe('blob:materialized-preview')
+    })
+    expect(readImageFromPath).toHaveBeenCalledWith({ fullPath: 'C:/real-board/huge.png' })
+
+    unmount()
+
+    expect(revokeObjectUrl).toHaveBeenCalledWith('blob:materialized-preview')
   })
 
   it('keeps original source previews smoothly sampled at extreme zoom', () => {

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/CanvasImageDomPreview.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/CanvasImageDomPreview.tsx
@@ -7,6 +7,10 @@ import {
 } from '../canvasImageDisplayUtils'
 import { resolveCanvasImageLodDecision } from '../canvasImageLodPolicy'
 import { getCanvasImageAssetSize } from '../canvasImageAssetUtils'
+import {
+  canReadCanvasLocalImageSource,
+  createCanvasLocalImageObjectUrl
+} from '../canvasLocalImageSource'
 
 type CanvasImageDomPreviewProps = {
   item: CanvasImageItem
@@ -109,6 +113,11 @@ export default function CanvasImageDomPreview({
 }: CanvasImageDomPreviewProps) {
   const canvasRef = React.useRef<HTMLCanvasElement | null>(null)
   const [canvasReady, setCanvasReady] = React.useState(false)
+  const [materializedSource, setMaterializedSource] = React.useState<{
+    originalSrc: string
+    objectUrl: string | null
+    failed: boolean
+  } | null>(null)
   const hasImageAsset = Boolean(item.image)
   const shouldDrawAssetCanvas = hasImageAsset && !sourceImagePreview
 
@@ -145,10 +154,53 @@ export default function CanvasImageDomPreview({
   const shouldRenderFallbackImage =
     hasImageAsset && !canvasReady && lodDecision.shouldUseSourceTexture
   const shouldRenderSourceImage = sourceImagePreview || shouldRenderFallbackImage
+  const shouldMaterializeLocalSource =
+    shouldRenderSourceImage && canReadCanvasLocalImageSource(item.src)
   const fallbackLayout = React.useMemo(
     () => (shouldRenderSourceImage ? resolveCanvasImageDomPreviewLayout(item) : null),
     [item, shouldRenderSourceImage]
   )
+  const materializedObjectUrl =
+    materializedSource?.originalSrc === item.src ? materializedSource.objectUrl : null
+  const materializedFailed =
+    materializedSource?.originalSrc === item.src ? materializedSource.failed : false
+  const previewImageSrc = shouldMaterializeLocalSource
+    ? (materializedObjectUrl ?? (materializedFailed ? item.src : null))
+    : item.src
+
+  React.useEffect(() => {
+    if (!shouldMaterializeLocalSource) {
+      setMaterializedSource(null)
+      return
+    }
+
+    let cancelled = false
+    let objectUrl: string | null = null
+    setMaterializedSource(null)
+
+    void createCanvasLocalImageObjectUrl(item.src, item.fileName).then((resolvedSrc) => {
+      objectUrl = resolvedSrc
+      if (cancelled) {
+        if (objectUrl) {
+          URL.revokeObjectURL(objectUrl)
+        }
+        return
+      }
+
+      setMaterializedSource({
+        originalSrc: item.src,
+        objectUrl,
+        failed: !objectUrl
+      })
+    })
+
+    return () => {
+      cancelled = true
+      if (objectUrl) {
+        URL.revokeObjectURL(objectUrl)
+      }
+    }
+  }, [item.fileName, item.src, shouldMaterializeLocalSource])
 
   return (
     <Box
@@ -178,10 +230,10 @@ export default function CanvasImageDomPreview({
           }}
         />
       ) : null}
-      {shouldRenderSourceImage ? (
+      {shouldRenderSourceImage && previewImageSrc ? (
         <Box
           component="img"
-          src={item.src}
+          src={previewImageSrc}
           alt=""
           draggable={false}
           loading="lazy"

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/CanvasItemPlaceholder.test.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/CanvasItemPlaceholder.test.tsx
@@ -146,6 +146,34 @@ describe('CanvasItemPlaceholder', () => {
     )
   })
 
+  it('uses the source image for image fallback placeholders without a decoded asset', () => {
+    const item = createImageItem()
+
+    render(
+      <CanvasItemPlaceholder
+        canvasContainerRef={React.createRef<HTMLDivElement>()}
+        item={item}
+        isSelected={false}
+        visualVariant="image-fallback"
+        stagePos={{ x: 0, y: 0 }}
+        stageScale={1}
+        onSelect={vi.fn()}
+        onDragEnd={vi.fn()}
+        onTransformEnd={vi.fn()}
+      />
+    )
+
+    const previewContent = rectOverlayProps.at(-1)?.previewContent as
+      | React.ReactElement<{
+          previewMode?: string
+          sourceImagePreview?: boolean
+        }>
+      | undefined
+
+    expect(previewContent?.props.previewMode).toBe('image-fallback')
+    expect(previewContent?.props.sourceImagePreview).toBe(true)
+  })
+
   it('restores the body cursor on mouse leave instead of forcing default', () => {
     render(
       <CanvasItemPlaceholder

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/CanvasItemPlaceholder.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/CanvasItemPlaceholder.tsx
@@ -113,7 +113,12 @@ const CanvasItemPlaceholder: React.FC<CanvasItemPlaceholderProps> = ({
     }
 
     return (
-      <CanvasImageDomPreview item={item} previewMode="image-fallback" stageScale={stageScale} />
+      <CanvasImageDomPreview
+        item={item}
+        previewMode="image-fallback"
+        stageScale={stageScale}
+        sourceImagePreview={!item.image}
+      />
     )
   }, [item, stageScale, visualVariant])
 


### PR DESCRIPTION
﻿## Summary

- recover persisted local canvas images by materializing `local-media://` and `file://` sources through `svcFs` when direct browser image loading fails
- keep unselected and multi-selected fallback images visible through the DOM placeholder path
- add focused coverage for local path normalization, hydration fallback, thumbnail fallback, and source preview rendering

## Root Cause

Dragged images were visible while their decoded `HTMLImageElement` stayed in memory. After reload or restore, the canvas only had the persisted local source URL, and direct `local-media://` image loading could fail under the renderer origin, leaving no drawable image for unselected or restored items.

## Validation

- `npx vitest run --config config/vitest/vitest.web.config.mjs packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasLocalImageSource.test.ts packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasAssetIntakeHelpers.test.ts packages/app/src/renderer/src/pages/ProjectCanvasPage/components/CanvasImageDomPreview.test.tsx packages/app/src/renderer/src/pages/ProjectCanvasPage/components/CanvasItemPlaceholder.test.tsx packages/app/src/renderer/src/pages/ProjectCanvasPage/ProjectCanvasPageStageScene.test.tsx`
- `npm run typecheck:web`
