### PR TITLE
[codex] fix canvas local image rendering

### DIFF
--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/ProjectCanvasPageStageScene.test.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/ProjectCanvasPageStageScene.test.tsx
@@ -705,6 +705,15 @@ describe('ProjectCanvasPageStageScene WebGL integration seam', () => {
       '[data-project-canvas-high-res-image-layer="dom"] img[data-canvas-source-image-preview="true"]'
     )
     expect(highResImage?.getAttribute('src')).toBe('file:///image-jumbo-webgl-source.png')
+
+    const highResLayer = document.querySelector(
+      '[data-project-canvas-high-res-image-layer="dom"]'
+    ) as HTMLElement | null
+    expect(highResLayer).not.toBeNull()
+    act(() => {
+      root.setAttribute('data-project-canvas-marquee-active', 'true')
+    })
+    expect(getComputedStyle(highResLayer as HTMLElement).display).not.toBe('none')
   })
 
   it('budgets jumbo source overlays by visible pixels instead of a four item cap', async () => {
@@ -1421,7 +1430,7 @@ describe('ProjectCanvasPageStageScene WebGL integration seam', () => {
     expect(syncViewportSpy).toHaveBeenCalledWith({ x: 96, y: 72 }, 1.25)
   })
 
-  it('temporarily suspends DOM image interaction overlays during marquee selection', async () => {
+  it('keeps DOM image interaction overlays visible during marquee selection while suppressing chrome', async () => {
     const selectedItem = createImageItem('image-selected')
     const siblingItem = createImageItem('image-sibling')
     siblingItem.x = 420
@@ -1444,11 +1453,15 @@ describe('ProjectCanvasPageStageScene WebGL integration seam', () => {
     )
 
     await waitFor(() => {
-      expect(imageInteractionOverlayProps.size).toBe(0)
+      expect(imageInteractionOverlayProps.has(selectedItem.id)).toBe(true)
     })
     expect(canvasPlaceholderProps.has(selectedItem.id)).toBe(false)
     expect(canvasPlaceholderProps.has(siblingItem.id)).toBe(true)
     expect(canvasPlaceholderProps.get(siblingItem.id)?.visualVariant).toBe('transparent')
+    expect(imageInteractionOverlayProps.get(selectedItem.id)?.isSelected).toBe(false)
+    expect(imageInteractionOverlayProps.get(selectedItem.id)?.showTransformer).toBe(false)
+    expect(imageInteractionOverlayProps.get(selectedItem.id)?.isDraggable).toBe(false)
+    expect(imageInteractionOverlayProps.get(selectedItem.id)?.allowPointerPassthrough).toBe(true)
   })
 
   it('keeps DOM image interaction overlays mounted for zero-size marquee noise', async () => {
@@ -1479,7 +1492,7 @@ describe('ProjectCanvasPageStageScene WebGL integration seam', () => {
     expect(canvasPlaceholderProps.has(selectedItem.id)).toBe(false)
   })
 
-  it('hides proxy hit layers while the canvas marquee flag is active', async () => {
+  it('keeps proxy hit layers visible while the canvas marquee flag is active', async () => {
     const selectedItem = createImageItem('image-marquee-proxy-selected')
     const siblingItem = createImageItem('image-marquee-proxy-sibling')
     siblingItem.x = 420
@@ -1509,7 +1522,7 @@ describe('ProjectCanvasPageStageScene WebGL integration seam', () => {
       root.setAttribute('data-project-canvas-marquee-active', 'true')
     })
 
-    expect(getComputedStyle(proxyLayer).display).toBe('none')
+    expect(getComputedStyle(proxyLayer).display).not.toBe('none')
   })
 
   it('does not rerender proxy placeholders when only marquee bounds change', async () => {

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/ProjectCanvasPageStageScene.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/ProjectCanvasPageStageScene.tsx
@@ -70,7 +70,7 @@ const CANVAS_TEXT_TRANSFORM_MIN_FONT_SIZE = 8
 const CANVAS_ANNOTATION_TRANSFORM_MIN_SIZE = 20
 const CANVAS_ANNOTATION_TEXT_TRANSFORM_MIN_FONT_SIZE = 8
 const PROJECT_CANVAS_DENSE_WEBGL_IMAGE_PROXY_LIMIT = 256
-const PROJECT_CANVAS_SELECTION_RECT_HIDE_IMAGE_LAYER_THRESHOLD_PX = 3
+const PROJECT_CANVAS_SELECTION_RECT_ACTIVE_THRESHOLD_PX = 3
 const PROJECT_CANVAS_HIGH_RES_DOM_IMAGE_MIN_SOURCE_RATIO = 1.25
 const PROJECT_CANVAS_HIGH_RES_DOM_IMAGE_VIEWPORT_PIXEL_BUDGET_MULTIPLIER = 8
 const PROJECT_CANVAS_HIGH_RES_DOM_IMAGE_MIN_VISIBLE_SCREEN_AREA = 160 * 160
@@ -1279,14 +1279,13 @@ export default function ProjectCanvasPageStageScene(props: any) {
     () => new Set(placeholderProxyImageItems.map((item) => item.id)),
     [placeholderProxyImageItems]
   )
-  const shouldHideImageInteractionLayerForSelectionRect =
+  const shouldSuppressSelectionChromeForSelectionRect =
     selectionRect != null &&
-    (selectionRect.w > PROJECT_CANVAS_SELECTION_RECT_HIDE_IMAGE_LAYER_THRESHOLD_PX ||
-      selectionRect.h > PROJECT_CANVAS_SELECTION_RECT_HIDE_IMAGE_LAYER_THRESHOLD_PX)
-  const shouldRenderImageInteractionLayer =
-    interactiveImageOverlayItems.length > 0 &&
-    !shouldHideImageInteractionLayerForSelectionRect &&
-    !suppressSelectionChromeAfterMarquee
+    (selectionRect.w > PROJECT_CANVAS_SELECTION_RECT_ACTIVE_THRESHOLD_PX ||
+      selectionRect.h > PROJECT_CANVAS_SELECTION_RECT_ACTIVE_THRESHOLD_PX)
+  const shouldSuppressSelectionChrome =
+    shouldSuppressSelectionChromeForSelectionRect || suppressSelectionChromeAfterMarquee
+  const shouldRenderImageInteractionLayer = interactiveImageOverlayItems.length > 0
   const { activeRegionSelectionImageItem, multiSelectionTransformItems, selectedSingleItem } =
     React.useMemo(() => {
       let nextActiveRegionSelectionImageItem: CanvasImageItem | null = null
@@ -2907,16 +2906,22 @@ export default function ProjectCanvasPageStageScene(props: any) {
         }),
         '&[data-project-canvas-marquee-active="true"] [data-project-canvas-image-interaction-layer="dom"]':
           {
-            display: 'none'
+            pointerEvents: 'none'
           },
         '&[data-project-canvas-marquee-active="true"] [data-project-canvas-proxy-layer="dom"]': {
-          display: 'none'
+          pointerEvents: 'none'
         },
         '&[data-project-canvas-marquee-active="true"] [data-project-canvas-high-res-image-layer="dom"]':
           {
-            display: 'none'
+            pointerEvents: 'none'
           },
-        '&[data-project-canvas-marquee-active="true"] [data-project-canvas-rect-interaction-layer]':
+        '&[data-project-canvas-marquee-active="true"] [data-canvas-overlay="image-interaction"], &[data-project-canvas-marquee-active="true"] [data-canvas-overlay="rect-interaction"]':
+          {
+            pointerEvents: 'none !important',
+            outline: 'none !important',
+            boxShadow: 'none !important'
+          },
+        '&[data-project-canvas-marquee-active="true"] [data-canvas-image-handle], &[data-project-canvas-marquee-active="true"] [data-canvas-image-rotate-hotspot], &[data-project-canvas-marquee-active="true"] [data-canvas-rect-handle], &[data-project-canvas-marquee-active="true"] [data-canvas-rect-rotate-hotspot]':
           {
             display: 'none'
           },
@@ -3069,6 +3074,7 @@ export default function ProjectCanvasPageStageScene(props: any) {
                 const isSelected = selectedIds.has(imageItem.id) && tool === 'select'
                 const imageRuntimeRoute = getImageRuntimeRoute(imageItem)
                 const suppressDomImagePreview = imageRuntimeRoute === 'webgl-primary'
+                const shouldShowSelectionChrome = isSelected && !shouldSuppressSelectionChrome
 
                 return (
                   <Box
@@ -3091,14 +3097,21 @@ export default function ProjectCanvasPageStageScene(props: any) {
                     <ProjectCanvasImageInteractionOverlay
                       canvasContainerRef={canvasContainerRef}
                       item={imageItem}
-                      isSelected={isSelected}
+                      isSelected={shouldShowSelectionChrome}
                       selectedCount={selectedIds.size}
                       renderMode={imageRuntimeRoute}
                       suppressImagePreview={suppressDomImagePreview}
                       preferDomImagePreview={false}
-                      showTransformer={tool === 'select' && selectedIds.size === 1 && isSelected}
-                      isDraggable={tool === 'select' && !imageItem.locked}
-                      allowPointerPassthrough={tool === 'hand'}
+                      showTransformer={
+                        tool === 'select' &&
+                        selectedIds.size === 1 &&
+                        isSelected &&
+                        !shouldSuppressSelectionChrome
+                      }
+                      isDraggable={
+                        tool === 'select' && !imageItem.locked && !shouldSuppressSelectionChrome
+                      }
+                      allowPointerPassthrough={tool === 'hand' || shouldSuppressSelectionChrome}
                       stagePos={stagePos}
                       stageScale={stageScale}
                       stagePosRef={stagePosRef}

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasAssetIntakeHelpers.test.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasAssetIntakeHelpers.test.ts
@@ -220,6 +220,52 @@ describe('canvasAssetIntakeHelpers', () => {
     expect(getCanvasImagePreviewMaxSideForBatch(Number.NaN)).toBe(CANVAS_IMAGE_PROXY_MAX_SIDE)
   })
 
+  it('loads dropped local-media images through svcFs object URLs before decoding', async () => {
+    const loadedSources: string[] = []
+    window.Image = function MockImage() {
+      const image = createImage(640, 360)
+      let currentSrc = ''
+      Object.defineProperty(image, 'src', {
+        configurable: true,
+        get: () => currentSrc,
+        set: (value: string) => {
+          currentSrc = value
+          loadedSources.push(value)
+          queueMicrotask(() => image.onload?.(new Event('load')))
+        }
+      })
+
+      return image
+    } as unknown as typeof Image
+
+    const readImageFromPath = vi.fn(async () => ({
+      image: new Uint8Array([1, 2, 3, 4]),
+      filename: 'reference.png'
+    }))
+    const createObjectUrl = vi.fn((_blob: Blob) => 'blob:local-image')
+    URL.createObjectURL = createObjectUrl as unknown as typeof URL.createObjectURL
+
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      writable: true,
+      value: {
+        svcFs: {
+          readImageFromPath
+        }
+      }
+    })
+
+    const loaded = await loadImageFromSrc('local-media:///C:/assets/reference.png')
+
+    expect(readImageFromPath).toHaveBeenCalledWith({ fullPath: 'C:/assets/reference.png' })
+    expect(createObjectUrl).toHaveBeenCalled()
+    expect(loadedSources).toEqual(['blob:local-image'])
+    expect(loaded).toMatchObject({
+      width: 640,
+      height: 360
+    })
+  })
+
   it('marks generated deferred placeholder assets so selected WebGL images do not show them as previews', async () => {
     const placeholder = await buildCanvasImagePlaceholderAsset({ width: 512, height: 314 })
 

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasAssetIntakeHelpers.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasAssetIntakeHelpers.ts
@@ -465,7 +465,7 @@ function shouldUseAnonymousCrossOrigin(src: string): boolean {
   return !/^(data:|blob:|file:\/\/|local-media:\/\/)/i.test(src.trim())
 }
 
-export function loadImageFromSrc(src: string): Promise<LoadedCanvasImage> {
+function loadImageElementFromSrc(src: string, logSource = src): Promise<LoadedCanvasImage> {
   return new Promise((resolve, reject) => {
     const img = new window.Image()
     if (shouldUseAnonymousCrossOrigin(src)) {
@@ -479,11 +479,16 @@ export function loadImageFromSrc(src: string): Promise<LoadedCanvasImage> {
     img.onerror = () => {
       img.onload = null
       img.onerror = null
-      console.error('[Canvas] Failed to load image source:', describeCanvasImageSource(src))
+      console.error('[Canvas] Failed to load image source:', describeCanvasImageSource(logSource))
       reject(new Error('Failed to load image'))
     }
     img.src = src
   })
+}
+
+export async function loadImageFromSrc(src: string): Promise<LoadedCanvasImage> {
+  const localObjectUrl = await createCanvasLocalImageObjectUrl(src)
+  return await loadImageElementFromSrc(localObjectUrl ?? src, src)
 }
 
 async function createComfyImageObjectUrl(item: CanvasImageItem): Promise<string | null> {

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasWebGLImageLayer.test.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasWebGLImageLayer.test.tsx
@@ -3412,6 +3412,88 @@ describe('ProjectCanvasWebGLImageLayer', () => {
     }
   }, 30000)
 
+  it('loads source-only local-media images through svcFs object URLs', async () => {
+    const { default: ProjectCanvasWebGLImageLayer } = await import('./ProjectCanvasWebGLImageLayer')
+    const originalApi = window.api
+    const originalCreateObjectURL = URL.createObjectURL
+    const attemptedSrcs: string[] = []
+    const readImageFromPath = vi.fn(async () => ({
+      image: new Uint8Array([1, 2, 3, 4]),
+      filename: 'source-only.png'
+    }))
+    const createObjectURLMock = vi.fn((_blob: Blob) => 'blob:webgl-local-image')
+
+    class MockImage {
+      onload: null | (() => void) = null
+      onerror: null | (() => void) = null
+      crossOrigin: string | null = null
+      naturalWidth = 640
+      naturalHeight = 360
+      width = 640
+      height = 360
+      private _src = ''
+
+      set src(value: string) {
+        this._src = value
+        attemptedSrcs.push(value)
+        window.setTimeout(() => this.onload?.(), 0)
+      }
+
+      get src() {
+        return this._src
+      }
+    }
+
+    URL.createObjectURL = createObjectURLMock as unknown as typeof URL.createObjectURL
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      writable: true,
+      value: {
+        svcFs: {
+          readImageFromPath
+        }
+      }
+    })
+    vi.stubGlobal('Image', MockImage as unknown as typeof Image)
+
+    try {
+      render(
+        <ProjectCanvasWebGLImageLayer
+          items={[
+            createItem({
+              id: 'image-local-source-only',
+              src: 'local-media:///C:/real-board/source-only.png',
+              fileName: 'source-only.png',
+              image: undefined as unknown as HTMLImageElement
+            })
+          ]}
+          stagePos={{ x: 0, y: 0 }}
+          stageScale={1}
+          stageSize={{ width: 1280, height: 720 }}
+        />
+      )
+
+      await waitFor(
+        () => {
+          expect(readImageFromPath).toHaveBeenCalledWith({
+            fullPath: 'C:/real-board/source-only.png'
+          })
+          expect(attemptedSrcs).toEqual(['blob:webgl-local-image'])
+          expect(getLiveSpriteByLabel('image-local-source-only')?.texture.width).toBe(640)
+        },
+        { timeout: 15000 }
+      )
+    } finally {
+      vi.unstubAllGlobals()
+      URL.createObjectURL = originalCreateObjectURL
+      Object.defineProperty(window, 'api', {
+        configurable: true,
+        writable: true,
+        value: originalApi
+      })
+    }
+  }, 30000)
+
   it('falls back to an image element when bounded source fetch fails', async () => {
     const { default: ProjectCanvasWebGLImageLayer } = await import('./ProjectCanvasWebGLImageLayer')
     const attemptedSrcs: string[] = []

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasWebGLImageLayer.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasWebGLImageLayer.tsx
@@ -32,6 +32,11 @@ import { isCanvasThumbnailSetFresh, pickBestCanvasThumbnailLevel } from '../canv
 import type { CanvasImageThumbnailLevel, CanvasImageThumbnailSet } from '../canvasThumbnailTypes'
 import { PROJECT_CANVAS_MIN_STAGE_SCALE } from '../projectCanvasViewportScale'
 import type { ProjectCanvasWebGLRuntimeMetrics } from '../projectCanvasWebGLRuntimeState'
+import {
+  canReadCanvasLocalImageSource,
+  createCanvasLocalImageObjectUrl,
+  readCanvasLocalImageBlobFromSource
+} from '../canvasLocalImageSource'
 
 type ProjectCanvasWebGLImageLayerProps = {
   items: CanvasImageItem[]
@@ -296,7 +301,7 @@ function shouldForceSelectedSourceTextureUpgrade(
   )
 }
 
-function loadImageElement(
+function loadImageElementDirect(
   src: string,
   options: { crossOrigin?: 'anonymous' | null } = {}
 ): Promise<HTMLImageElement> {
@@ -309,6 +314,19 @@ function loadImageElement(
     image.onerror = () => reject(new Error('Failed to load downscaled source texture.'))
     image.src = src
   })
+}
+
+function loadImageElement(
+  src: string,
+  options: { crossOrigin?: 'anonymous' | null } = {}
+): Promise<HTMLImageElement> {
+  if (!canReadCanvasLocalImageSource(src)) {
+    return loadImageElementDirect(src, options)
+  }
+
+  return createCanvasLocalImageObjectUrl(src).then((localObjectUrl) =>
+    loadImageElementDirect(localObjectUrl ?? src, options)
+  )
 }
 
 function resolveBoundedSourceTextureSize(width: number, height: number) {
@@ -462,12 +480,17 @@ async function loadBoundedSourceTextureFromUrl({
     return null
   }
 
-  const response = await fetch(src)
-  if (!response.ok && response.status !== 0) {
-    throw new Error(`Failed to fetch bounded source texture: ${response.status}`)
+  const localBlob = await readCanvasLocalImageBlobFromSource(src)
+  let blob = localBlob
+  if (!blob) {
+    const response = await fetch(src)
+    if (!response.ok && response.status !== 0) {
+      throw new Error(`Failed to fetch bounded source texture: ${response.status}`)
+    }
+
+    blob = await response.blob()
   }
 
-  const blob = await response.blob()
   return createImageBitmap(blob, {
     resizeWidth: targetSize.width,
     resizeHeight: targetSize.height,
@@ -1653,11 +1676,6 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
         return
       }
 
-      const img = new Image()
-      if (shouldUseAnonymousCrossOrigin(item.src)) {
-        img.crossOrigin = 'anonymous'
-      }
-
       if (mode === 'source-upgrade') {
         activeSourceUpgradeCountRef.current += 1
         activeSourceUpgradeSrcByIdRef.current.set(item.id, item.src)
@@ -1667,7 +1685,7 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
         pendingLoadSrcByIdRef.current.set(item.id, item.src)
       }
 
-      img.onload = () => {
+      const handleImageLoad = (img: HTMLImageElement) => {
         clearPendingLoad(item.id, item.src)
         void (async () => {
           let resolvedImage: CanvasImageAsset = img
@@ -1694,7 +1712,8 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
           }
         })()
       }
-      img.onerror = () => {
+
+      const handleImageError = () => {
         clearPendingLoad(item.id, item.src)
         finishInitialLoad()
         finishSourceUpgrade()
@@ -1711,7 +1730,28 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
           scheduleImageVersionUpdate()
         }
       }
-      img.src = item.src
+
+      const startImageElementLoad = (resolvedSrc: string) => {
+        const img = new Image()
+        if (shouldUseAnonymousCrossOrigin(item.src)) {
+          img.crossOrigin = 'anonymous'
+        }
+        img.onload = () => handleImageLoad(img)
+        img.onerror = handleImageError
+        img.src = resolvedSrc
+      }
+
+      if (canReadCanvasLocalImageSource(item.src)) {
+        void createCanvasLocalImageObjectUrl(item.src)
+          .then((localObjectUrl) => {
+            startImageElementLoad(localObjectUrl ?? item.src)
+          })
+          .catch(() => {
+            startImageElementLoad(item.src)
+          })
+      } else {
+        startImageElementLoad(item.src)
+      }
     }
 
     function pumpInitialImageLoadQueue() {

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/useCanvasAssetIntake.test.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/useCanvasAssetIntake.test.tsx
@@ -293,6 +293,87 @@ describe('useCanvasAssetIntake', () => {
     }
   })
 
+  it('builds real previews for lazy-tail local files when the source File is still available', async () => {
+    const originalImageCtor = window.Image
+    const originalCreateImageBitmap = globalThis.createImageBitmap
+    const loadedSources: string[] = []
+    const tailPreview = {
+      width: 192,
+      height: 108,
+      close: vi.fn()
+    } as unknown as ImageBitmap
+    const createImageBitmapMock = vi.fn(
+      async () => tailPreview
+    ) as unknown as typeof createImageBitmap
+
+    Object.defineProperty(globalThis, 'createImageBitmap', {
+      configurable: true,
+      value: createImageBitmapMock
+    })
+    window.Image = function MockImage() {
+      const image = document.createElement('img')
+      Object.defineProperty(image, 'naturalWidth', { configurable: true, value: 320 })
+      Object.defineProperty(image, 'naturalHeight', { configurable: true, value: 180 })
+      Object.defineProperty(image, 'width', { configurable: true, value: 320 })
+      Object.defineProperty(image, 'height', { configurable: true, value: 180 })
+      Object.defineProperty(image, 'src', {
+        configurable: true,
+        get: () => '',
+        set: (value: string) => {
+          loadedSources.push(value)
+          window.setTimeout(() => image.onload?.(new Event('load')), 0)
+        }
+      })
+      return image
+    } as unknown as typeof Image
+
+    try {
+      const sources: CanvasImageSourceInput[] = Array.from(
+        { length: PROJECT_CANVAS_IMAGE_LAZY_IMPORT_THRESHOLD + 1 },
+        (_, index) => {
+          const lazyTail = index >= PROJECT_CANVAS_IMAGE_LAZY_IMPORT_EAGER_COUNT
+          return {
+            src: `local-media:///C:/real-board/file-tail-${index}.png`,
+            fileName: `file-tail-${index}.png`,
+            sizeBytes: 1024 + index,
+            sourceWidthHint: 320,
+            sourceHeightHint: 180,
+            ...(lazyTail
+              ? { sourceFile: new File([new Uint8Array([1, 2, 3, 4])], `file-tail-${index}.png`) }
+              : {})
+          }
+        }
+      )
+      const onComplete = vi.fn()
+
+      render(<LargeImageBatchHarness sources={sources} onComplete={onComplete} />)
+
+      await waitFor(
+        () => {
+          expect(onComplete).toHaveBeenCalledTimes(1)
+        },
+        { timeout: 5000 }
+      )
+
+      const [items] = onComplete.mock.calls[0] as [CanvasItem[], CanvasImageItem[]]
+      const imageItems = items.filter((item): item is CanvasImageItem => item.type === 'image')
+      expect(loadedSources).toHaveLength(PROJECT_CANVAS_IMAGE_LAZY_IMPORT_EAGER_COUNT)
+      expect(createImageBitmapMock).toHaveBeenCalled()
+      expect(imageItems[PROJECT_CANVAS_IMAGE_LAZY_IMPORT_EAGER_COUNT].image).toBe(tailPreview)
+    } finally {
+      window.Image = originalImageCtor
+      if (originalCreateImageBitmap) {
+        Object.defineProperty(globalThis, 'createImageBitmap', {
+          configurable: true,
+          value: originalCreateImageBitmap
+        })
+      } else {
+        delete (globalThis as unknown as { createImageBitmap?: typeof createImageBitmap })
+          .createImageBitmap
+      }
+    }
+  })
+
   it('does not block lazy-tail imports on cold thumbnail generation', async () => {
     const originalImageCtor = window.Image
     const originalApi = window.api
@@ -706,6 +787,99 @@ describe('useCanvasAssetIntake', () => {
       expect(imageItems[0].image).toBe(previewBitmap)
     } finally {
       window.Image = originalImageCtor
+      if (originalCreateImageBitmap) {
+        Object.defineProperty(globalThis, 'createImageBitmap', {
+          configurable: true,
+          value: originalCreateImageBitmap
+        })
+      } else {
+        delete (globalThis as unknown as { createImageBitmap?: typeof createImageBitmap })
+          .createImageBitmap
+      }
+      if (originalFetch) {
+        Object.defineProperty(globalThis, 'fetch', {
+          configurable: true,
+          value: originalFetch
+        })
+      } else {
+        delete (globalThis as unknown as { fetch?: typeof fetch }).fetch
+      }
+    }
+  })
+
+  it('reads local-media deferred previews through svcFs when the file bridge is available', async () => {
+    const originalApi = window.api
+    const originalCreateImageBitmap = globalThis.createImageBitmap
+    const originalFetch = globalThis.fetch
+    const readImageFromPath = vi.fn(async () => ({
+      image: new Uint8Array([1, 2, 3, 4]),
+      filename: 'huge-from-bridge.png'
+    }))
+    const previewBitmap = {
+      width: 2048,
+      height: 1255,
+      close: vi.fn()
+    } as unknown as ImageBitmap
+    const createImageBitmapMock = vi.fn(
+      async () => previewBitmap
+    ) as unknown as typeof createImageBitmap
+    const fetchMock = vi.fn()
+
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      writable: true,
+      value: {
+        svcFs: {
+          readImageFromPath
+        }
+      }
+    })
+    Object.defineProperty(globalThis, 'createImageBitmap', {
+      configurable: true,
+      value: createImageBitmapMock
+    })
+    Object.defineProperty(globalThis, 'fetch', {
+      configurable: true,
+      value: fetchMock
+    })
+
+    try {
+      const hugeSource = {
+        src: 'local-media:///C:/real-board/huge-from-bridge.png',
+        fileName: 'huge-from-bridge.png',
+        sizeBytes: 90 * 1024 * 1024,
+        sourceWidthHint: 19_717,
+        sourceHeightHint: 12_079
+      }
+      const onComplete = vi.fn()
+
+      render(<LargeImageBatchHarness sources={[hugeSource]} onComplete={onComplete} />)
+
+      await waitFor(
+        () => {
+          expect(onComplete).toHaveBeenCalledTimes(1)
+        },
+        { timeout: 5000 }
+      )
+
+      const [items] = onComplete.mock.calls[0] as [CanvasItem[], CanvasImageItem[]]
+      const imageItems = items.filter((item): item is CanvasImageItem => item.type === 'image')
+      expect(readImageFromPath).toHaveBeenCalledWith({
+        fullPath: 'C:/real-board/huge-from-bridge.png'
+      })
+      expect(fetchMock).not.toHaveBeenCalled()
+      expect(createImageBitmapMock).toHaveBeenCalledWith(expect.any(Blob), {
+        resizeWidth: 2048,
+        resizeHeight: 1255,
+        resizeQuality: 'high'
+      })
+      expect(imageItems[0].image).toBe(previewBitmap)
+    } finally {
+      Object.defineProperty(window, 'api', {
+        configurable: true,
+        writable: true,
+        value: originalApi
+      })
       if (originalCreateImageBitmap) {
         Object.defineProperty(globalThis, 'createImageBitmap', {
           configurable: true,

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/useCanvasAssetIntake.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/useCanvasAssetIntake.ts
@@ -9,6 +9,7 @@ import { extractModelArchive } from './modelArchive'
 import { materializePsdFile } from './psdImport'
 import { resolveCanvas3DRenderActivationDelay } from './canvas3DRenderActivation'
 import { getCanvasLocalMediaSourceUrl, getElectronCanvasFilePath } from './canvasLocalFileSource'
+import { readCanvasLocalImageBlobFromSource } from './canvasLocalImageSource'
 import {
   createCanvasFileItemDraft,
   createCanvasHtmlItemDraft,
@@ -512,6 +513,11 @@ async function resolveDeferredCanvasImagePreviewBlob(
     return source.sourceFile
   }
 
+  const localBlob = await readCanvasLocalImageBlobFromSource(source.src, source.fileName)
+  if (localBlob) {
+    return localBlob
+  }
+
   if (typeof fetch !== 'function' || !canFetchDeferredCanvasImagePreviewSource(source.src)) {
     return null
   }
@@ -617,13 +623,15 @@ async function buildDeferredCanvasImageStreamEntry({
   sourceIndex,
   maxPreviewSide,
   fitImageToCanvasSize,
-  resolveInitialDisplayAsset = true
+  resolveInitialDisplayAsset = true,
+  resolveInitialThumbnail = resolveInitialDisplayAsset
 }: {
   source: NormalizedCanvasImageSource
   sourceIndex: number
   maxPreviewSide: number
   fitImageToCanvasSize: (width: number, height: number) => { width: number; height: number }
   resolveInitialDisplayAsset?: boolean
+  resolveInitialThumbnail?: boolean
 }): Promise<CanvasImageStreamEntry> {
   const shouldDeferFullDecode = shouldDeferCanvasImageSourceFullDecode(source)
   const hasDimensionHints =
@@ -636,7 +644,7 @@ async function buildDeferredCanvasImageStreamEntry({
       : PROJECT_CANVAS_IMAGE_LAZY_IMPORT_DEFAULT_SOURCE_EDGE
   )
   const fittedSize = fitImageToCanvasSize(sourceWidth, sourceHeight)
-  const thumbnailPreview = resolveInitialDisplayAsset
+  const thumbnailPreview = resolveInitialThumbnail
     ? await resolveCanvasImageIntakeThumbnail({
         source,
         maxPreviewSide
@@ -650,7 +658,7 @@ async function buildDeferredCanvasImageStreamEntry({
           sourceHeight,
           maxPreviewSide
         })
-      : shouldDeferFullDecode && resolveInitialDisplayAsset
+      : resolveInitialDisplayAsset
         ? await buildDeferredCanvasImagePreview({
             source,
             sourceWidth,
@@ -1270,18 +1278,17 @@ export function useCanvasAssetIntake({
           PROJECT_CANVAS_IMAGE_BATCH_LOAD_CONCURRENCY,
           async (source, sourceIndex) => {
             try {
-              if (
-                shouldDeferCanvasImageSourceFullDecode(source) ||
-                (lazyImportTail && sourceIndex >= PROJECT_CANVAS_IMAGE_LAZY_IMPORT_EAGER_COUNT)
-              ) {
+              const isLazyTail =
+                lazyImportTail && sourceIndex >= PROJECT_CANVAS_IMAGE_LAZY_IMPORT_EAGER_COUNT
+              const shouldResolveLazyTailDisplayAsset = isLazyTail && Boolean(source.sourceFile)
+              if (shouldDeferCanvasImageSourceFullDecode(source) || isLazyTail) {
                 return buildDeferredCanvasImageStreamEntry({
                   source,
                   sourceIndex,
                   maxPreviewSide,
                   fitImageToCanvasSize,
-                  resolveInitialDisplayAsset: !(
-                    lazyImportTail && sourceIndex >= PROJECT_CANVAS_IMAGE_LAZY_IMPORT_EAGER_COUNT
-                  )
+                  resolveInitialDisplayAsset: !isLazyTail || shouldResolveLazyTailDisplayAsset,
+                  resolveInitialThumbnail: !isLazyTail
                 })
               }
 


### PR DESCRIPTION
## Summary
- keep DOM image layers visible during marquee selection while suppressing only selection chrome and pointer interaction
- load local `local-media://` canvas images through the Electron file bridge before browser image decoding
- route WebGL source, thumbnail, and deferred preview loads through local blobs so large local batches render real previews instead of white placeholders

## Root Cause
Recent local-image recovery paths persist dropped files as `local-media://` URLs, but some initial import and WebGL rendering paths still handed those custom-scheme URLs directly to `Image`, `fetch`, or thumbnail loaders. In the dev renderer origin, that is blocked by browser CORS rules and leaves placeholder previews on the canvas.

## Validation
- `npx vitest run --config config/vitest/vitest.web.config.mjs packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasWebGLImageLayer.test.tsx packages/app/src/renderer/src/pages/ProjectCanvasPage/useCanvasAssetIntake.test.tsx packages/app/src/renderer/src/pages/ProjectCanvasPage/useCanvasFileIntake.test.tsx packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasLocalImageSource.test.ts packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasAssetIntakeHelpers.test.ts packages/app/src/renderer/src/pages/ProjectCanvasPage/ProjectCanvasPageStageScene.test.tsx --pool=forks --maxWorkers=1`
- `npm run typecheck:web`
- `git diff --check origin/master...HEAD`