### PR TITLE
[codex] fix SeedVR2 CPU smoke fallback

### DIFF
--- a/scripts/prepare-embedded-staging.mjs
+++ b/scripts/prepare-embedded-staging.mjs
@@ -190,6 +190,41 @@ function validateStaging() {
   }
 }
 
+function applySeedVr2CpuDeviceFallback() {
+  const memoryManagerPath = path.join(
+    customNodesDst,
+    'ComfyUI-SeedVR2_VideoUpscaler',
+    'src',
+    'optimization',
+    'memory_manager.py'
+  )
+  if (!fs.existsSync(memoryManagerPath)) {
+    return
+  }
+
+  const source = fs.readFileSync(memoryManagerPath, 'utf8')
+  if (source.includes('SeedVR2 schema definitions index the first device')) {
+    return
+  }
+
+  const patched = source.replace(
+    /(\n\s*result\.extend\(devs\)\r?\n\s*)return result if result else \[\]/,
+    `$1if result:
+        return result
+
+    # SeedVR2 schema definitions index the first device during ComfyUI's quick test.
+    # GitHub-hosted Windows release runners are CPU-only, so keep registration alive.
+    return ["cpu"]`
+  )
+
+  if (patched === source) {
+    throw new Error(`Could not apply SeedVR2 CPU device fallback: ${memoryManagerPath}`)
+  }
+
+  fs.writeFileSync(memoryManagerPath, patched, 'utf8')
+  console.log('[prepare-embedded-staging] Applied SeedVR2 CPU device fallback')
+}
+
 function main() {
   if (!fs.existsSync(localComfyRepo)) {
     throw new Error(`Missing ComfyUI source repo: ${localComfyRepo}`)
@@ -204,6 +239,7 @@ function main() {
   cloneFreshComfySource()
   copyTree(customNodesSrc, customNodesDst, shouldSkipCustomNodeSource)
   removeRepositoryMetadata(customNodesDst)
+  applySeedVr2CpuDeviceFallback()
 
   validateStaging()
   console.log(`[prepare-embedded-staging] Wrote ${comfyDst}`)


### PR DESCRIPTION
## Summary

- patch the staged SeedVR2 custom node so CPU-only release runners can register its schemas
- keep strict embedded smoke enabled for all other import failures
- fail deterministically if the upstream SeedVR2 source no longer matches the expected patch target

## Root Cause

The latest `ComfyUI-SeedVR2_VideoUpscaler` submodule returns an empty device list on CPU-only hosts. Its DiT and VAE schema loaders index the first device as their default value, so GitHub's Windows release runner fails ComfyUI quick test with `list index out of range` and `(IMPORT FAILED)`.

This is separate from the earlier `electron-builder` publish issue. The release workflow now stops correctly in `prepare:embedded` before packaging.

## Validation

- `node --check scripts/prepare-embedded-staging.mjs`
- `npm run prepare:embedded-staging`
- verified staged SeedVR2 `memory_manager.py` contains the CPU fallback
- `python -m py_compile .staging/embedded/ComfyUI/custom_nodes/ComfyUI-SeedVR2_VideoUpscaler/src/optimization/memory_manager.py`
- `npm run check:text-encoding -- scripts/prepare-embedded-staging.mjs`
- `git diff --check`