### PR TITLE
[codex] fix release windows publish step

### DIFF
--- a/.github/workflows/call-release.yml
+++ b/.github/workflows/call-release.yml
@@ -60,11 +60,12 @@ jobs:
 
       - name: Build package
         run: |
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
+
           npm run build:embedded
           npm run prepare:embedded
-          npx cross-env PACKAGE_MODE=embedded npm run package:win
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          npx cross-env PACKAGE_MODE=embedded npm run package:win -- --publish never
 
       - name: Create Release
         id: create_release


### PR DESCRIPTION
## Summary

- prevent `electron-builder` from auto-publishing the Windows embedded ZIP during packaging
- keep GitHub release publishing in the dedicated `softprops/action-gh-release` step
- make the PowerShell build step fail fast when native commands fail

## Root Cause

The `release-windows` job provided `GH_TOKEN` to `electron-builder`. In CI, that made `electron-builder` try to publish after building the ZIP. It inferred the release repository from package metadata as `MagicPotTeam/MagicPot`, while the workflow runs in `MagicPotTeam/magicpot-open`, so the workflow token could not access that release endpoint and GitHub returned `404`.

The log also showed an embedded ComfyUI smoke failure before packaging, but the multi-command PowerShell step continued running and the later publish error masked it.

## Validation

- `git diff --check`
- parsed `.github/workflows/call-release.yml` with `js-yaml`
- checked that the Build package step includes `--publish never` and no longer includes `GH_TOKEN`
- commit hook ran `node scripts/check-text-encoding.mjs`