### PR TITLE
[codex] fix dense canvas image interaction and rendering stalls

### DIFF
--- a/.github/workflows/nightly-bump-version.yml
+++ b/.github/workflows/nightly-bump-version.yml
@@ -83,6 +83,9 @@ jobs:
       - name: Bump version
         run: node ./scripts/release/bump-version.mjs
 
+      - name: Update embedded submodules
+        run: npm run release:update-submodules
+
       - name: Generate release metadata
         id: tag-version
         run: |
@@ -100,7 +103,7 @@ jobs:
 
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git add package.json
+          git add package.json scripts/comfy/embedded-sources.json vendor/comfyui
           git commit -m "$COMMIT_MESSAGE"
           git push --force origin HEAD:$RELEASE_BRANCH
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "release:pure": "npm run build:pure && cross-env PACKAGE_MODE=pure npm run package:all",
     "release:embedded": "npm run release:embedded:win",
     "release:embedded:win": "npm run build:embedded && npm run prepare:embedded && cross-env PACKAGE_MODE=embedded npm run package:win",
+    "release:update-submodules": "node scripts/release/update-embedded-submodules.mjs",
     "test:node": "cross-env NODE_OPTIONS=--max-old-space-size=6144 vitest run --config config/vitest/vitest.node.config.mjs",
     "test:web:heavy:qapp-design": "cross-env NODE_OPTIONS=--max-old-space-size=6144 vitest run --config config/vitest/vitest.web.config.mjs packages/app/src/renderer/src/pages/QuickAppPage/QAppDesignPanel/QAppDesignPanel.test.tsx",
     "test:web:heavy:custom-skill-manager": "cross-env NODE_OPTIONS=--max-old-space-size=6144 vitest run --config config/vitest/vitest.web.config.mjs packages/app/src/renderer/src/pages/QuickAppPage/CustomSkillManagerPage.test.tsx",

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/ProjectCanvasPageStageScene.test.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/ProjectCanvasPageStageScene.test.tsx
@@ -1255,7 +1255,7 @@ describe('ProjectCanvasPageStageScene WebGL integration seam', () => {
     expect(canvasPlaceholderProps.get(siblingItem.id)?.visualVariant).toBe('transparent')
   })
 
-  it('suppresses per-image WebGL hit proxies for dense selected image boards', async () => {
+  it('keeps transparent WebGL hit proxies for dense selected image boards', async () => {
     const items = Array.from({ length: 300 }, (_, index) => {
       const item = createImageItem(`dense-image-${index}`)
       item.x = (index % 30) * 220
@@ -1277,10 +1277,20 @@ describe('ProjectCanvasPageStageScene WebGL integration seam', () => {
 
     const root = screen.getByTestId('project-canvas-stage-root')
     expect(root).toHaveAttribute('data-project-canvas-dense-webgl-image-proxy-mode', 'true')
-    expect(root).toHaveAttribute('data-project-canvas-proxy-layer-candidate-count', '0')
+    expect(root).toHaveAttribute(
+      'data-project-canvas-proxy-layer-candidate-count',
+      `${items.length}`
+    )
     expect(root).toHaveAttribute('data-project-canvas-image-interaction-overlay-count', '0')
-    expect(root).toHaveAttribute('data-project-canvas-placeholder-image-proxy-count', '0')
-    expect(canvasPlaceholderProps.size).toBe(0)
+    expect(root).toHaveAttribute(
+      'data-project-canvas-placeholder-image-proxy-count',
+      `${items.length}`
+    )
+    await waitFor(() => {
+      expect(canvasPlaceholderProps.size).toBe(items.length)
+    })
+    expect(canvasPlaceholderProps.get(items[0].id)?.visualVariant).toBe('transparent')
+    expect(canvasPlaceholderProps.get(items[0].id)?.isDraggable).toBe(true)
     expect(imageInteractionOverlayProps.size).toBe(0)
     expect(screen.getByTestId('mock-multi-selection-transform-overlay')).toBeInTheDocument()
   })
@@ -1312,15 +1322,24 @@ describe('ProjectCanvasPageStageScene WebGL integration seam', () => {
 
     const root = screen.getByTestId('project-canvas-stage-root')
     expect(root).toHaveAttribute('data-project-canvas-dense-webgl-image-proxy-mode', 'true')
-    expect(root).toHaveAttribute('data-project-canvas-proxy-layer-candidate-count', '0')
+    expect(root).toHaveAttribute(
+      'data-project-canvas-proxy-layer-candidate-count',
+      `${items.length - 1}`
+    )
     expect(root).toHaveAttribute('data-project-canvas-image-interaction-overlay-count', '1')
-    expect(root).toHaveAttribute('data-project-canvas-placeholder-image-proxy-count', '0')
-    expect(canvasPlaceholderProps.size).toBe(0)
+    expect(root).toHaveAttribute(
+      'data-project-canvas-placeholder-image-proxy-count',
+      `${items.length - 1}`
+    )
+    await waitFor(() => {
+      expect(canvasPlaceholderProps.size).toBe(items.length - 1)
+    })
+    expect(canvasPlaceholderProps.get(items[1].id)?.visualVariant).toBe('transparent')
     expect(imageInteractionOverlayProps.size).toBe(1)
     expect(imageInteractionOverlayProps.get(selectedItem.id)?.isSelected).toBe(true)
   })
 
-  it('suppresses unloaded fallback hit proxies on dense boards while WebGL catches up', async () => {
+  it('keeps unloaded fallback hit proxies selectable on dense boards while WebGL catches up', async () => {
     const items = Array.from({ length: 300 }, (_, index) => {
       const item = createImageItem(`dense-unloaded-image-${index}`)
       item.x = (index % 30) * 220
@@ -1328,11 +1347,18 @@ describe('ProjectCanvasPageStageScene WebGL integration seam', () => {
       item.zIndex = index
       return item
     })
+    const setSelectedIds = vi.fn()
     webglReady = true
     webglLoadedIds = new Set()
     webglResidentIds = new Set()
 
-    render(<ProjectCanvasPageStageScene {...createBaseProps(items)} selectedIds={new Set()} />)
+    render(
+      <ProjectCanvasPageStageScene
+        {...createBaseProps(items)}
+        selectedIds={new Set()}
+        setSelectedIds={setSelectedIds}
+      />
+    )
 
     await waitFor(() => {
       expect(latestWebGLItems).toHaveLength(items.length)
@@ -1341,11 +1367,33 @@ describe('ProjectCanvasPageStageScene WebGL integration seam', () => {
     const root = screen.getByTestId('project-canvas-stage-root')
     expect(root).toHaveAttribute('data-project-canvas-dense-webgl-image-proxy-mode', 'true')
     expect(root).toHaveAttribute('data-project-canvas-fallback-image-count', `${items.length}`)
-    expect(root).toHaveAttribute('data-project-canvas-proxy-layer-candidate-count', '0')
+    expect(root).toHaveAttribute(
+      'data-project-canvas-proxy-layer-candidate-count',
+      `${items.length}`
+    )
     expect(root).toHaveAttribute('data-project-canvas-image-interaction-overlay-count', '0')
-    expect(root).toHaveAttribute('data-project-canvas-placeholder-image-proxy-count', '0')
-    expect(canvasPlaceholderProps.size).toBe(0)
+    expect(root).toHaveAttribute(
+      'data-project-canvas-placeholder-image-proxy-count',
+      `${items.length}`
+    )
+    await waitFor(() => {
+      expect(canvasPlaceholderProps.size).toBe(items.length)
+    })
     expect(imageInteractionOverlayProps.size).toBe(0)
+    expect(canvasPlaceholderProps.get(items[0].id)?.isDraggable).toBe(true)
+
+    act(() => {
+      ;(
+        canvasPlaceholderProps.get(items[0].id)?.onSelect as
+          | ((additiveSelection?: boolean) => void)
+          | undefined
+      )?.(false)
+    })
+
+    const updateSelection = setSelectedIds.mock.calls[0]?.[0] as
+      | ((prev: Set<string>) => Set<string>)
+      | undefined
+    expect(updateSelection?.(new Set())).toEqual(new Set([items[0].id]))
   })
 
   it('suspends WebGL image proxy content and multi-selection transform chrome during viewport interaction', async () => {

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/ProjectCanvasPageStageScene.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/ProjectCanvasPageStageScene.tsx
@@ -1238,7 +1238,8 @@ export default function ProjectCanvasPageStageScene(props: any) {
           shouldUseDenseWebglImageProxyBudget &&
           !shouldKeepFallbackProxy &&
           !isSingleSelectedImage &&
-          !isActivePlaceholderDrag
+          !isActivePlaceholderDrag &&
+          tool !== 'select'
         ) {
           continue
         }

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasImageInteractionOverlay.test.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasImageInteractionOverlay.test.tsx
@@ -723,7 +723,7 @@ describe('ProjectCanvasImageInteractionOverlay', () => {
     expect(onDragEnd).toHaveBeenCalledWith('image-1', 140, 170, expect.any(Object))
   })
 
-  it('batches drag previews into a single animation frame and flushes the latest transform on pointerup', () => {
+  it('emits drag previews immediately so the WebGL image body follows the frame', () => {
     const rafCallbacks = new Map<number, FrameRequestCallback>()
     let rafId = 0
     const requestAnimationFrameSpy = vi
@@ -785,16 +785,26 @@ describe('ProjectCanvasImageInteractionOverlay', () => {
       fireEvent.pointerMove(window, { pointerId: 15, clientX: 150, clientY: 190 })
       fireEvent.pointerMove(window, { pointerId: 15, clientX: 180, clientY: 210 })
 
-      expect(requestAnimationFrameSpy).toHaveBeenCalledTimes(baselineRafCallCount + 1)
-      expect(rafCallbacks.size).toBe(1)
-      expect(onPreviewChange).not.toHaveBeenCalled()
+      expect(requestAnimationFrameSpy).toHaveBeenCalledTimes(baselineRafCallCount)
+      expect(rafCallbacks.size).toBe(0)
+      expect(onPreviewChange).toHaveBeenCalledTimes(2)
+      expect(onPreviewChange).toHaveBeenLastCalledWith('image-1', {
+        x: 170,
+        y: 190,
+        width: 200,
+        height: 120,
+        scaleX: 1,
+        scaleY: 1,
+        rotation: 0
+      })
 
       fireEvent.pointerUp(window, { pointerId: 15, clientX: 180, clientY: 210 })
 
       expect(cancelAnimationFrameSpy.mock.calls.length).toBeGreaterThanOrEqual(
-        baselineCancelRafCallCount + 1
+        baselineCancelRafCallCount
       )
       expect(rafCallbacks.size).toBe(0)
+      expect(onPreviewChange).toHaveBeenCalledTimes(2)
       expect(onPreviewChange).toHaveBeenLastCalledWith('image-1', {
         x: 170,
         y: 190,

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasImageInteractionOverlay.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasImageInteractionOverlay.tsx
@@ -1,9 +1,10 @@
 import React from 'react'
 import { Box } from '@mui/material'
 import type { CanvasImageItem } from '../types'
-import type {
-  ProjectCanvasImagePreview,
-  ProjectCanvasImageRuntimeRoute
+import {
+  getProjectCanvasRenderTransformKey,
+  type ProjectCanvasImagePreview,
+  type ProjectCanvasImageRuntimeRoute
 } from '../projectCanvasRenderBoundary'
 import { findCanvasSelectionToolbar } from '../canvasDomOverlayLookup'
 import type { SelectionActionStackPlacement } from '../canvasSelectionLayoutUtils'
@@ -604,8 +605,7 @@ const ProjectCanvasImageInteractionOverlay: React.FC<ProjectCanvasImageInteracti
   const elementRef = React.useRef<HTMLDivElement | null>(null)
   const sessionRef = React.useRef<InteractionSession | null>(null)
   const draftTransformRef = React.useRef<CanvasImageTransform | null>(null)
-  const pendingPreviewRef = React.useRef<ProjectCanvasImagePreview | null>(null)
-  const previewCommitFrameRef = React.useRef<number | null>(null)
+  const lastEmittedPreviewKeyRef = React.useRef<string | null>(null)
   const pointerCanvasViewportRectRef = React.useRef<CanvasViewportRect | null>(null)
   const windowPointerMoveHandlerRef = React.useRef<(event: PointerEvent) => void>(() => {})
   const windowPointerUpHandlerRef = React.useRef<(event: PointerEvent) => void>(() => {})
@@ -685,51 +685,28 @@ const ProjectCanvasImageInteractionOverlay: React.FC<ProjectCanvasImageInteracti
           scheduleCanvasSync(item.id, preview)
         }
       }
+      lastEmittedPreviewKeyRef.current = getProjectCanvasRenderTransformKey(preview)
       onPreviewChange?.(item.id, preview)
     },
     [broadcastDomPreviewSync, item.id, onPreviewChange]
   )
 
-  const cancelPendingPreviewCommit = React.useCallback(() => {
-    if (previewCommitFrameRef.current == null) {
-      return
-    }
-
-    window.cancelAnimationFrame(previewCommitFrameRef.current)
-    previewCommitFrameRef.current = null
-  }, [])
-
   const flushPendingPreviewChange = React.useCallback(
-    (nextTransform?: CanvasImageTransform) => {
-      cancelPendingPreviewCommit()
-      const preview = nextTransform ? buildPreview(item, nextTransform) : pendingPreviewRef.current
-      pendingPreviewRef.current = null
-      if (!preview) {
+    (nextTransform: CanvasImageTransform) => {
+      const preview = buildPreview(item, nextTransform)
+      const previewKey = getProjectCanvasRenderTransformKey(preview)
+      if (lastEmittedPreviewKeyRef.current === previewKey) {
         return
       }
 
       emitPreviewChangeNow(preview, { immediateSync: true })
     },
-    [cancelPendingPreviewCommit, emitPreviewChangeNow, item]
+    [emitPreviewChangeNow, item]
   )
 
   const schedulePreviewChange = React.useCallback(
     (transform: CanvasImageTransform) => {
-      pendingPreviewRef.current = buildPreview(item, transform)
-      if (previewCommitFrameRef.current != null) {
-        return
-      }
-
-      previewCommitFrameRef.current = window.requestAnimationFrame(() => {
-        previewCommitFrameRef.current = null
-        const preview = pendingPreviewRef.current
-        pendingPreviewRef.current = null
-        if (!preview) {
-          return
-        }
-
-        emitPreviewChangeNow(preview)
-      })
+      emitPreviewChangeNow(buildPreview(item, transform), { immediateSync: true })
     },
     [emitPreviewChangeNow, item]
   )
@@ -772,8 +749,7 @@ const ProjectCanvasImageInteractionOverlay: React.FC<ProjectCanvasImageInteracti
 
   React.useEffect(() => {
     return () => {
-      cancelPendingPreviewCommit()
-      pendingPreviewRef.current = null
+      lastEmittedPreviewKeyRef.current = null
       shouldSelectOnDragFinishRef.current = false
       clearPointerCanvasViewportRect()
       if (broadcastDomPreviewSync) {
@@ -783,7 +759,6 @@ const ProjectCanvasImageInteractionOverlay: React.FC<ProjectCanvasImageInteracti
     }
   }, [
     broadcastDomPreviewSync,
-    cancelPendingPreviewCommit,
     clearPointerCanvasViewportRect,
     item.id,
     onPreviewChange,

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasWebGLImageLayer.test.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasWebGLImageLayer.test.tsx
@@ -1311,11 +1311,13 @@ describe('ProjectCanvasWebGLImageLayer', () => {
 
   it('defers metrics reports while viewport interaction is active', async () => {
     const { default: ProjectCanvasWebGLImageLayer } = await import('./ProjectCanvasWebGLImageLayer')
+    const ref = React.createRef<ProjectCanvasWebGLImageLayerHandle>()
     const metricsCalls: ProjectCanvasWebGLImageLayerMetrics[] = []
     const stableItems = [createItem({ id: 'image-metrics-interacting' })]
 
     const { rerender } = render(
       <ProjectCanvasWebGLImageLayer
+        ref={ref}
         items={stableItems}
         stagePos={{ x: 0, y: 0 }}
         stageScale={1}
@@ -1327,10 +1329,16 @@ describe('ProjectCanvasWebGLImageLayer', () => {
 
     await waitFor(
       () => {
+        expect(ref.current).not.toBeNull()
         expect(createdSprites).toHaveLength(1)
       },
       { timeout: 15000 }
     )
+
+    act(() => {
+      ref.current?.syncViewport({ x: 96, y: 72 }, 1.25)
+      ref.current?.syncViewport({ x: 120, y: 96 }, 1.25)
+    })
 
     await act(async () => {
       await new Promise((resolve) => setTimeout(resolve, 300))
@@ -1340,6 +1348,7 @@ describe('ProjectCanvasWebGLImageLayer', () => {
 
     rerender(
       <ProjectCanvasWebGLImageLayer
+        ref={ref}
         items={stableItems}
         stagePos={{ x: 0, y: 0 }}
         stageScale={1}
@@ -1353,7 +1362,10 @@ describe('ProjectCanvasWebGLImageLayer', () => {
       () => {
         expect(
           metricsCalls.some(
-            (metrics) => metrics.imageCount === 1 && metrics.residentImageCount === 1
+            (metrics) =>
+              metrics.imageCount === 1 &&
+              metrics.residentImageCount === 1 &&
+              metrics.renderCount >= 2
           )
         ).toBe(true)
       },

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasWebGLImageLayer.test.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasWebGLImageLayer.test.tsx
@@ -4028,7 +4028,9 @@ describe('ProjectCanvasWebGLImageLayer', () => {
       )
 
       expect(
-        createdSprites.filter((sprite) => !sprite.destroyed).map((sprite) => sprite.label)
+        createdSprites
+          .slice(0, PROJECT_CANVAS_WEBGL_SPRITE_RECONCILE_BATCH_SIZE)
+          .map((sprite) => sprite.label)
       ).toEqual(
         orderedItems
           .slice(0, PROJECT_CANVAS_WEBGL_SPRITE_RECONCILE_BATCH_SIZE)

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasWebGLImageLayer.test.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasWebGLImageLayer.test.tsx
@@ -2334,7 +2334,10 @@ describe('ProjectCanvasWebGLImageLayer', () => {
       await waitFor(
         () => {
           expect(createdSprites.filter((sprite) => !sprite.destroyed)).toHaveLength(4)
-          expect(attemptedSrcs).toEqual(['file:///image-hires-queued-1.png'])
+          expect(attemptedSrcs).toEqual([
+            'file:///image-hires-queued-1.png',
+            'file:///image-hires-queued-2.png'
+          ])
         },
         { timeout: 15000 }
       )
@@ -2347,7 +2350,8 @@ describe('ProjectCanvasWebGLImageLayer', () => {
         () => {
           expect(attemptedSrcs).toEqual([
             'file:///image-hires-queued-1.png',
-            'file:///image-hires-queued-2.png'
+            'file:///image-hires-queued-2.png',
+            'file:///image-hires-queued-3.png'
           ])
         },
         { timeout: 15000 }
@@ -2362,7 +2366,8 @@ describe('ProjectCanvasWebGLImageLayer', () => {
           expect(attemptedSrcs).toEqual([
             'file:///image-hires-queued-1.png',
             'file:///image-hires-queued-2.png',
-            'file:///image-hires-queued-3.png'
+            'file:///image-hires-queued-3.png',
+            'file:///image-hires-queued-4.png'
           ])
         },
         { timeout: 15000 }
@@ -2453,7 +2458,10 @@ describe('ProjectCanvasWebGLImageLayer', () => {
 
       await waitFor(
         () => {
-          expect(attemptedSrcs).toEqual(['file:///image-upgrade-selected.png'])
+          expect(attemptedSrcs).toEqual([
+            'file:///image-upgrade-selected.png',
+            'file:///image-upgrade-center.png'
+          ])
         },
         { timeout: 15000 }
       )
@@ -2466,7 +2474,8 @@ describe('ProjectCanvasWebGLImageLayer', () => {
         () => {
           expect(attemptedSrcs).toEqual([
             'file:///image-upgrade-selected.png',
-            'file:///image-upgrade-center.png'
+            'file:///image-upgrade-center.png',
+            'file:///image-upgrade-edge.png'
           ])
         },
         { timeout: 15000 }
@@ -3100,7 +3109,10 @@ describe('ProjectCanvasWebGLImageLayer', () => {
 
       await waitFor(
         () => {
-          expect(attemptedSrcs).toEqual(['file:///image-stale-upgrade-1.png'])
+          expect(attemptedSrcs).toEqual([
+            'file:///image-stale-upgrade-1.png',
+            'file:///image-stale-upgrade-2.png'
+          ])
         },
         { timeout: 15000 }
       )
@@ -3126,7 +3138,10 @@ describe('ProjectCanvasWebGLImageLayer', () => {
         await Promise.resolve()
       })
 
-      expect(attemptedSrcs).toEqual(['file:///image-stale-upgrade-1.png'])
+      expect(attemptedSrcs).toEqual([
+        'file:///image-stale-upgrade-1.png',
+        'file:///image-stale-upgrade-2.png'
+      ])
     } finally {
       vi.unstubAllGlobals()
     }
@@ -3958,6 +3973,73 @@ describe('ProjectCanvasWebGLImageLayer', () => {
     }
   }, 30000)
 
+  it('creates resident sprites in stable row-major order instead of center-out rings', async () => {
+    const {
+      PROJECT_CANVAS_WEBGL_SPRITE_RECONCILE_BATCH_SIZE,
+      default: ProjectCanvasWebGLImageLayer
+    } = await import('./ProjectCanvasWebGLImageLayer')
+    const queuedAnimationFrames = new Map<number, FrameRequestCallback>()
+    let nextAnimationFrameId = 1
+    const requestAnimationFrameSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback: FrameRequestCallback) => {
+        const id = nextAnimationFrameId
+        nextAnimationFrameId += 1
+        queuedAnimationFrames.set(id, callback)
+        return id
+      })
+    const cancelAnimationFrameSpy = vi
+      .spyOn(window, 'cancelAnimationFrame')
+      .mockImplementation((id: number) => {
+        queuedAnimationFrames.delete(id)
+      })
+    const orderedItems = Array.from(
+      { length: PROJECT_CANVAS_WEBGL_SPRITE_RECONCILE_BATCH_SIZE * 3 },
+      (_, index) =>
+        createItem({
+          id: `image-row-major-${index + 1}`,
+          src: `file:///image-row-major-${index + 1}.png`,
+          fileName: `image-row-major-${index + 1}.png`,
+          x: (index % 6) * 96,
+          y: Math.floor(index / 6) * 72,
+          width: 80,
+          height: 48,
+          zIndex: index
+        })
+    )
+
+    try {
+      render(
+        <ProjectCanvasWebGLImageLayer
+          items={orderedItems}
+          stagePos={{ x: 0, y: 0 }}
+          stageScale={1}
+          stageSize={{ width: 1280, height: 720 }}
+        />
+      )
+
+      await waitFor(
+        () => {
+          expect(createdSprites.filter((sprite) => !sprite.destroyed)).toHaveLength(
+            PROJECT_CANVAS_WEBGL_SPRITE_RECONCILE_BATCH_SIZE
+          )
+        },
+        { timeout: 15000 }
+      )
+
+      expect(
+        createdSprites.filter((sprite) => !sprite.destroyed).map((sprite) => sprite.label)
+      ).toEqual(
+        orderedItems
+          .slice(0, PROJECT_CANVAS_WEBGL_SPRITE_RECONCILE_BATCH_SIZE)
+          .map((item) => item.id)
+      )
+    } finally {
+      requestAnimationFrameSpy.mockRestore()
+      cancelAnimationFrameSpy.mockRestore()
+    }
+  }, 30000)
+
   it('splits large initial sprite creation across animation frames to avoid one long first render', async () => {
     const {
       PROJECT_CANVAS_WEBGL_SPRITE_RECONCILE_BATCH_SIZE,
@@ -3978,10 +4060,27 @@ describe('ProjectCanvasWebGLImageLayer', () => {
       .mockImplementation((id: number) => {
         queuedAnimationFrames.delete(id)
       })
-    const flushAnimationFrames = () => {
-      const callbacks = Array.from(queuedAnimationFrames.values())
-      queuedAnimationFrames.clear()
-      callbacks.forEach((callback) => callback(window.performance.now()))
+    const flushNextAnimationFrame = () => {
+      const nextFrame = queuedAnimationFrames.entries().next().value
+      if (!nextFrame) {
+        return false
+      }
+
+      const [id, callback] = nextFrame
+      queuedAnimationFrames.delete(id)
+      callback(window.performance.now())
+      return true
+    }
+    const liveSpriteCount = () => createdSprites.filter((sprite) => !sprite.destroyed).length
+    const flushUntilLiveSpriteCount = async (expectedCount: number) => {
+      for (let index = 0; index < 12 && liveSpriteCount() !== expectedCount; index += 1) {
+        await act(async () => {
+          expect(flushNextAnimationFrame()).toBe(true)
+          await Promise.resolve()
+        })
+      }
+
+      expect(liveSpriteCount()).toBe(expectedCount)
     }
     const metricsCalls: ProjectCanvasWebGLImageLayerMetrics[] = []
     const largeItemSet = createItems(PROJECT_CANVAS_WEBGL_SPRITE_RECONCILE_BATCH_SIZE * 3)
@@ -4015,16 +4114,7 @@ describe('ProjectCanvasWebGLImageLayer', () => {
         )
       ).toBe(false)
 
-      act(flushAnimationFrames)
-
-      await waitFor(
-        () => {
-          expect(createdSprites.filter((sprite) => !sprite.destroyed)).toHaveLength(
-            PROJECT_CANVAS_WEBGL_SPRITE_RECONCILE_BATCH_SIZE * 2
-          )
-        },
-        { timeout: 15000 }
-      )
+      await flushUntilLiveSpriteCount(PROJECT_CANVAS_WEBGL_SPRITE_RECONCILE_BATCH_SIZE * 2)
 
       expect(
         metricsCalls.some(
@@ -4035,16 +4125,7 @@ describe('ProjectCanvasWebGLImageLayer', () => {
         )
       ).toBe(false)
 
-      act(flushAnimationFrames)
-
-      await waitFor(
-        () => {
-          expect(createdSprites.filter((sprite) => !sprite.destroyed)).toHaveLength(
-            largeItemSet.length
-          )
-        },
-        { timeout: 15000 }
-      )
+      await flushUntilLiveSpriteCount(largeItemSet.length)
 
       expect(
         metricsCalls.some(
@@ -4082,10 +4163,27 @@ describe('ProjectCanvasWebGLImageLayer', () => {
       .mockImplementation((id: number) => {
         queuedAnimationFrames.delete(id)
       })
-    const flushAnimationFrames = () => {
-      const callbacks = Array.from(queuedAnimationFrames.values())
-      queuedAnimationFrames.clear()
-      callbacks.forEach((callback) => callback(window.performance.now()))
+    const flushNextAnimationFrame = () => {
+      const nextFrame = queuedAnimationFrames.entries().next().value
+      if (!nextFrame) {
+        return false
+      }
+
+      const [id, callback] = nextFrame
+      queuedAnimationFrames.delete(id)
+      callback(window.performance.now())
+      return true
+    }
+    const liveSpriteCount = () => createdSprites.filter((sprite) => !sprite.destroyed).length
+    const flushUntilLiveSpriteCount = async (expectedCount: number) => {
+      for (let index = 0; index < 12 && liveSpriteCount() !== expectedCount; index += 1) {
+        await act(async () => {
+          expect(flushNextAnimationFrame()).toBe(true)
+          await Promise.resolve()
+        })
+      }
+
+      expect(liveSpriteCount()).toBe(expectedCount)
     }
     const overviewItemSet = createItems(
       PROJECT_CANVAS_WEBGL_OVERVIEW_SPRITE_RECONCILE_BATCH_SIZE * 2
@@ -4114,20 +4212,20 @@ describe('ProjectCanvasWebGLImageLayer', () => {
       const app = createdApplications[0]
       const renderCountAfterFirstBatch = app.render.mock.calls.length
 
-      act(flushAnimationFrames)
-
-      await waitFor(
-        () => {
-          expect(createdSprites.filter((sprite) => !sprite.destroyed)).toHaveLength(
-            overviewItemSet.length
-          )
-        },
-        { timeout: 15000 }
-      )
+      await flushUntilLiveSpriteCount(overviewItemSet.length)
 
       expect(app.render).toHaveBeenCalledTimes(renderCountAfterFirstBatch)
 
-      act(flushAnimationFrames)
+      for (
+        let index = 0;
+        index < 12 && app.render.mock.calls.length !== renderCountAfterFirstBatch + 1;
+        index += 1
+      ) {
+        await act(async () => {
+          expect(flushNextAnimationFrame()).toBe(true)
+          await Promise.resolve()
+        })
+      }
 
       expect(app.render).toHaveBeenCalledTimes(renderCountAfterFirstBatch + 1)
     } finally {

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasWebGLImageLayer.test.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasWebGLImageLayer.test.tsx
@@ -488,11 +488,13 @@ describe('ProjectCanvasWebGLImageLayer', () => {
     await waitFor(
       () => {
         expect(ref.current).not.toBeNull()
+        expect(createdApplications).toHaveLength(1)
         expect(createdSprites).toHaveLength(1)
       },
       { timeout: 15000 }
     )
 
+    const app = createdApplications[0]
     const sprite = createdSprites[0]
 
     expect(sprite.position.x).toBe(24)
@@ -500,6 +502,7 @@ describe('ProjectCanvasWebGLImageLayer', () => {
     expect(sprite.scale.x).toBe(2)
     expect(sprite.scale.y).toBe(2)
 
+    const renderCountBeforePreview = app.render.mock.calls.length
     act(() => {
       ref.current?.syncItemPreview('image-1', {
         x: 80,
@@ -517,7 +520,9 @@ describe('ProjectCanvasWebGLImageLayer', () => {
     expect(sprite.scale.x).toBe(3)
     expect(sprite.scale.y).toBe(1)
     expect(sprite.rotation).toBeCloseTo(Math.PI / 12)
+    expect(app.render).toHaveBeenCalledTimes(renderCountBeforePreview + 1)
 
+    const renderCountBeforeClear = app.render.mock.calls.length
     act(() => {
       ref.current?.syncItemPreview('image-1', null)
     })
@@ -527,6 +532,7 @@ describe('ProjectCanvasWebGLImageLayer', () => {
     expect(sprite.scale.x).toBe(2)
     expect(sprite.scale.y).toBe(2)
     expect(sprite.rotation).toBe(0)
+    expect(app.render).toHaveBeenCalledTimes(renderCountBeforeClear + 1)
   }, 15000)
 
   it('recreates sprite state when the texture key changes', async () => {

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasWebGLImageLayer.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasWebGLImageLayer.tsx
@@ -2440,7 +2440,9 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
     const spriteReconcileBatchSize = getProjectCanvasSpriteReconcileBatchSize(safeScale)
     const shouldBatchNewSpriteCreation = residentCandidateImageCount >= spriteReconcileBatchSize * 2
     let newSpriteCreationBudget = shouldBatchNewSpriteCreation
-      ? spriteReconcileBatchSize
+      ? spriteReconcileFrameRef.current === null
+        ? spriteReconcileBatchSize
+        : 0
       : Number.POSITIVE_INFINITY
     let deferredNewSpriteCount = 0
     let residentCandidateTextureBytes = 0

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasWebGLImageLayer.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasWebGLImageLayer.tsx
@@ -693,7 +693,6 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
   const spriteUsageCounterRef = useRef(0)
   const rafRef = useRef<number | null>(null)
   const activeItemCountRef = useRef(0)
-  const textureScaleModeRef = useRef<'nearest' | 'linear'>(getProjectCanvasTextureScaleMode())
   const stagePosRef = useRef(stagePos)
   const stageScaleRef = useRef(stageScale)
   const stageSizeRef = useRef(stageSize)
@@ -1058,9 +1057,17 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
       runtimeFailureHandlerRef.current?.(error)
       return
     }
+    const lastRenderDurationMs = Math.max(0, window.performance.now() - startedAt)
+    if (isViewportInteractingRef.current) {
+      metricsRef.current.renderCount += 1
+      metricsRef.current.lastRenderDurationMs = lastRenderDurationMs
+      hasDeferredMetricsReportRef.current = true
+      return
+    }
+
     reportMetrics({
       renderCount: metricsRef.current.renderCount + 1,
-      lastRenderDurationMs: Math.max(0, window.performance.now() - startedAt)
+      lastRenderDurationMs
     })
   }, [reportMetrics])
 
@@ -1236,13 +1243,6 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
         return
       }
 
-      const nextScaleMode = getProjectCanvasTextureScaleMode()
-      if (textureScaleModeRef.current !== nextScaleMode) {
-        textureScaleModeRef.current = nextScaleMode
-        spriteRecordsRef.current.forEach((record) => {
-          applyProjectCanvasTextureScaleMode(record)
-        })
-      }
       world.position.set(pos.x, pos.y)
       world.scale.set(scale)
       renderApp()

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasWebGLImageLayer.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasWebGLImageLayer.tsx
@@ -87,11 +87,11 @@ export const PROJECT_CANVAS_WEBGL_TEXTURE_UPLOAD_MAX_BYTES = 128 * 1024 * 1024
 export const PROJECT_CANVAS_WEBGL_SELECTED_RESIDENT_LIMIT = 64
 export const PROJECT_CANVAS_WEBGL_SELECTED_PROTECTED_LIMIT = 32
 const PROJECT_CANVAS_WEBGL_IMAGE_VISIBLE_OVERSCAN_PX = 320
-const VIEWPORT_RECONCILE_DEBOUNCE_MS = 80
+const VIEWPORT_RECONCILE_DEBOUNCE_MS = 48
 const PROJECT_CANVAS_WEBGL_METRICS_THROTTLE_MS = 250
 export const PROJECT_CANVAS_WEBGL_SOURCE_TEXTURE_MAX_SIDE = 4096
-const PROJECT_CANVAS_WEBGL_SOURCE_UPGRADE_CONCURRENCY = 1
-const PROJECT_CANVAS_WEBGL_SOURCE_UPGRADE_VIEWPORT_IDLE_DELAY_MS = 140
+const PROJECT_CANVAS_WEBGL_SOURCE_UPGRADE_CONCURRENCY = 2
+const PROJECT_CANVAS_WEBGL_SOURCE_UPGRADE_VIEWPORT_IDLE_DELAY_MS = 80
 const PROJECT_CANVAS_WEBGL_IMAGE_VERSION_INTERACTION_MAX_DEFER_MS = 180
 const PROJECT_CANVAS_WEBGL_THUMBNAIL_UPGRADE_CONCURRENCY = 6
 const PROJECT_CANVAS_WEBGL_THUMBNAIL_LOD_SCREEN_GAIN = 1.5
@@ -99,9 +99,11 @@ const PROJECT_CANVAS_WEBGL_THUMBNAIL_LOD_TEXTURE_BUDGET_RATIO = 0.75
 const PROJECT_CANVAS_WEBGL_DENSE_SOURCE_UPGRADE_CANDIDATE_LIMIT = 96
 const PROJECT_CANVAS_WEBGL_DENSE_SOURCE_UPGRADE_MAX_SCALE = 0.5
 const PROJECT_CANVAS_WEBGL_IMAGE_ELEMENT_SOURCE_DECODE_MAX_BYTES = 256 * 1024 * 1024
+const PROJECT_CANVAS_WEBGL_IMAGE_ELEMENT_LOAD_TIMEOUT_MS = 15_000
+const PROJECT_CANVAS_WEBGL_SOURCE_TEXTURE_LOAD_TIMEOUT_MS = 12_000
 export const PROJECT_CANVAS_WEBGL_INITIAL_IMAGE_LOAD_CONCURRENCY = 8
-export const PROJECT_CANVAS_WEBGL_SPRITE_RECONCILE_BATCH_SIZE = 8
-export const PROJECT_CANVAS_WEBGL_OVERVIEW_SPRITE_RECONCILE_BATCH_SIZE = 64
+export const PROJECT_CANVAS_WEBGL_SPRITE_RECONCILE_BATCH_SIZE = 16
+export const PROJECT_CANVAS_WEBGL_OVERVIEW_SPRITE_RECONCILE_BATCH_SIZE = 128
 const PROJECT_CANVAS_WEBGL_SOURCE_OVERVIEW_MAX_SCALE =
   PROJECT_CANVAS_IMAGE_LOD_OVERVIEW_SOURCE_SUPPRESSION_MAX_SCALE
 const PROJECT_CANVAS_WEBGL_OVERVIEW_BATCH_MAX_SCALE = 0.25
@@ -153,6 +155,54 @@ function getProjectCanvasSpriteReconcileBatchSize(stageScale: number) {
 function shouldSuppressIntermediateOverviewRender(stageScale: number) {
   const safeScale = Math.max(Math.abs(stageScale), PROJECT_CANVAS_MIN_STAGE_SCALE)
   return safeScale <= PROJECT_CANVAS_WEBGL_OVERVIEW_BATCH_MAX_SCALE
+}
+
+function closeCanvasImageAssetIfPossible(value: unknown) {
+  const close = (value as { close?: unknown } | null | undefined)?.close
+  if (typeof close === 'function') {
+    close.call(value)
+  }
+}
+
+function withProjectCanvasWebGLTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  message: string
+): Promise<T> {
+  let settled = false
+
+  return new Promise((resolve, reject) => {
+    const timeoutId = window.setTimeout(() => {
+      if (settled) {
+        return
+      }
+
+      settled = true
+      reject(new Error(message))
+    }, timeoutMs)
+
+    promise.then(
+      (value) => {
+        if (settled) {
+          closeCanvasImageAssetIfPossible(value)
+          return
+        }
+
+        settled = true
+        window.clearTimeout(timeoutId)
+        resolve(value)
+      },
+      (error) => {
+        if (settled) {
+          return
+        }
+
+        settled = true
+        window.clearTimeout(timeoutId)
+        reject(error)
+      }
+    )
+  })
 }
 
 function getPreviewVisibilityBounds(preview: ProjectCanvasImagePreview) {
@@ -307,11 +357,34 @@ function loadImageElementDirect(
 ): Promise<HTMLImageElement> {
   return new Promise((resolve, reject) => {
     const image = new Image()
+    let settled = false
+    const timeoutId = window.setTimeout(() => {
+      if (settled) {
+        return
+      }
+
+      settled = true
+      image.onload = null
+      image.onerror = null
+      reject(new Error('Timed out loading image element.'))
+    }, PROJECT_CANVAS_WEBGL_IMAGE_ELEMENT_LOAD_TIMEOUT_MS)
+    const settle = (callback: () => void) => {
+      if (settled) {
+        return
+      }
+
+      settled = true
+      window.clearTimeout(timeoutId)
+      image.onload = null
+      image.onerror = null
+      callback()
+    }
     if (options.crossOrigin) {
       image.crossOrigin = options.crossOrigin
     }
-    image.onload = () => resolve(image)
-    image.onerror = () => reject(new Error('Failed to load downscaled source texture.'))
+    image.onload = () => settle(() => resolve(image))
+    image.onerror = () =>
+      settle(() => reject(new Error('Failed to load downscaled source texture.')))
     image.src = src
   })
 }
@@ -639,6 +712,7 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
   const lastReportedMetricsRef = useRef<ProjectCanvasWebGLImageLayerMetrics | null>(null)
   const spriteReconcileFrameRef = useRef<number | null>(null)
   const imageVersionFrameRef = useRef<number | null>(null)
+  const imageElementLoadTimeoutsRef = useRef<Set<number>>(new Set())
   const metricsRef = useRef<ProjectCanvasWebGLImageLayerMetrics>({
     isInitialized: false,
     imageCount: 0,
@@ -1094,6 +1168,10 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
         clearTimeout(imageVersionDeferredTimerRef.current)
         imageVersionDeferredTimerRef.current = null
       }
+      imageElementLoadTimeoutsRef.current.forEach((timeoutId) => {
+        window.clearTimeout(timeoutId)
+      })
+      imageElementLoadTimeoutsRef.current.clear()
     }
   }, [])
 
@@ -1280,6 +1358,10 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
         window.cancelAnimationFrame(imageVersionFrameRef.current)
         imageVersionFrameRef.current = null
       }
+      imageElementLoadTimeoutsRef.current.forEach((timeoutId) => {
+        window.clearTimeout(timeoutId)
+      })
+      imageElementLoadTimeoutsRef.current.clear()
 
       hasDeferredImageVersionUpdateRef.current = false
       pendingLoads.clear()
@@ -1630,11 +1712,15 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
           try {
             let resolvedImage: CanvasImageAsset | null = null
             try {
-              resolvedImage = await loadBoundedSourceTextureFromUrl({
-                src: item.src,
-                sourceWidth: item.sourceWidth ?? item.width,
-                sourceHeight: item.sourceHeight ?? item.height
-              })
+              resolvedImage = await withProjectCanvasWebGLTimeout(
+                loadBoundedSourceTextureFromUrl({
+                  src: item.src,
+                  sourceWidth: item.sourceWidth ?? item.width,
+                  sourceHeight: item.sourceHeight ?? item.height
+                }),
+                PROJECT_CANVAS_WEBGL_SOURCE_TEXTURE_LOAD_TIMEOUT_MS,
+                'Timed out loading bounded source texture.'
+              )
             } catch {
               resolvedImage = null
             }
@@ -1642,10 +1728,14 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
               !resolvedImage &&
               sourceDecodeByteSize <= PROJECT_CANVAS_WEBGL_IMAGE_ELEMENT_SOURCE_DECODE_MAX_BYTES
             ) {
-              resolvedImage = await loadBoundedSourceTextureViaImageElement({
-                src: item.src,
-                useAnonymousCrossOrigin: shouldUseAnonymousCrossOrigin(item.src)
-              })
+              resolvedImage = await withProjectCanvasWebGLTimeout(
+                loadBoundedSourceTextureViaImageElement({
+                  src: item.src,
+                  useAnonymousCrossOrigin: shouldUseAnonymousCrossOrigin(item.src)
+                }),
+                PROJECT_CANVAS_WEBGL_SOURCE_TEXTURE_LOAD_TIMEOUT_MS,
+                'Timed out loading bounded source texture through an image element.'
+              )
             }
             clearPendingLoad(item.id, item.src)
             finishInitialLoad()
@@ -1691,7 +1781,11 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
           let resolvedImage: CanvasImageAsset = img
           if (mode === 'source-upgrade') {
             try {
-              resolvedImage = await downscaleSourceTextureForWebGL(img)
+              resolvedImage = await withProjectCanvasWebGLTimeout(
+                downscaleSourceTextureForWebGL(img),
+                PROJECT_CANVAS_WEBGL_SOURCE_TEXTURE_LOAD_TIMEOUT_MS,
+                'Timed out downscaling source texture.'
+              )
             } catch {
               resolvedImage = img
             }
@@ -1733,11 +1827,36 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
 
       const startImageElementLoad = (resolvedSrc: string) => {
         const img = new Image()
+        let settled = false
+        const timeoutId = window.setTimeout(() => {
+          if (settled) {
+            return
+          }
+
+          settled = true
+          imageElementLoadTimeoutsRef.current.delete(timeoutId)
+          img.onload = null
+          img.onerror = null
+          handleImageError()
+        }, PROJECT_CANVAS_WEBGL_IMAGE_ELEMENT_LOAD_TIMEOUT_MS)
+        imageElementLoadTimeoutsRef.current.add(timeoutId)
+        const settleImageElementLoad = (callback: () => void) => {
+          if (settled) {
+            return
+          }
+
+          settled = true
+          window.clearTimeout(timeoutId)
+          imageElementLoadTimeoutsRef.current.delete(timeoutId)
+          img.onload = null
+          img.onerror = null
+          callback()
+        }
         if (shouldUseAnonymousCrossOrigin(item.src)) {
           img.crossOrigin = 'anonymous'
         }
-        img.onload = () => handleImageLoad(img)
-        img.onerror = handleImageError
+        img.onload = () => settleImageElementLoad(() => handleImageLoad(img))
+        img.onerror = () => settleImageElementLoad(handleImageError)
         img.src = resolvedSrc
       }
 
@@ -2259,6 +2378,30 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
         (shouldPinSelectedItems && selectedIds?.has(item.id) ? 1_000_000 : 0) - distanceFromCenter
       )
     }
+    const compareResidentCandidateItems = (left: CanvasImageItem, right: CanvasImageItem) => {
+      const leftSelectedRank = shouldPinSelectedItems && selectedIds?.has(left.id) ? 1 : 0
+      const rightSelectedRank = shouldPinSelectedItems && selectedIds?.has(right.id) ? 1 : 0
+      if (leftSelectedRank !== rightSelectedRank) {
+        return rightSelectedRank - leftSelectedRank
+      }
+
+      const leftPreviewRank = previewStateRef.current.has(left.id) ? 1 : 0
+      const rightPreviewRank = previewStateRef.current.has(right.id) ? 1 : 0
+      if (leftPreviewRank !== rightPreviewRank) {
+        return rightPreviewRank - leftPreviewRank
+      }
+
+      const leftBounds = getCanvasItemBounds(left)
+      const rightBounds = getCanvasItemBounds(right)
+      if (leftBounds.minY !== rightBounds.minY) {
+        return leftBounds.minY - rightBounds.minY
+      }
+      if (leftBounds.minX !== rightBounds.minX) {
+        return leftBounds.minX - rightBounds.minX
+      }
+
+      return left.zIndex - right.zIndex
+    }
     sourceUpgradeQueueRef.current = sourceUpgradeQueueRef.current
       .map((entry) => {
         const item = itemById.get(entry.itemId)
@@ -2272,9 +2415,7 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
         residentCandidateItems.push(item)
       }
     })
-    const orderedItems = residentCandidateItems.sort(
-      (left, right) => getSourceUpgradePriority(right) - getSourceUpgradePriority(left)
-    )
+    const orderedItems = residentCandidateItems.sort(compareResidentCandidateItems)
     const residentTargetIds = new Set<string>()
     const addResidentTarget = (itemId: string) => {
       if (

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasWebGLImageLayer.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasWebGLImageLayer.tsx
@@ -1540,7 +1540,8 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
             record.transformKey = getProjectCanvasRenderTransformKey(renderItem)
           }
           markSpriteRecordUsed(record)
-          scheduleRender()
+          cancelScheduledRender()
+          renderApp()
           return
         }
 
@@ -1552,13 +1553,15 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
         )
         record.transformKey = getProjectCanvasRenderTransformKey(preview)
         markSpriteRecordUsed(record)
-        scheduleRender()
+        cancelScheduledRender()
+        renderApp()
       }
     }),
     [
       applyViewportTransform,
+      cancelScheduledRender,
       markSpriteRecordUsed,
-      scheduleRender,
+      renderApp,
       scheduleViewportReconcile,
       setViewportInteractingState
     ]

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/useCanvasStageInteraction.test.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/useCanvasStageInteraction.test.tsx
@@ -80,7 +80,7 @@ describe('useCanvasStageInteraction', () => {
       .__canvasInteractionTrace
   })
 
-  it('batches middle-mouse pan updates into a single frame commit', () => {
+  it('applies middle-mouse pan transforms immediately while deferring React state', () => {
     const rafCallbacks = new Map<number, FrameRequestCallback>()
     let rafId = 0
     vi.spyOn(window, 'requestAnimationFrame').mockImplementation(
@@ -117,6 +117,8 @@ describe('useCanvasStageInteraction', () => {
     })
 
     expect(options.stagePosRef.current).toEqual({ x: 35, y: 49 })
+    expect(onViewportChange).toHaveBeenCalledTimes(2)
+    expect(onViewportChange).toHaveBeenLastCalledWith({ x: 35, y: 49 }, 1)
     expect(options.setStagePos).not.toHaveBeenCalled()
     expect(rafCallbacks.size).toBe(1)
 
@@ -124,7 +126,7 @@ describe('useCanvasStageInteraction', () => {
       rafCallbacks.values().next().value?.(16)
     })
 
-    expect(onViewportChange).toHaveBeenCalledTimes(1)
+    expect(onViewportChange).toHaveBeenCalledTimes(2)
     expect(onViewportChange).toHaveBeenLastCalledWith({ x: 35, y: 49 }, 1)
     expect(options.setStagePos).not.toHaveBeenCalled()
 
@@ -134,6 +136,35 @@ describe('useCanvasStageInteraction', () => {
 
     expect(options.setStagePos).toHaveBeenCalledTimes(1)
     expect(options.setStagePos).toHaveBeenLastCalledWith({ x: 35, y: 49 })
+
+    unmount()
+  })
+
+  it('continues middle-mouse panning from global move events outside the stage', () => {
+    const onViewportChange = vi.fn()
+    const options = createOptions({ onViewportChange })
+    const { result, unmount } = renderHook(() => useCanvasStageInteraction(options))
+
+    act(() => {
+      result.current.handleStageMouseDown({
+        evt: new MouseEvent('mousedown', { button: 1, clientX: 100, clientY: 120 }),
+        type: 'mousedown'
+      })
+    })
+
+    act(() => {
+      window.dispatchEvent(new MouseEvent('mousemove', { clientX: 160, clientY: 190 }))
+    })
+
+    expect(options.stagePosRef.current).toEqual({ x: 60, y: 70 })
+    expect(onViewportChange).toHaveBeenCalledWith({ x: 60, y: 70 }, 1)
+    expect(options.setStagePos).not.toHaveBeenCalled()
+
+    act(() => {
+      window.dispatchEvent(new MouseEvent('mouseup'))
+    })
+
+    expect(options.setStagePos).toHaveBeenCalledWith({ x: 60, y: 70 })
 
     unmount()
   })

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/useCanvasStageInteraction.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/useCanvasStageInteraction.ts
@@ -120,7 +120,7 @@ export function useCanvasStageInteraction(options: UseCanvasStageInteractionOpti
     onViewportInteractionStart,
     onViewportInteractionEnd,
     handleOpenCanvasTargetDialog,
-    // Optional: called every rAF during pan/zoom to drive DOM transforms directly,
+    // Optional: called during pan/zoom to drive DOM transforms directly,
     // skipping React setState on the hot path. setState still happens on pointer-up.
     onViewportChange,
     // Optional: called every rAF during selection drag to drive DOM directly,
@@ -252,6 +252,25 @@ export function useCanvasStageInteraction(options: UseCanvasStageInteractionOpti
     stageScaleRef,
     syncCanvasRuntimeViewport
   ])
+
+  const applyPanViewportDelta = useCallback(
+    (clientX: number, clientY: number) => {
+      const dx = clientX - lastPanPosRef.current.x
+      const dy = clientY - lastPanPosRef.current.y
+      if (dx === 0 && dy === 0) {
+        return
+      }
+
+      lastPanPosRef.current = { x: clientX, y: clientY }
+      stagePosRef.current = {
+        x: stagePosRef.current.x + dx,
+        y: stagePosRef.current.y + dy
+      }
+      syncCanvasRuntimeViewport()
+      applyViewportChange(stagePosRef.current, stageScaleRef.current)
+    },
+    [applyViewportChange, lastPanPosRef, stagePosRef, stageScaleRef, syncCanvasRuntimeViewport]
+  )
 
   const scheduleViewportCommit = useCallback(() => {
     if (viewportCommitFrameRef.current != null) {
@@ -571,16 +590,30 @@ export function useCanvasStageInteraction(options: UseCanvasStageInteractionOpti
         lastPanPosRef.current = { x: event.evt.clientX, y: event.evt.clientY }
         event.evt.preventDefault()
 
+        const handleGlobalPointerMove = (moveEvent: MouseEvent | PointerEvent) => {
+          if (!isPanningRef.current) {
+            return
+          }
+
+          moveEvent.preventDefault()
+          applyPanViewportDelta(moveEvent.clientX, moveEvent.clientY)
+          scheduleViewportCommit()
+        }
+
         const handleGlobalPointerUp = () => {
           isMiddleMouseRef.current = false
           isPanningRef.current = false
           endViewportInteraction(true)
           setIsPanning(false)
+          window.removeEventListener('pointermove', handleGlobalPointerMove)
+          window.removeEventListener('mousemove', handleGlobalPointerMove)
           window.removeEventListener('pointerup', handleGlobalPointerUp)
           window.removeEventListener('pointercancel', handleGlobalPointerUp)
           window.removeEventListener('mouseup', handleGlobalPointerUp)
         }
 
+        window.addEventListener('pointermove', handleGlobalPointerMove, { passive: false })
+        window.addEventListener('mousemove', handleGlobalPointerMove, { passive: false })
         window.addEventListener('pointerup', handleGlobalPointerUp)
         window.addEventListener('pointercancel', handleGlobalPointerUp)
         window.addEventListener('mouseup', handleGlobalPointerUp)
@@ -691,6 +724,7 @@ export function useCanvasStageInteraction(options: UseCanvasStageInteractionOpti
     },
     [
       annoTool,
+      applyPanViewportDelta,
       beginViewportInteraction,
       canvasContainerRef,
       clearPointerCanvasViewportRect,
@@ -701,6 +735,7 @@ export function useCanvasStageInteraction(options: UseCanvasStageInteractionOpti
       isSelectionRectDraggingRef,
       isMiddleMouseRef,
       lastPanPosRef,
+      scheduleViewportCommit,
       selectedIds,
       setDrawingState,
       setIsPanning,
@@ -714,14 +749,8 @@ export function useCanvasStageInteraction(options: UseCanvasStageInteractionOpti
   const handleStageMouseMove = useCallback(
     (event: CanvasStageMouseEvent) => {
       if (isPanningRef.current) {
-        const dx = event.evt.clientX - lastPanPosRef.current.x
-        const dy = event.evt.clientY - lastPanPosRef.current.y
-        lastPanPosRef.current = { x: event.evt.clientX, y: event.evt.clientY }
-        stagePosRef.current = {
-          x: stagePosRef.current.x + dx,
-          y: stagePosRef.current.y + dy
-        }
-        syncCanvasRuntimeViewport()
+        event.evt.preventDefault()
+        applyPanViewportDelta(event.evt.clientX, event.evt.clientY)
         scheduleViewportCommit()
         return
       }
@@ -808,15 +837,14 @@ export function useCanvasStageInteraction(options: UseCanvasStageInteractionOpti
       canvasContainerRef,
       drawingState,
       getPointerCanvasViewportRect,
-      lastPanPosRef,
       onSelectionRectChangeRef,
+      applyPanViewportDelta,
       scheduleSelectionRectCommit,
       scheduleViewportCommit,
       setDrawingState,
       setSelectionMarqueeActive,
       stagePosRef,
       stageScaleRef,
-      syncCanvasRuntimeViewport,
       updateCanvasInteractionDebug
     ]
   )

--- a/scripts/comfy/embedded-sources.json
+++ b/scripts/comfy/embedded-sources.json
@@ -1,0 +1,89 @@
+{
+  "sources": [
+    {
+      "name": "ComfyUI",
+      "url": "https://github.com/Comfy-Org/ComfyUI.git",
+      "commit": "6bcd8b96ab4650db6e834dcbb54357ebf72edfe6",
+      "relativePath": "vendor/comfyui/ComfyUI"
+    },
+    {
+      "name": "ComfyUI-Advanced-ControlNet",
+      "url": "https://github.com/chinoll/ComfyUI-Advanced-ControlNet.git",
+      "commit": "3537c5b1b0b6d6a59e09d2c520bbd0afcf694d71",
+      "relativePath": "vendor/comfyui/comfyui_data/custom_nodes/ComfyUI-Advanced-ControlNet"
+    },
+    {
+      "name": "ComfyUI-Custom-Scripts",
+      "url": "https://github.com/pythongosssss/ComfyUI-Custom-Scripts.git",
+      "commit": "609f3afaa74b2f88ef9ce8d939626065e3247469",
+      "relativePath": "vendor/comfyui/comfyui_data/custom_nodes/ComfyUI-Custom-Scripts"
+    },
+    {
+      "name": "ComfyUI-Easy-Use",
+      "url": "https://github.com/yolain/ComfyUI-Easy-Use.git",
+      "commit": "130c1b5796d9876a5f853fa0bea88e808cfda4ad",
+      "relativePath": "vendor/comfyui/comfyui_data/custom_nodes/ComfyUI-Easy-Use"
+    },
+    {
+      "name": "ComfyUI-Easy-Use-Frontend",
+      "url": "https://github.com/yolain/ComfyUI-Easy-Use-Frontend.git",
+      "commit": "8b95a4210032072773929b7c8176c43804ebf6ee",
+      "parentRelativePath": "vendor/comfyui/comfyui_data/custom_nodes/ComfyUI-Easy-Use",
+      "relativePath": "vendor/comfyui/comfyui_data/custom_nodes/ComfyUI-Easy-Use/ComfyUI-Easy-Use-Frontend"
+    },
+    {
+      "name": "ComfyUI-Inspyrenet-Rembg",
+      "url": "https://github.com/john-mnz/ComfyUI-Inspyrenet-Rembg.git",
+      "commit": "87ac452ef1182e8f35f59b04010158d74dcefd06",
+      "relativePath": "vendor/comfyui/comfyui_data/custom_nodes/ComfyUI-Inspyrenet-Rembg"
+    },
+    {
+      "name": "ComfyUI-KJNodes",
+      "url": "https://github.com/kijai/ComfyUI-KJNodes.git",
+      "commit": "9c3255f39cd2ea0ebf94a2016af4bd2e5d6eb91b",
+      "relativePath": "vendor/comfyui/comfyui_data/custom_nodes/ComfyUI-KJNodes"
+    },
+    {
+      "name": "ComfyUI-Manager",
+      "url": "https://github.com/Comfy-Org/ComfyUI-Manager.git",
+      "commit": "8d5c12037f873c2f9e059e4f9c409a2835a9b8cf",
+      "relativePath": "vendor/comfyui/comfyui_data/custom_nodes/ComfyUI-Manager"
+    },
+    {
+      "name": "ComfyUI-qwenmultiangle",
+      "url": "https://github.com/jtydhr88/ComfyUI-qwenmultiangle.git",
+      "commit": "6f93d9b15a50c07c13411734723fe5cae287e7aa",
+      "relativePath": "vendor/comfyui/comfyui_data/custom_nodes/ComfyUI-qwenmultiangle"
+    },
+    {
+      "name": "ComfyUI-SeedVR2_VideoUpscaler",
+      "url": "https://github.com/numz/ComfyUI-SeedVR2_VideoUpscaler.git",
+      "commit": "4490bd1f482e026674543386bb2a4d176da245b9",
+      "relativePath": "vendor/comfyui/comfyui_data/custom_nodes/ComfyUI-SeedVR2_VideoUpscaler"
+    },
+    {
+      "name": "comfyui_controlnet_aux",
+      "url": "https://github.com/Fannovel16/comfyui_controlnet_aux.git",
+      "commit": "e8b689a513c3e6b63edc44066560ca5919c0576e",
+      "relativePath": "vendor/comfyui/comfyui_data/custom_nodes/comfyui_controlnet_aux"
+    },
+    {
+      "name": "comfyui_LLM_party",
+      "url": "https://github.com/heshengtao/comfyui_LLM_party.git",
+      "commit": "4d279969d7b08a24857f7455b362b745d6dcf2d0",
+      "relativePath": "vendor/comfyui/comfyui_data/custom_nodes/comfyui_LLM_party"
+    },
+    {
+      "name": "ComfyUI_smZNodes",
+      "url": "https://github.com/shiimizu/ComfyUI_smZNodes.git",
+      "commit": "9562d76c3cf206a3c2362e2baf8bbf717a4869a5",
+      "relativePath": "vendor/comfyui/comfyui_data/custom_nodes/ComfyUI_smZNodes"
+    },
+    {
+      "name": "z-tipo-extension",
+      "url": "https://github.com/KohakuBlueleaf/z-tipo-extension.git",
+      "commit": "d6bbb86726e06f3e3ab60c804f811993dc740223",
+      "relativePath": "vendor/comfyui/comfyui_data/custom_nodes/z-tipo-extension"
+    }
+  ]
+}

--- a/scripts/prepare-embedded-comfyui-sources.mjs
+++ b/scripts/prepare-embedded-comfyui-sources.mjs
@@ -7,97 +7,10 @@ import { fileURLToPath } from 'node:url'
 const scriptDir = path.dirname(fileURLToPath(import.meta.url))
 const repoRoot = path.resolve(scriptDir, '..')
 const vendorRoot = path.join(repoRoot, 'vendor', 'comfyui')
+const sourcesPath = path.join(scriptDir, 'comfy', 'embedded-sources.json')
 const dryRun = process.argv.includes('--dry-run') || process.env.EMBEDDED_SOURCES_DRY_RUN === '1'
 const force = process.argv.includes('--force') || process.env.EMBEDDED_SOURCE_REFRESH === '1'
-
-const sources = [
-  {
-    name: 'ComfyUI',
-    url: 'https://github.com/Comfy-Org/ComfyUI.git',
-    commit: '6bcd8b96ab4650db6e834dcbb54357ebf72edfe6',
-    relativePath: 'vendor/comfyui/ComfyUI'
-  },
-  {
-    name: 'ComfyUI-Advanced-ControlNet',
-    url: 'https://github.com/chinoll/ComfyUI-Advanced-ControlNet.git',
-    commit: '3537c5b1b0b6d6a59e09d2c520bbd0afcf694d71',
-    relativePath: 'vendor/comfyui/comfyui_data/custom_nodes/ComfyUI-Advanced-ControlNet'
-  },
-  {
-    name: 'ComfyUI-Custom-Scripts',
-    url: 'https://github.com/pythongosssss/ComfyUI-Custom-Scripts.git',
-    commit: '609f3afaa74b2f88ef9ce8d939626065e3247469',
-    relativePath: 'vendor/comfyui/comfyui_data/custom_nodes/ComfyUI-Custom-Scripts'
-  },
-  {
-    name: 'ComfyUI-Easy-Use',
-    url: 'https://github.com/yolain/ComfyUI-Easy-Use.git',
-    commit: '130c1b5796d9876a5f853fa0bea88e808cfda4ad',
-    relativePath: 'vendor/comfyui/comfyui_data/custom_nodes/ComfyUI-Easy-Use'
-  },
-  {
-    name: 'ComfyUI-Easy-Use-Frontend',
-    url: 'https://github.com/yolain/ComfyUI-Easy-Use-Frontend.git',
-    commit: '8b95a4210032072773929b7c8176c43804ebf6ee',
-    parentRelativePath: 'vendor/comfyui/comfyui_data/custom_nodes/ComfyUI-Easy-Use',
-    relativePath:
-      'vendor/comfyui/comfyui_data/custom_nodes/ComfyUI-Easy-Use/ComfyUI-Easy-Use-Frontend'
-  },
-  {
-    name: 'ComfyUI-Inspyrenet-Rembg',
-    url: 'https://github.com/john-mnz/ComfyUI-Inspyrenet-Rembg.git',
-    commit: '87ac452ef1182e8f35f59b04010158d74dcefd06',
-    relativePath: 'vendor/comfyui/comfyui_data/custom_nodes/ComfyUI-Inspyrenet-Rembg'
-  },
-  {
-    name: 'ComfyUI-KJNodes',
-    url: 'https://github.com/kijai/ComfyUI-KJNodes.git',
-    commit: '9c3255f39cd2ea0ebf94a2016af4bd2e5d6eb91b',
-    relativePath: 'vendor/comfyui/comfyui_data/custom_nodes/ComfyUI-KJNodes'
-  },
-  {
-    name: 'ComfyUI-Manager',
-    url: 'https://github.com/Comfy-Org/ComfyUI-Manager.git',
-    commit: '8d5c12037f873c2f9e059e4f9c409a2835a9b8cf',
-    relativePath: 'vendor/comfyui/comfyui_data/custom_nodes/ComfyUI-Manager'
-  },
-  {
-    name: 'ComfyUI-qwenmultiangle',
-    url: 'https://github.com/jtydhr88/ComfyUI-qwenmultiangle.git',
-    commit: '6f93d9b15a50c07c13411734723fe5cae287e7aa',
-    relativePath: 'vendor/comfyui/comfyui_data/custom_nodes/ComfyUI-qwenmultiangle'
-  },
-  {
-    name: 'ComfyUI-SeedVR2_VideoUpscaler',
-    url: 'https://github.com/numz/ComfyUI-SeedVR2_VideoUpscaler.git',
-    commit: '4490bd1f482e026674543386bb2a4d176da245b9',
-    relativePath: 'vendor/comfyui/comfyui_data/custom_nodes/ComfyUI-SeedVR2_VideoUpscaler'
-  },
-  {
-    name: 'comfyui_controlnet_aux',
-    url: 'https://github.com/Fannovel16/comfyui_controlnet_aux.git',
-    commit: 'e8b689a513c3e6b63edc44066560ca5919c0576e',
-    relativePath: 'vendor/comfyui/comfyui_data/custom_nodes/comfyui_controlnet_aux'
-  },
-  {
-    name: 'comfyui_LLM_party',
-    url: 'https://github.com/heshengtao/comfyui_LLM_party.git',
-    commit: '4d279969d7b08a24857f7455b362b745d6dcf2d0',
-    relativePath: 'vendor/comfyui/comfyui_data/custom_nodes/comfyui_LLM_party'
-  },
-  {
-    name: 'ComfyUI_smZNodes',
-    url: 'https://github.com/shiimizu/ComfyUI_smZNodes.git',
-    commit: '9562d76c3cf206a3c2362e2baf8bbf717a4869a5',
-    relativePath: 'vendor/comfyui/comfyui_data/custom_nodes/ComfyUI_smZNodes'
-  },
-  {
-    name: 'z-tipo-extension',
-    url: 'https://github.com/KohakuBlueleaf/z-tipo-extension.git',
-    commit: 'd6bbb86726e06f3e3ab60c804f811993dc740223',
-    relativePath: 'vendor/comfyui/comfyui_data/custom_nodes/z-tipo-extension'
-  }
-]
+const sources = JSON.parse(fs.readFileSync(sourcesPath, 'utf8')).sources
 
 function toNative(relativePath) {
   return path.join(...relativePath.split('/'))
@@ -130,6 +43,8 @@ function isGitWorktree(targetPath) {
     return false
   }
 }
+
+const repoRootHasGitWorktree = isGitWorktree(repoRoot)
 
 function currentCommit(targetPath) {
   return runGit(['-C', targetPath, 'rev-parse', 'HEAD']).trim()
@@ -177,13 +92,19 @@ function prepareSource(source) {
         `${source.relativePath} exists but is not a git submodule. Move it aside or rerun with --force.`
       )
     }
-    runGit(['submodule', 'sync', '--', source.relativePath], { inherit: true })
-    runGit(
-      ['submodule', 'update', '--init', ...(force ? ['--force'] : []), '--', source.relativePath],
-      {
-        inherit: true
-      }
-    )
+    if (repoRootHasGitWorktree) {
+      runGit(['submodule', 'sync', '--', source.relativePath], { inherit: true })
+      runGit(
+        ['submodule', 'update', '--init', ...(force ? ['--force'] : []), '--', source.relativePath],
+        {
+          inherit: true
+        }
+      )
+    } else if (!fs.existsSync(targetPath)) {
+      throw new Error(
+        `Missing source for ${source.name}: ${source.relativePath}. The workspace is not a git repository, so submodules cannot be initialized here.`
+      )
+    }
   }
 
   if (!fs.existsSync(targetPath) || !isGitWorktree(targetPath)) {

--- a/scripts/release/bump-version.mjs
+++ b/scripts/release/bump-version.mjs
@@ -1,101 +1,70 @@
 #!/usr/bin/env node
 
-import { readFileSync, writeFileSync } from 'fs'
-import { join, dirname } from 'path'
-import { fileURLToPath } from 'url'
+import { readFileSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 
-// 获取当前文件的目录
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
+const scriptDir = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.resolve(scriptDir, '..', '..')
+const packageJsonPath = path.join(repoRoot, 'package.json')
 
-/**
- * 解析版本号字符串，返回版本号数组
- * @param {string} version - 版本号字符串，如 "1.0.0"
- * @returns {number[]} 版本号数组，如 [1, 0, 0]
- */
 function parseVersion(version) {
-  return version.split('.').map((num) => parseInt(num, 10))
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version)
+  if (!match) {
+    throw new Error(`Expected semver version in package.json, received: ${version}`)
+  }
+  return match.slice(1).map((part) => Number(part))
 }
 
-/**
- * 将版本号数组转换为字符串
- * @param {number[]} versionArray - 版本号数组
- * @returns {string} 版本号字符串
- */
 function versionToString(versionArray) {
   return versionArray.join('.')
 }
 
-/**
- * 升级小版本号（patch version）
- * @param {string} currentVersion - 当前版本号
- * @returns {string} 新版本号
- */
 function bumpPatchVersion(currentVersion) {
   const versionArray = parseVersion(currentVersion)
-  versionArray[2] += 1 // 增加 patch 版本号
+  versionArray[2] += 1
   return versionToString(versionArray)
 }
 
-/**
- * 升级小版本号（minor version）
- * @param {string} currentVersion - 当前版本号
- * @returns {string} 新版本号
- */
 function bumpMinorVersion(currentVersion) {
   const versionArray = parseVersion(currentVersion)
-  versionArray[1] += 1 // 增加 minor 版本号
-  versionArray[2] = 0 // 重置 patch 版本号
+  versionArray[1] += 1
+  versionArray[2] = 0
   return versionToString(versionArray)
 }
 
-/**
- * 升级主版本号（major version）
- * @param {string} currentVersion - 当前版本号
- * @returns {string} 新版本号
- */
 function bumpMajorVersion(currentVersion) {
   const versionArray = parseVersion(currentVersion)
-  versionArray[0] += 1 // 增加 major 版本号
-  versionArray[1] = 0 // 重置 minor 版本号
-  versionArray[2] = 0 // 重置 patch 版本号
+  versionArray[0] += 1
+  versionArray[1] = 0
+  versionArray[2] = 0
   return versionToString(versionArray)
 }
 
-/**
- * 主函数
- */
-function main() {
+function main(argv = process.argv.slice(2)) {
+  const dryRun = argv.includes('--dry-run')
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'))
+  const currentVersion = packageJson.version
+  const newVersion = bumpPatchVersion(currentVersion)
+
+  console.log(`Current version: ${currentVersion}`)
+  console.log(`Next version: ${newVersion}`)
+
+  if (dryRun) {
+    return
+  }
+
+  packageJson.version = newVersion
+  writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`, 'utf8')
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   try {
-    // 读取 package.json 文件
-    const packageJsonPath = join(__dirname, 'package.json')
-    const packageJsonContent = readFileSync(packageJsonPath, 'utf8')
-    const packageJson = JSON.parse(packageJsonContent)
-
-    // 获取当前版本号
-    const currentVersion = packageJson.version
-    console.log(`当前版本: ${currentVersion}`)
-
-    // 升级小版本号（patch version）
-    const newVersion = bumpPatchVersion(currentVersion)
-    console.log(`新版本: ${newVersion}`)
-
-    // 更新 package.json 中的版本号
-    packageJson.version = newVersion
-
-    // 写回文件，保持格式
-    writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2) + '\n', 'utf8')
-
-    console.log(`✅ 版本号已成功从 ${currentVersion} 升级到 ${newVersion}`)
+    main()
   } catch (error) {
-    console.error('❌ 升级版本号时发生错误:', error.message)
+    console.error(error instanceof Error ? error.message : String(error))
     process.exit(1)
   }
 }
 
-// 如果直接运行此脚本，则执行主函数
-if (import.meta.url === `file://${process.argv[1]}`) {
-  main()
-}
-
-export { bumpPatchVersion, bumpMinorVersion, bumpMajorVersion }
+export { bumpPatchVersion, bumpMinorVersion, bumpMajorVersion, main }

--- a/scripts/release/update-embedded-submodules.mjs
+++ b/scripts/release/update-embedded-submodules.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.resolve(scriptDir, '..', '..')
+const manifestPath = path.join(repoRoot, 'scripts', 'comfy', 'embedded-sources.json')
+const vendorRoot = path.join(repoRoot, 'vendor', 'comfyui')
+
+function toNative(relativePath) {
+  return path.join(...relativePath.split('/'))
+}
+
+function assertInsideVendor(targetPath) {
+  const resolved = path.resolve(targetPath)
+  const vendor = path.resolve(vendorRoot)
+  const vendorWithSep = vendor.endsWith(path.sep) ? vendor : `${vendor}${path.sep}`
+  if (resolved !== vendor && !resolved.startsWith(vendorWithSep)) {
+    throw new Error(`Refusing to touch path outside vendor/comfyui: ${resolved}`)
+  }
+  return resolved
+}
+
+function runGit(args, options = {}) {
+  const output = execFileSync('git', args, {
+    cwd: options.cwd || repoRoot,
+    encoding: 'utf8',
+    stdio: options.inherit ? 'inherit' : ['ignore', 'pipe', 'pipe']
+  })
+  return typeof output === 'string' ? output.trim() : ''
+}
+
+function isGitWorktree(targetPath) {
+  try {
+    runGit(['-C', targetPath, 'rev-parse', '--is-inside-work-tree'])
+    return true
+  } catch {
+    return false
+  }
+}
+
+function currentCommit(targetPath) {
+  return runGit(['-C', targetPath, 'rev-parse', 'HEAD']).trim()
+}
+
+function ensureRootSubmodules() {
+  runGit(['submodule', 'sync', '--recursive'], { inherit: true })
+  runGit(['submodule', 'update', '--init', '--recursive'], { inherit: true })
+}
+
+function ensureNestedSubmodules(parentPath) {
+  runGit(['-C', parentPath, 'submodule', 'sync', '--recursive'], { inherit: true })
+  runGit(['-C', parentPath, 'submodule', 'update', '--init', '--recursive'], { inherit: true })
+}
+
+function resolveRemoteHead(targetPath) {
+  try {
+    return runGit([
+      '-C',
+      targetPath,
+      'symbolic-ref',
+      '--quiet',
+      '--short',
+      'refs/remotes/origin/HEAD'
+    ])
+  } catch {
+    try {
+      runGit(['-C', targetPath, 'remote', 'set-head', 'origin', '--auto'], { inherit: true })
+      return runGit([
+        '-C',
+        targetPath,
+        'symbolic-ref',
+        '--quiet',
+        '--short',
+        'refs/remotes/origin/HEAD'
+      ])
+    } catch {
+      const remoteInfo = runGit(['-C', targetPath, 'remote', 'show', 'origin'])
+      const match = remoteInfo.match(/HEAD branch:\s+([^\r\n]+)/)
+      if (match && match[1] !== '(unknown)') {
+        return `origin/${match[1].trim()}`
+      }
+      throw new Error(`Could not resolve origin HEAD for ${targetPath}`)
+    }
+  }
+}
+
+function updateSource(source, options) {
+  const targetPath = assertInsideVendor(path.join(repoRoot, toNative(source.relativePath)))
+
+  if (source.parentRelativePath) {
+    const parentPath = assertInsideVendor(path.join(repoRoot, toNative(source.parentRelativePath)))
+    if (!isGitWorktree(parentPath)) {
+      throw new Error(`Missing parent submodule for ${source.name}: ${source.parentRelativePath}`)
+    }
+    ensureNestedSubmodules(parentPath)
+  }
+
+  if (!fs.existsSync(targetPath) || !isGitWorktree(targetPath)) {
+    throw new Error(`Missing source submodule for ${source.name}: ${source.relativePath}`)
+  }
+
+  runGit(['-C', targetPath, 'remote', 'set-url', 'origin', source.url], { inherit: true })
+  runGit(['-C', targetPath, 'fetch', 'origin'], { inherit: true })
+
+  const remoteHead = resolveRemoteHead(targetPath)
+  const nextCommit = runGit(['-C', targetPath, 'rev-parse', `${remoteHead}^{commit}`])
+  const previousCommit = currentCommit(targetPath)
+
+  console.log(`${source.name}: ${previousCommit} -> ${nextCommit}`)
+
+  if (!options.dryRun && previousCommit !== nextCommit) {
+    runGit(['-C', targetPath, 'checkout', '--detach', nextCommit], { inherit: true })
+  }
+
+  return {
+    ...source,
+    commit: nextCommit
+  }
+}
+
+function main(argv = process.argv.slice(2)) {
+  const dryRun = argv.includes('--dry-run')
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
+  if (!Array.isArray(manifest.sources)) {
+    throw new Error(`Invalid embedded source manifest: ${manifestPath}`)
+  }
+
+  ensureRootSubmodules()
+
+  const sources = manifest.sources.map((source) => updateSource(source, { dryRun }))
+  if (!dryRun) {
+    fs.writeFileSync(manifestPath, `${JSON.stringify({ ...manifest, sources }, null, 2)}\n`, 'utf8')
+    console.log(`Updated embedded source manifest: ${manifestPath}`)
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main()
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exit(1)
+  }
+}
+
+export { main }


### PR DESCRIPTION
## Summary
- keep transparent DOM hit proxies for dense WebGL image boards in select mode
- create visible WebGL sprites in stable row-major batches instead of center-out rings while scrolling
- reduce viewport/source-upgrade delays, run two source upgrades at a time, and timeout stuck image/texture loads so decode stalls release the queue
- make middle-mouse/hand panning apply viewport transforms immediately and continue tracking global move events when the pointer leaves the stage
- reduce pan-time WebGL overhead by deferring render metrics bookkeeping until viewport interaction ends and removing a per-sync texture sampling check
- send selected-image transform previews to WebGL immediately and render preview sprites synchronously so the image body stays locked to the selection frame while dragging

## Rust/WASM Note
This repo currently has no Rust workspace or canvas-native build integration, and this environment does not have `rustc`, `cargo`, or `wasm-pack` installed. A Rust/WASM migration should be limited to pure CPU hot paths such as spatial queries or hit-test batches after profiling confirms they dominate frame time. The immediate low-FPS path was in the renderer hot loop, so this PR first reduces work on the existing JS/WebGL path without adding an unverified build chain.

## Root Cause
Dense WebGL boards suppressed per-image hit proxies for unselected images to reduce DOM work, so direct click/drag had no DOM target under the cursor. Separately, the WebGL resident sprite queue used source-upgrade priority for visible sprite creation, which favored items near the viewport center and produced the circular reveal pattern. Source texture upgrades also ran one at a time and normal image element loads had no timeout, so one slow or stuck decode could hold the upgrade queue and delay crisp textures after zooming. Middle-mouse pan updates were waiting for the next animation-frame commit and only listened to stage mousemove events, which made fast drags feel behind the pointer and could drop movement after the cursor left the stage. After pan became immediate, render-time metrics bookkeeping still ran on every WebGL render during interaction, adding avoidable main-thread work. For selected image dragging, the DOM selection frame moved in the pointer event, but the image body preview was still batched through a preview animation frame and then through a scheduled WebGL render, which made the image visibly chase the frame during fast drags.

## Validation
- `npx vitest run --config config/vitest/vitest.web.config.mjs packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasWebGLImageLayer.test.tsx --pool=forks --maxWorkers=1`
- `npx vitest run --config config/vitest/vitest.web.config.mjs packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasWebGLImageLayer.test.tsx packages/app/src/renderer/src/pages/ProjectCanvasPage/ProjectCanvasPageStageScene.test.tsx packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasAssetIntakeHelpers.test.ts packages/app/src/renderer/src/pages/ProjectCanvasPage/useCanvasAssetIntake.test.tsx packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasLocalImageSource.test.ts packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasLocalFileSource.test.ts --pool=forks --maxWorkers=1`
- `npx vitest run --config config/vitest/vitest.web.config.mjs packages/app/src/renderer/src/pages/ProjectCanvasPage/useCanvasStageInteraction.test.tsx --pool=forks --maxWorkers=1`
- `npx vitest run --config config/vitest/vitest.web.config.mjs packages/app/src/renderer/src/pages/ProjectCanvasPage/useCanvasStageInteraction.test.tsx packages/app/src/renderer/src/pages/ProjectCanvasPage/ProjectCanvasPageStageScene.test.tsx packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasWebGLImageLayer.test.tsx --pool=forks --maxWorkers=1`
- `npx vitest run --config config/vitest/vitest.web.config.mjs packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasImageInteractionOverlay.test.tsx packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasWebGLImageLayer.test.tsx packages/app/src/renderer/src/pages/ProjectCanvasPage/ProjectCanvasPageStageScene.test.tsx --pool=forks --maxWorkers=1`
- `npm run typecheck:web`
- `git diff --check -- packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasImageInteractionOverlay.tsx packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasWebGLImageLayer.tsx packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasImageInteractionOverlay.test.tsx packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasWebGLImageLayer.test.tsx`