### PR TITLE
[codex] fix nightly release retry assets

### DIFF
--- a/.github/workflows/call-release.yml
+++ b/.github/workflows/call-release.yml
@@ -85,76 +85,17 @@ jobs:
           }
 
           $archive = $archiveFiles[0]
-          [int64]$maxPartBytes = [int64]1900 * 1024 * 1024
           [int64]$githubLimitBytes = [int64]2147483648
           $hash = (Get-FileHash -Algorithm SHA256 -LiteralPath $archive.FullName).Hash.ToLowerInvariant()
 
+          if ($archive.Length -ge $githubLimitBytes) {
+            throw "Windows archive exceeds GitHub's single-asset size limit: $($archive.Name) is $($archive.Length) bytes"
+          }
+
+          Copy-Item -LiteralPath $archive.FullName -Destination (Join-Path $assetsDir $archive.Name)
           Set-Content `
             -LiteralPath (Join-Path $assetsDir "$($archive.Name).sha256") `
             -Value "$hash  $($archive.Name)"
-
-          if ($archive.Length -lt $githubLimitBytes) {
-            Copy-Item -LiteralPath $archive.FullName -Destination (Join-Path $assetsDir $archive.Name)
-            Set-Content `
-              -LiteralPath (Join-Path $assetsDir "$($archive.Name).parts.txt") `
-              -Value @(
-                "file=$($archive.Name)"
-                "sha256=$hash"
-                "parts=1"
-                "This archive is below GitHub's single-asset size limit and does not need reassembly."
-              )
-            Get-ChildItem -LiteralPath $assetsDir | Select-Object Name,Length
-            exit 0
-          }
-
-          $buffer = New-Object byte[] (4 * 1024 * 1024)
-          $inputStream = [System.IO.File]::OpenRead($archive.FullName)
-          $partNames = @()
-
-          try {
-            while ($inputStream.Position -lt $inputStream.Length) {
-              $partName = "{0}.{1:D3}" -f $archive.Name, ($partNames.Count + 1)
-              $partPath = Join-Path $assetsDir $partName
-              $partNames += $partName
-              $outputStream = [System.IO.File]::Create($partPath)
-
-              try {
-                [int64]$remaining = [Math]::Min($maxPartBytes, $inputStream.Length - $inputStream.Position)
-                while ($remaining -gt 0) {
-                  [int64]$readLength = [Math]::Min([int64]$buffer.Length, $remaining)
-                  $read = $inputStream.Read($buffer, 0, [int]$readLength)
-                  if ($read -le 0) {
-                    break
-                  }
-
-                  $outputStream.Write($buffer, 0, $read)
-                  $remaining -= $read
-                }
-              } finally {
-                $outputStream.Dispose()
-              }
-
-              $part = Get-Item -LiteralPath $partPath
-              if ($part.Length -ge $githubLimitBytes) {
-                throw "Split part exceeds GitHub release asset limit: $partPath"
-              }
-            }
-          } finally {
-            $inputStream.Dispose()
-          }
-
-          $cmdParts = $partNames -join '+'
-          Set-Content `
-            -LiteralPath (Join-Path $assetsDir "$($archive.Name).parts.txt") `
-            -Value @(
-              "file=$($archive.Name)"
-              "sha256=$hash"
-              "parts=$($partNames.Count)"
-              "Download every numbered part, then reassemble in order before extracting."
-              "Windows cmd example:"
-              "copy /b $cmdParts $($archive.Name)"
-              "After reassembly, verify the SHA256 against $($archive.Name).sha256."
-            )
 
           Get-ChildItem -LiteralPath $assetsDir | Select-Object Name,Length
 
@@ -169,8 +110,8 @@ jobs:
           prerelease: false
           generate_release_notes: true
           body: |
-            Windows embedded builds are distributed as `.7z` archives and may be split because GitHub Release assets must be smaller than 2 GiB.
-            If numbered `.001`, `.002`, ... files are present, download all parts and follow the matching `.parts.txt` instructions before extracting.
+            Windows embedded builds are distributed as single `.7z` archives.
+            A `.sha256` file is included for archive integrity verification.
           files: |
             dist/release-assets/*
         env:

--- a/.github/workflows/call-release.yml
+++ b/.github/workflows/call-release.yml
@@ -60,11 +60,12 @@ jobs:
 
       - name: Build package
         run: |
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
+
           npm run build:embedded
           npm run prepare:embedded
-          npx cross-env PACKAGE_MODE=embedded npm run package:win
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          npx cross-env PACKAGE_MODE=embedded npm run package:win -- --publish never
 
       - name: Create Release
         id: create_release

--- a/.github/workflows/call-release.yml
+++ b/.github/workflows/call-release.yml
@@ -67,6 +67,94 @@ jobs:
           npm run prepare:embedded
           npx cross-env PACKAGE_MODE=embedded npm run package:win -- --publish never
 
+      - name: Prepare release assets
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          $assetsDir = 'dist/release-assets'
+          New-Item -ItemType Directory -Force -Path $assetsDir | Out-Null
+          Get-ChildItem -LiteralPath $assetsDir -Force | Remove-Item -Force
+
+          $zipFiles = @(Get-ChildItem -LiteralPath 'dist/embedded' -Filter '*-win.zip' -File)
+          if ($zipFiles.Count -ne 1) {
+            throw "Expected exactly one Windows ZIP, found $($zipFiles.Count)"
+          }
+
+          $zip = $zipFiles[0]
+          [int64]$maxPartBytes = [int64]1900 * 1024 * 1024
+          [int64]$githubLimitBytes = [int64]2147483648
+          $hash = (Get-FileHash -Algorithm SHA256 -LiteralPath $zip.FullName).Hash.ToLowerInvariant()
+
+          Set-Content `
+            -LiteralPath (Join-Path $assetsDir "$($zip.Name).sha256") `
+            -Value "$hash  $($zip.Name)"
+
+          if ($zip.Length -lt $githubLimitBytes) {
+            Copy-Item -LiteralPath $zip.FullName -Destination (Join-Path $assetsDir $zip.Name)
+            Set-Content `
+              -LiteralPath (Join-Path $assetsDir "$($zip.Name).parts.txt") `
+              -Value @(
+                "file=$($zip.Name)"
+                "sha256=$hash"
+                "parts=1"
+                "This ZIP is below GitHub's single-asset size limit and does not need reassembly."
+              )
+            Get-ChildItem -LiteralPath $assetsDir | Select-Object Name,Length
+            exit 0
+          }
+
+          $buffer = New-Object byte[] (4 * 1024 * 1024)
+          $inputStream = [System.IO.File]::OpenRead($zip.FullName)
+          $partNames = @()
+
+          try {
+            while ($inputStream.Position -lt $inputStream.Length) {
+              $partName = "{0}.{1:D3}" -f $zip.Name, ($partNames.Count + 1)
+              $partPath = Join-Path $assetsDir $partName
+              $partNames += $partName
+              $outputStream = [System.IO.File]::Create($partPath)
+
+              try {
+                [int64]$remaining = [Math]::Min($maxPartBytes, $inputStream.Length - $inputStream.Position)
+                while ($remaining -gt 0) {
+                  [int64]$readLength = [Math]::Min([int64]$buffer.Length, $remaining)
+                  $read = $inputStream.Read($buffer, 0, [int]$readLength)
+                  if ($read -le 0) {
+                    break
+                  }
+
+                  $outputStream.Write($buffer, 0, $read)
+                  $remaining -= $read
+                }
+              } finally {
+                $outputStream.Dispose()
+              }
+
+              $part = Get-Item -LiteralPath $partPath
+              if ($part.Length -ge $githubLimitBytes) {
+                throw "Split part exceeds GitHub release asset limit: $partPath"
+              }
+            }
+          } finally {
+            $inputStream.Dispose()
+          }
+
+          $cmdParts = $partNames -join '+'
+          Set-Content `
+            -LiteralPath (Join-Path $assetsDir "$($zip.Name).parts.txt") `
+            -Value @(
+              "file=$($zip.Name)"
+              "sha256=$hash"
+              "parts=$($partNames.Count)"
+              "Download every numbered part, then reassemble in order before extracting."
+              "Windows cmd example:"
+              "copy /b $cmdParts $($zip.Name)"
+              "After reassembly, verify the SHA256 against $($zip.Name).sha256."
+            )
+
+          Get-ChildItem -LiteralPath $assetsDir | Select-Object Name,Length
+
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@v2
@@ -76,8 +164,11 @@ jobs:
           draft: false
           prerelease: false
           generate_release_notes: true
+          body: |
+            Windows embedded builds may be split because GitHub Release assets must be smaller than 2 GiB.
+            If numbered `.001`, `.002`, ... files are present, download all parts and follow the matching `.parts.txt` instructions before extracting.
           files: |
-            dist/embedded/*-win.zip
+            dist/release-assets/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/call-release.yml
+++ b/.github/workflows/call-release.yml
@@ -76,41 +76,44 @@ jobs:
           New-Item -ItemType Directory -Force -Path $assetsDir | Out-Null
           Get-ChildItem -LiteralPath $assetsDir -Force | Remove-Item -Force
 
-          $zipFiles = @(Get-ChildItem -LiteralPath 'dist/embedded' -Filter '*-win.zip' -File)
-          if ($zipFiles.Count -ne 1) {
-            throw "Expected exactly one Windows ZIP, found $($zipFiles.Count)"
+          $archiveFiles = @(
+            Get-ChildItem -LiteralPath 'dist/embedded' -File |
+              Where-Object { $_.Name -like '*-win.7z' -or $_.Name -like '*-win.zip' }
+          )
+          if ($archiveFiles.Count -ne 1) {
+            throw "Expected exactly one Windows archive, found $($archiveFiles.Count)"
           }
 
-          $zip = $zipFiles[0]
+          $archive = $archiveFiles[0]
           [int64]$maxPartBytes = [int64]1900 * 1024 * 1024
           [int64]$githubLimitBytes = [int64]2147483648
-          $hash = (Get-FileHash -Algorithm SHA256 -LiteralPath $zip.FullName).Hash.ToLowerInvariant()
+          $hash = (Get-FileHash -Algorithm SHA256 -LiteralPath $archive.FullName).Hash.ToLowerInvariant()
 
           Set-Content `
-            -LiteralPath (Join-Path $assetsDir "$($zip.Name).sha256") `
-            -Value "$hash  $($zip.Name)"
+            -LiteralPath (Join-Path $assetsDir "$($archive.Name).sha256") `
+            -Value "$hash  $($archive.Name)"
 
-          if ($zip.Length -lt $githubLimitBytes) {
-            Copy-Item -LiteralPath $zip.FullName -Destination (Join-Path $assetsDir $zip.Name)
+          if ($archive.Length -lt $githubLimitBytes) {
+            Copy-Item -LiteralPath $archive.FullName -Destination (Join-Path $assetsDir $archive.Name)
             Set-Content `
-              -LiteralPath (Join-Path $assetsDir "$($zip.Name).parts.txt") `
+              -LiteralPath (Join-Path $assetsDir "$($archive.Name).parts.txt") `
               -Value @(
-                "file=$($zip.Name)"
+                "file=$($archive.Name)"
                 "sha256=$hash"
                 "parts=1"
-                "This ZIP is below GitHub's single-asset size limit and does not need reassembly."
+                "This archive is below GitHub's single-asset size limit and does not need reassembly."
               )
             Get-ChildItem -LiteralPath $assetsDir | Select-Object Name,Length
             exit 0
           }
 
           $buffer = New-Object byte[] (4 * 1024 * 1024)
-          $inputStream = [System.IO.File]::OpenRead($zip.FullName)
+          $inputStream = [System.IO.File]::OpenRead($archive.FullName)
           $partNames = @()
 
           try {
             while ($inputStream.Position -lt $inputStream.Length) {
-              $partName = "{0}.{1:D3}" -f $zip.Name, ($partNames.Count + 1)
+              $partName = "{0}.{1:D3}" -f $archive.Name, ($partNames.Count + 1)
               $partPath = Join-Path $assetsDir $partName
               $partNames += $partName
               $outputStream = [System.IO.File]::Create($partPath)
@@ -142,15 +145,15 @@ jobs:
 
           $cmdParts = $partNames -join '+'
           Set-Content `
-            -LiteralPath (Join-Path $assetsDir "$($zip.Name).parts.txt") `
+            -LiteralPath (Join-Path $assetsDir "$($archive.Name).parts.txt") `
             -Value @(
-              "file=$($zip.Name)"
+              "file=$($archive.Name)"
               "sha256=$hash"
               "parts=$($partNames.Count)"
               "Download every numbered part, then reassemble in order before extracting."
               "Windows cmd example:"
-              "copy /b $cmdParts $($zip.Name)"
-              "After reassembly, verify the SHA256 against $($zip.Name).sha256."
+              "copy /b $cmdParts $($archive.Name)"
+              "After reassembly, verify the SHA256 against $($archive.Name).sha256."
             )
 
           Get-ChildItem -LiteralPath $assetsDir | Select-Object Name,Length
@@ -166,7 +169,7 @@ jobs:
           prerelease: false
           generate_release_notes: true
           body: |
-            Windows embedded builds may be split because GitHub Release assets must be smaller than 2 GiB.
+            Windows embedded builds are distributed as `.7z` archives and may be split because GitHub Release assets must be smaller than 2 GiB.
             If numbered `.001`, `.002`, ... files are present, download all parts and follow the matching `.parts.txt` instructions before extracting.
           files: |
             dist/release-assets/*

--- a/.github/workflows/call-release.yml
+++ b/.github/workflows/call-release.yml
@@ -86,16 +86,12 @@ jobs:
 
           $archive = $archiveFiles[0]
           [int64]$githubLimitBytes = [int64]2147483648
-          $hash = (Get-FileHash -Algorithm SHA256 -LiteralPath $archive.FullName).Hash.ToLowerInvariant()
 
           if ($archive.Length -ge $githubLimitBytes) {
             throw "Windows archive exceeds GitHub's single-asset size limit: $($archive.Name) is $($archive.Length) bytes"
           }
 
           Copy-Item -LiteralPath $archive.FullName -Destination (Join-Path $assetsDir $archive.Name)
-          Set-Content `
-            -LiteralPath (Join-Path $assetsDir "$($archive.Name).sha256") `
-            -Value "$hash  $($archive.Name)"
 
           Get-ChildItem -LiteralPath $assetsDir | Select-Object Name,Length
 
@@ -111,7 +107,6 @@ jobs:
           generate_release_notes: true
           body: |
             Windows embedded builds are distributed as single `.7z` archives.
-            A `.sha256` file is included for archive integrity verification.
           files: |
             dist/release-assets/*
         env:

--- a/.github/workflows/call-release.yml
+++ b/.github/workflows/call-release.yml
@@ -160,6 +160,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: release/${{ inputs.tag_name }}
+          target_commitish: ${{ inputs.ref }}
           name: ${{ inputs.release_name }}
           draft: false
           prerelease: false

--- a/.github/workflows/nightly-bump-version.yml
+++ b/.github/workflows/nightly-bump-version.yml
@@ -11,8 +11,13 @@ env:
 jobs:
   check-commits:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
-      has_commits: ${{ steps.check-commits.outputs.has_commits }}
+      release_mode: ${{ steps.check-commits.outputs.release_mode }}
+      tag_name: ${{ steps.check-commits.outputs.tag_name }}
+      release_name: ${{ steps.check-commits.outputs.release_name }}
+      ref: ${{ steps.check-commits.outputs.ref }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -21,8 +26,43 @@ jobs:
 
       - name: Check for new commits
         id: check-commits
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          LAST_RELEASE_COMMIT=$(git log --oneline --grep="^release: " origin/master | head -1 | cut -d' ' -f1)
+          LAST_RELEASE_COMMIT=$(git log --format=%H --grep="^release: " origin/master | head -1)
+
+          if [ -n "$LAST_RELEASE_COMMIT" ]; then
+            LAST_RELEASE_SUBJECT=$(git log -1 --format=%s "$LAST_RELEASE_COMMIT")
+            if [[ "$LAST_RELEASE_SUBJECT" =~ ^release:\ Nightly\ Release\ ([0-9]{4})-([0-9]{2})-([0-9]{2})\ -\ ([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+              RELEASE_DATE="${BASH_REMATCH[1]}-${BASH_REMATCH[2]}-${BASH_REMATCH[3]}"
+              VERSION="${BASH_REMATCH[4]}"
+              TAG_NAME="nightly-${BASH_REMATCH[1]}${BASH_REMATCH[2]}${BASH_REMATCH[3]}-${VERSION}"
+              RELEASE_NAME="Nightly Release ${RELEASE_DATE} - ${VERSION}"
+              RELEASE_JSON=$(gh release view "release/${TAG_NAME}" \
+                --json isDraft,assets \
+                --jq '{isDraft: .isDraft, assetCount: (.assets | length)}' 2>/dev/null || true)
+
+              if [ -z "$RELEASE_JSON" ]; then
+                echo "Latest release commit has no GitHub release, retrying ${TAG_NAME}"
+                echo "release_mode=retry" >> "$GITHUB_OUTPUT"
+                echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
+                echo "release_name=$RELEASE_NAME" >> "$GITHUB_OUTPUT"
+                echo "ref=refs/heads/master" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+
+              IS_DRAFT=$(echo "$RELEASE_JSON" | jq -r '.isDraft')
+              ASSET_COUNT=$(echo "$RELEASE_JSON" | jq -r '.assetCount')
+              if [ "$IS_DRAFT" = "true" ] || [ "$ASSET_COUNT" -eq 0 ]; then
+                echo "Latest release ${TAG_NAME} is incomplete, retrying without bumping"
+                echo "release_mode=retry" >> "$GITHUB_OUTPUT"
+                echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
+                echo "release_name=$RELEASE_NAME" >> "$GITHUB_OUTPUT"
+                echo "ref=refs/heads/master" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+            fi
+          fi
 
           if [ -z "$LAST_RELEASE_COMMIT" ]; then
             COMMITS=$(git log --oneline origin/master | wc -l)
@@ -32,22 +72,22 @@ jobs:
 
           if [ "$COMMITS" -eq 0 ]; then
             echo "No new commits found on master, skipping workflow"
-            echo "has_commits=false" >> "$GITHUB_OUTPUT"
+            echo "release_mode=skip" >> "$GITHUB_OUTPUT"
           else
             echo "Found $COMMITS new commits, continuing workflow"
-            echo "has_commits=true" >> "$GITHUB_OUTPUT"
+            echo "release_mode=bump" >> "$GITHUB_OUTPUT"
           fi
 
   ci:
     needs: check-commits
-    if: needs.check-commits.outputs.has_commits == 'true'
+    if: needs.check-commits.outputs.release_mode == 'bump'
     uses: ./.github/workflows/call-ci.yml
     with:
       ref: refs/heads/master
 
   build:
     needs: check-commits
-    if: needs.check-commits.outputs.has_commits == 'true'
+    if: needs.check-commits.outputs.release_mode == 'bump'
     uses: ./.github/workflows/call-build.yml
     with:
       ref: refs/heads/master
@@ -57,7 +97,7 @@ jobs:
       - check-commits
       - ci
       - build
-    if: needs.check-commits.outputs.has_commits == 'true'
+    if: needs.check-commits.outputs.release_mode == 'bump'
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -180,11 +220,25 @@ jobs:
 
   release:
     needs: bump-version
+    if: needs.bump-version.result == 'success'
     uses: ./.github/workflows/call-release.yml
     with:
       tag_name: ${{ needs.bump-version.outputs.tag_name }}
       release_name: ${{ needs.bump-version.outputs.release_name }}
       ref: ${{ needs.bump-version.outputs.ref }}
+    secrets: inherit
+    permissions:
+      actions: read
+      contents: write
+
+  release-existing:
+    needs: check-commits
+    if: needs.check-commits.outputs.release_mode == 'retry'
+    uses: ./.github/workflows/call-release.yml
+    with:
+      tag_name: ${{ needs.check-commits.outputs.tag_name }}
+      release_name: ${{ needs.check-commits.outputs.release_name }}
+      ref: ${{ needs.check-commits.outputs.ref }}
     secrets: inherit
     permissions:
       actions: read

--- a/.github/workflows/nightly-bump-version.yml
+++ b/.github/workflows/nightly-bump-version.yml
@@ -30,6 +30,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           LAST_RELEASE_COMMIT=$(git log --format=%H --grep="^release: " origin/master | head -1)
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
 
           if [ -n "$LAST_RELEASE_COMMIT" ]; then
             LAST_RELEASE_SUBJECT=$(git log -1 --format=%s "$LAST_RELEASE_COMMIT")
@@ -42,24 +43,26 @@ jobs:
                 --json isDraft,assets \
                 --jq '{isDraft: .isDraft, assetCount: (.assets | length)}' 2>/dev/null || true)
 
-              if [ -z "$RELEASE_JSON" ]; then
+              if [ "$VERSION" != "$PACKAGE_VERSION" ]; then
+                echo "Latest release ${TAG_NAME} does not match package.json ${PACKAGE_VERSION}, not retrying it"
+              elif [ -z "$RELEASE_JSON" ]; then
                 echo "Latest release commit has no GitHub release, retrying ${TAG_NAME}"
                 echo "release_mode=retry" >> "$GITHUB_OUTPUT"
                 echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
                 echo "release_name=$RELEASE_NAME" >> "$GITHUB_OUTPUT"
                 echo "ref=refs/heads/master" >> "$GITHUB_OUTPUT"
                 exit 0
-              fi
-
-              IS_DRAFT=$(echo "$RELEASE_JSON" | jq -r '.isDraft')
-              ASSET_COUNT=$(echo "$RELEASE_JSON" | jq -r '.assetCount')
-              if [ "$IS_DRAFT" = "true" ] || [ "$ASSET_COUNT" -eq 0 ]; then
-                echo "Latest release ${TAG_NAME} is incomplete, retrying without bumping"
-                echo "release_mode=retry" >> "$GITHUB_OUTPUT"
-                echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
-                echo "release_name=$RELEASE_NAME" >> "$GITHUB_OUTPUT"
-                echo "ref=refs/heads/master" >> "$GITHUB_OUTPUT"
-                exit 0
+              else
+                IS_DRAFT=$(echo "$RELEASE_JSON" | jq -r '.isDraft')
+                ASSET_COUNT=$(echo "$RELEASE_JSON" | jq -r '.assetCount')
+                if [ "$IS_DRAFT" = "true" ] || [ "$ASSET_COUNT" -eq 0 ]; then
+                  echo "Latest release ${TAG_NAME} is incomplete, retrying without bumping"
+                  echo "release_mode=retry" >> "$GITHUB_OUTPUT"
+                  echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
+                  echo "release_name=$RELEASE_NAME" >> "$GITHUB_OUTPUT"
+                  echo "ref=refs/heads/master" >> "$GITHUB_OUTPUT"
+                  exit 0
+                fi
               fi
             fi
           fi

--- a/.github/workflows/nightly-bump-version.yml
+++ b/.github/workflows/nightly-bump-version.yml
@@ -109,7 +109,9 @@ jobs:
     outputs:
       tag_name: ${{ steps.tag-version.outputs.tag_name }}
       release_name: ${{ steps.tag-version.outputs.release_name }}
-      ref: ${{ steps.merge-pr.outputs.ref }}
+      ref: ${{ steps.commit-version-bump.outputs.ref }}
+      pr_number: ${{ steps.open-pr.outputs.pr_number }}
+      commit_message: ${{ steps.commit-version-bump.outputs.commit_message }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -146,11 +148,13 @@ jobs:
 
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git add package.json scripts/comfy/embedded-sources.json vendor/comfyui
+          git add package.json package-lock.json scripts/comfy/embedded-sources.json vendor/comfyui
           git commit -m "$COMMIT_MESSAGE"
+          COMMIT_SHA=$(git rev-parse HEAD)
           git push --force origin HEAD:$RELEASE_BRANCH
 
           echo "commit_message=$COMMIT_MESSAGE" >> "$GITHUB_OUTPUT"
+          echo "ref=$COMMIT_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Create or update release PR
         id: open-pr
@@ -170,6 +174,7 @@ jobs:
           - Source branch: \`$RELEASE_BRANCH\`
           - Triggered by: \`${{ github.workflow }}\`
           - Run: \`${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\`
+          - Merge policy: this PR is merged only after the release package is built and uploaded successfully.
           EOF
           )
 
@@ -194,33 +199,6 @@ jobs:
 
           echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
 
-      - name: Merge release PR
-        id: merge-pr
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh pr merge "${{ steps.open-pr.outputs.pr_number }}" \
-            --squash \
-            --delete-branch=false \
-            --subject "${{ steps.commit-version-bump.outputs.commit_message }}" \
-            --body ""
-
-          for attempt in $(seq 1 20); do
-            MERGE_SHA=$(gh pr view "${{ steps.open-pr.outputs.pr_number }}" \
-              --json mergeCommit \
-              --jq '.mergeCommit.oid')
-
-            if [ -n "$MERGE_SHA" ] && [ "$MERGE_SHA" != "null" ]; then
-              echo "ref=$MERGE_SHA" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-
-            sleep 3
-          done
-
-          echo "Merged PR did not expose a merge commit SHA in time" >&2
-          exit 1
-
   release:
     needs: bump-version
     if: needs.bump-version.result == 'success'
@@ -233,6 +211,26 @@ jobs:
     permissions:
       actions: read
       contents: write
+
+  merge-release:
+    needs:
+      - bump-version
+      - release
+    if: needs.release.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Merge release PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr merge "${{ needs.bump-version.outputs.pr_number }}" \
+            --squash \
+            --delete-branch=false \
+            --subject "${{ needs.bump-version.outputs.commit_message }}" \
+            --body ""
 
   release-existing:
     needs: check-commits

--- a/.github/workflows/nightly-bump-version.yml
+++ b/.github/workflows/nightly-bump-version.yml
@@ -44,7 +44,8 @@ jobs:
                 --jq '{isDraft: .isDraft, assetCount: (.assets | length)}' 2>/dev/null || true)
 
               if [ "$VERSION" != "$PACKAGE_VERSION" ]; then
-                echo "Latest release ${TAG_NAME} does not match package.json ${PACKAGE_VERSION}, not retrying it"
+                echo "Latest release ${TAG_NAME} does not match package.json ${PACKAGE_VERSION}, ignoring it"
+                LAST_RELEASE_COMMIT=""
               elif [ -z "$RELEASE_JSON" ]; then
                 echo "Latest release commit has no GitHub release, retrying ${TAG_NAME}"
                 echo "release_mode=retry" >> "$GITHUB_OUTPUT"
@@ -68,10 +69,12 @@ jobs:
           fi
 
           if [ -z "$LAST_RELEASE_COMMIT" ]; then
-            COMMITS=$(git log --oneline origin/master | wc -l)
-          else
-            COMMITS=$(git log --oneline "${LAST_RELEASE_COMMIT}..origin/master" | wc -l)
+            echo "No release commit matches package.json ${PACKAGE_VERSION}; creating the initial release without bumping"
+            echo "release_mode=initial" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+
+          COMMITS=$(git log --oneline "${LAST_RELEASE_COMMIT}..origin/master" | wc -l)
 
           if [ "$COMMITS" -eq 0 ]; then
             echo "No new commits found on master, skipping workflow"
@@ -83,14 +86,14 @@ jobs:
 
   ci:
     needs: check-commits
-    if: needs.check-commits.outputs.release_mode == 'bump'
+    if: needs.check-commits.outputs.release_mode == 'bump' || needs.check-commits.outputs.release_mode == 'initial'
     uses: ./.github/workflows/call-ci.yml
     with:
       ref: refs/heads/master
 
   build:
     needs: check-commits
-    if: needs.check-commits.outputs.release_mode == 'bump'
+    if: needs.check-commits.outputs.release_mode == 'bump' || needs.check-commits.outputs.release_mode == 'initial'
     uses: ./.github/workflows/call-build.yml
     with:
       ref: refs/heads/master
@@ -100,7 +103,7 @@ jobs:
       - check-commits
       - ci
       - build
-    if: needs.check-commits.outputs.release_mode == 'bump'
+    if: needs.check-commits.outputs.release_mode == 'bump' || needs.check-commits.outputs.release_mode == 'initial'
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -126,7 +129,13 @@ jobs:
           git checkout -B "$RELEASE_BRANCH" origin/master
 
       - name: Bump version
-        run: node ./scripts/release/bump-version.mjs
+        run: |
+          if [ "${{ needs.check-commits.outputs.release_mode }}" = "initial" ]; then
+            echo "Initial release uses the existing package.json version."
+            exit 0
+          fi
+
+          node ./scripts/release/bump-version.mjs
 
       - name: Update embedded submodules
         run: npm run release:update-submodules
@@ -149,7 +158,7 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add package.json package-lock.json scripts/comfy/embedded-sources.json vendor/comfyui
-          git commit -m "$COMMIT_MESSAGE"
+          git commit --allow-empty -m "$COMMIT_MESSAGE"
           COMMIT_SHA=$(git rev-parse HEAD)
           git push --force origin HEAD:$RELEASE_BRANCH
 
@@ -172,6 +181,7 @@ jobs:
           Automated nightly release PR.
 
           - Source branch: \`$RELEASE_BRANCH\`
+          - Release mode: \`${{ needs.check-commits.outputs.release_mode }}\`
           - Triggered by: \`${{ github.workflow }}\`
           - Run: \`${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\`
           - Merge policy: this PR is merged only after the release package is built and uploaded successfully.

--- a/config/electron/electron-builder.config.js
+++ b/config/electron/electron-builder.config.js
@@ -40,7 +40,7 @@ const modeMap = {
       comfySourceFile('advanced'),
       comfySourceFile('update')
     ],
-    winTarget: ['dir', 'zip'], // NSIS 不适合大包（python_embeded 文件过多）
+    winTarget: ['dir', '7z'],
     nsis: {
       oneClick: false, // 允许选择安装目录 (对于大包建议 false)
       allowToChangeInstallationDirectory: true,
@@ -108,7 +108,18 @@ const config = {
     buildResources: buildResourcesDir,
     output: modeConfig.distDir
   },
-  files: ['out', 'README.md', 'LICENSE'],
+  files: [
+    'out',
+    'README.md',
+    'LICENSE',
+    '!**/*.map',
+    '!**/demo/**',
+    '!**/demos/**',
+    '!**/example/**',
+    '!**/examples/**',
+    '!**/test/**',
+    '!**/tests/**'
+  ],
   extraFiles: bundledContentExtraFiles,
   asar: true,
   asarUnpack: ['**/*.safetensors', '**/*.ckpt', '**/*.pt', '**/*.pth', '**/models/**/*'],

--- a/config/electron/electron.vite.config.ts
+++ b/config/electron/electron.vite.config.ts
@@ -57,7 +57,7 @@ export default defineConfig({
     publicDir: resolve('packages/app/src/renderer/public'),
     server: {
       port: 5173,
-      strictPort: true,
+      strictPort: false,
       watch: {
         ignored: generatedRuntimeWatchIgnores
       }

--- a/package.json
+++ b/package.json
@@ -4,13 +4,13 @@
   "description": "An Electron application with React and TypeScript",
   "main": "./out/main/index.js",
   "author": "example.com",
-  "homepage": "https://github.com/MagicPotTeam/MagicPot",
+  "homepage": "https://github.com/MagicPotTeam/magicpot-open",
   "repository": {
     "type": "git",
-    "url": "https://github.com/MagicPotTeam/MagicPot.git"
+    "url": "https://github.com/MagicPotTeam/magicpot-open.git"
   },
   "bugs": {
-    "url": "https://github.com/MagicPotTeam/MagicPot/issues"
+    "url": "https://github.com/MagicPotTeam/magicpot-open/issues"
   },
   "license": "AGPL-3.0-only",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiengineelectron",
-  "version": "1.0.105",
+  "version": "1.0.106",
   "description": "An Electron application with React and TypeScript",
   "main": "./out/main/index.js",
   "author": "example.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiengineelectron",
-  "version": "1.0.108",
+  "version": "1.0.105",
   "description": "An Electron application with React and TypeScript",
   "main": "./out/main/index.js",
   "author": "example.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiengineelectron",
-  "version": "1.0.106",
+  "version": "1.0.107",
   "description": "An Electron application with React and TypeScript",
   "main": "./out/main/index.js",
   "author": "example.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiengineelectron",
-  "version": "1.0.107",
+  "version": "1.0.108",
   "description": "An Electron application with React and TypeScript",
   "main": "./out/main/index.js",
   "author": "example.com",

--- a/packages/app/src/main/api/svcLLMProxyImpl.test.ts
+++ b/packages/app/src/main/api/svcLLMProxyImpl.test.ts
@@ -1861,7 +1861,7 @@ describe('LLMProxySvcImpl', () => {
     )
   })
 
-  it('throws when neither Tencent API region nor COS region is configured', async () => {
+  it('uses ap-guangzhou when neither Tencent API region nor COS region is configured', async () => {
     generateFromMessagesMock.mockResolvedValue('[Generated 3D Model](https://example.com/cup.glb)')
 
     mockConfig({
@@ -1875,17 +1875,21 @@ describe('LLMProxySvcImpl', () => {
     })
 
     const svc = new LLMProxySvcImpl()
-    await expect(
-      svc.chat({
-        profileId: 'hunyuan3d-pro::SubmitHunyuanTo3DRapidJob',
-        messages: [{ role: 'user', content: 'missing region' }]
-      })
-    ).rejects.toThrow('COS')
+    await svc.chat({
+      profileId: 'hunyuan3d-pro::SubmitHunyuanTo3DRapidJob',
+      messages: [{ role: 'user', content: 'missing region' }]
+    })
 
-    expect(Hunyuan3DClientMock).not.toHaveBeenCalled()
+    expect(Hunyuan3DClientMock).toHaveBeenCalledWith(
+      '',
+      '',
+      'secret-id',
+      'secret-key',
+      'ap-guangzhou'
+    )
   })
 
-  it('falls back to the COS region when a dedicated Tencent API region is not configured', async () => {
+  it('does not reuse the COS region when a dedicated Tencent API region is not configured', async () => {
     generateFromMessagesMock.mockResolvedValue('[Generated 3D Model](https://example.com/cup.glb)')
 
     mockConfig({
@@ -1901,7 +1905,7 @@ describe('LLMProxySvcImpl', () => {
     const svc = new LLMProxySvcImpl()
     await svc.chat({
       profileId: 'hunyuan3d-pro::SubmitHunyuanTo3DRapidJob',
-      messages: [{ role: 'user', content: 'fallback to cos region' }]
+      messages: [{ role: 'user', content: 'default api region' }]
     })
 
     expect(Hunyuan3DClientMock).toHaveBeenCalledWith(
@@ -1909,7 +1913,7 @@ describe('LLMProxySvcImpl', () => {
       '',
       'secret-id',
       'secret-key',
-      'ap-singapore'
+      'ap-guangzhou'
     )
   })
 
@@ -1948,7 +1952,7 @@ describe('LLMProxySvcImpl', () => {
       'https://proxy.example',
       '',
       '',
-      ''
+      'ap-guangzhou'
     )
     expect(generateFromMessagesMock).toHaveBeenCalledWith(
       [{ role: 'user', content: 'api token pro path' }],
@@ -2031,7 +2035,7 @@ describe('LLMProxySvcImpl', () => {
       'https://proxy.example/v1',
       '',
       '',
-      ''
+      'ap-guangzhou'
     )
 
     const [submitUrl, submitInit] = fetchMock.mock.calls[0]

--- a/packages/app/src/main/api/svcLLMProxyImpl.ts
+++ b/packages/app/src/main/api/svcLLMProxyImpl.ts
@@ -78,6 +78,8 @@ const decodeHy3dProfileSegment = (value?: string): string => {
 const isMockFetchFunction = (value: unknown): value is FetchImpl =>
   typeof value === 'function' && 'mock' in (value as unknown as { mock?: unknown })
 
+const DEFAULT_HY3D_API_REGION = 'ap-guangzhou'
+
 const applySkillRuntimeContextMessageLimit = (req: LLMChatReq): LLMChatReq => {
   if (!req.skillRuntime) {
     return req
@@ -952,9 +954,7 @@ export class LLMProxySvcImpl implements LLMProxySvc {
   }
 
   private getHunyuan3DApiRegion(config: Config): string {
-    return (
-      config.aigc3d_config?.api_region?.trim() || config.aigc3d_config?.cos_region?.trim() || ''
-    )
+    return config.aigc3d_config?.api_region?.trim() || DEFAULT_HY3D_API_REGION
   }
 
   private async buildBigModelOcrFilePayload(attachment: ChatAttachment): Promise<string> {

--- a/packages/app/src/renderer/src/components/Layout.test.ts
+++ b/packages/app/src/renderer/src/components/Layout.test.ts
@@ -4,6 +4,7 @@ import {
   clampSidePanelWidth,
   resolveTabIdForCurrentRoute,
   resolveStartupRouteTarget,
+  resolveHashRoutePath,
   SIDE_PANEL_DEFAULT_WIDTH,
   shouldPersistCurrentRoute,
   shouldAutoCloseProjectSidePanel
@@ -99,6 +100,15 @@ describe('Layout route sync helpers', () => {
       shouldPersistCurrentRoute('/canvas?id=tab-project-42', '/canvas?id=tab-project-42')
     ).toBe(true)
     expect(shouldPersistCurrentRoute(null, '/settings')).toBe(true)
+  })
+
+  it('normalizes the browser hash route used to catch stale HashRouter locations', () => {
+    expect(resolveHashRoutePath('')).toBe('/')
+    expect(resolveHashRoutePath('#/settings')).toBe('/settings')
+    expect(resolveHashRoutePath('#qappdesign')).toBe('/qappdesign')
+    expect(resolveHashRoutePath('#/project-webgl?id=tab-project-42')).toBe(
+      '/canvas?id=tab-project-42'
+    )
   })
 
   it('auto-closes the quick app side panel only when first entering a project tab', () => {

--- a/packages/app/src/renderer/src/components/Layout.tsx
+++ b/packages/app/src/renderer/src/components/Layout.tsx
@@ -36,6 +36,7 @@ const SIDE_PANEL_MAX_WIDTH = 840
 const RIGHT_PANEL_MIN_WIDTH = 360
 const RIGHT_PANEL_MAX_WIDTH = 1024
 const BOTTOM_PANEL_DEFAULT_HEIGHT = 220
+const ROUTE_TAB_SYNC_DELAY_MS = 50
 
 export const clampSidePanelWidth = (currentWidth: number, delta: number): number =>
   Math.max(SIDE_PANEL_MIN_WIDTH, Math.min(SIDE_PANEL_MAX_WIDTH, currentWidth + delta))
@@ -108,6 +109,15 @@ export const shouldPersistCurrentRoute = (
   }
 
   return normalizeProjectCanvasRoutePath(currentRoute) === pendingStartupRoutePath
+}
+
+export const resolveHashRoutePath = (hash: string): string => {
+  const routePath = hash.replace(/^#/, '').trim()
+  if (!routePath) {
+    return '/'
+  }
+
+  return normalizeProjectCanvasRoutePath(routePath.startsWith('/') ? routePath : `/${routePath}`)
 }
 
 type ResizeDirection = 'side' | 'bottom' | 'right' | null
@@ -206,16 +216,28 @@ const Layout: React.FC = () => {
       return
     }
 
-    const routeTabId = resolveTabIdForCurrentRoute(
-      currentRoute,
-      location.pathname,
-      location.search,
-      openTabs
-    )
-    if (routeTabId && routeTabId !== activeTabId) {
-      dispatch(setActiveTab(routeTabId))
+    const syncTimerId = window.setTimeout(() => {
+      const hashRoutePath = resolveHashRoutePath(window.location.hash)
+      if (hashRoutePath && hashRoutePath !== currentRoute) {
+        navigate(hashRoutePath, { replace: true })
+        return
+      }
+
+      const routeTabId = resolveTabIdForCurrentRoute(
+        currentRoute,
+        location.pathname,
+        location.search,
+        openTabs
+      )
+      if (routeTabId && routeTabId !== activeTabId) {
+        dispatch(setActiveTab(routeTabId))
+      }
+    }, ROUTE_TAB_SYNC_DELAY_MS)
+
+    return () => {
+      window.clearTimeout(syncTimerId)
     }
-  }, [activeTabId, currentRoute, dispatch, location.pathname, location.search, openTabs])
+  }, [activeTabId, currentRoute, dispatch, location.pathname, location.search, navigate, openTabs])
 
   useEffect(() => {
     const timer = window.setTimeout(() => {

--- a/packages/app/src/renderer/src/components/inputs/InputText.tsx
+++ b/packages/app/src/renderer/src/components/inputs/InputText.tsx
@@ -6,6 +6,7 @@ type InputTextProps = InputProps<string> & {
   placeholder: string
   errorText?: string
   shrinkLabel?: boolean
+  updateMode?: 'blur' | 'change'
 }
 
 const InputText: React.FC<InputTextProps> = ({
@@ -15,7 +16,8 @@ const InputText: React.FC<InputTextProps> = ({
   placeholder,
   Icon,
   errorText,
-  shrinkLabel
+  shrinkLabel,
+  updateMode
 }) => {
   return (
     <BaseInputTextField
@@ -29,6 +31,7 @@ const InputText: React.FC<InputTextProps> = ({
       placeholder={placeholder}
       Icon={Icon}
       shrinkLabel={shrinkLabel}
+      updateMode={updateMode}
     />
   )
 }

--- a/packages/app/src/renderer/src/pages/ChatPage/components/ChatComposer.test.tsx
+++ b/packages/app/src/renderer/src/pages/ChatPage/components/ChatComposer.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, within } from '@testing-library/react'
+import { act, fireEvent, render, screen, within } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import { ThemeProvider } from '@mui/material'
 import { theme } from '@renderer/theme'
@@ -347,6 +347,29 @@ describe('ChatComposer', () => {
     expect(textarea).toHaveValue('hello Xworld')
     expect(textarea.selectionStart).toBe(7)
     expect(textarea.selectionEnd).toBe(7)
+  })
+
+  it('infers the middle insertion caret when selection events are stale', () => {
+    render(<ControlledChatComposer initialValue={'line 1\nline 2\nline 3'} />)
+
+    const textarea = screen.getByTestId('chat-composer-input') as HTMLTextAreaElement
+    act(() => {
+      textarea.focus()
+    })
+    textarea.setSelectionRange(7, 7)
+
+    fireEvent.change(textarea, {
+      target: {
+        value: 'line 1\nXline 2\nline 3',
+        selectionStart: 21,
+        selectionEnd: 21,
+        selectionDirection: 'none'
+      }
+    })
+
+    expect(textarea).toHaveValue('line 1\nXline 2\nline 3')
+    expect(textarea.selectionStart).toBe(8)
+    expect(textarea.selectionEnd).toBe(8)
   })
 
   it('keeps the middle caret through parent rerenders before typing', () => {

--- a/packages/app/src/renderer/src/pages/ChatPage/components/ChatComposer.tsx
+++ b/packages/app/src/renderer/src/pages/ChatPage/components/ChatComposer.tsx
@@ -121,41 +121,77 @@ const readInputSelectionSnapshot = (
   }
 }
 
-const inferSelectionAfterControlledInputChange = (
+const inferSelectionFromValueDiff = (
   previousValue: string,
-  previousSelection: InputSelectionSnapshot | null,
-  nextValue: string,
-  rawSelection: InputSelectionSnapshot
-): InputSelectionSnapshot => {
-  if (!previousSelection || previousSelection.value !== previousValue) {
-    return rawSelection
+  nextValue: string
+): InputSelectionSnapshot | null => {
+  if (previousValue === nextValue) {
+    return null
   }
 
-  const rawSelectionAtEnd =
-    rawSelection.start === nextValue.length && rawSelection.end === nextValue.length
-  const previousSelectionWasInsideText = previousSelection.start < previousValue.length
-  if (!rawSelectionAtEnd || !previousSelectionWasInsideText) {
-    return rawSelection
+  let prefixLength = 0
+  while (
+    prefixLength < previousValue.length &&
+    prefixLength < nextValue.length &&
+    previousValue[prefixLength] === nextValue[prefixLength]
+  ) {
+    prefixLength += 1
   }
 
-  const prefix = previousValue.slice(0, previousSelection.start)
-  const suffix = previousValue.slice(previousSelection.end)
-  if (!nextValue.startsWith(prefix) || !nextValue.endsWith(suffix)) {
-    return rawSelection
+  let previousSuffixIndex = previousValue.length
+  let nextSuffixIndex = nextValue.length
+  while (
+    previousSuffixIndex > prefixLength &&
+    nextSuffixIndex > prefixLength &&
+    previousValue[previousSuffixIndex - 1] === nextValue[nextSuffixIndex - 1]
+  ) {
+    previousSuffixIndex -= 1
+    nextSuffixIndex -= 1
   }
 
-  const insertedLength = nextValue.length - prefix.length - suffix.length
-  if (insertedLength < 0) {
-    return rawSelection
-  }
-
-  const inferredPosition = prefix.length + insertedLength
+  const insertedLength = Math.max(0, nextSuffixIndex - prefixLength)
+  const inferredPosition = prefixLength + insertedLength
   return {
     value: nextValue,
     start: inferredPosition,
     end: inferredPosition,
     direction: 'none'
   }
+}
+
+const inferSelectionAfterControlledInputChange = (
+  previousValue: string,
+  previousSelection: InputSelectionSnapshot | null,
+  nextValue: string,
+  rawSelection: InputSelectionSnapshot
+): InputSelectionSnapshot => {
+  const rawSelectionAtEnd =
+    rawSelection.start === nextValue.length && rawSelection.end === nextValue.length
+  if (!rawSelectionAtEnd || previousValue === nextValue) {
+    return rawSelection
+  }
+
+  if (
+    previousSelection?.value === previousValue &&
+    previousSelection.start < previousValue.length
+  ) {
+    const prefix = previousValue.slice(0, previousSelection.start)
+    const suffix = previousValue.slice(previousSelection.end)
+    if (nextValue.startsWith(prefix) && nextValue.endsWith(suffix)) {
+      const insertedLength = nextValue.length - prefix.length - suffix.length
+      if (insertedLength >= 0) {
+        const inferredPosition = prefix.length + insertedLength
+        return {
+          value: nextValue,
+          start: inferredPosition,
+          end: inferredPosition,
+          direction: 'none'
+        }
+      }
+    }
+  }
+
+  return inferSelectionFromValueDiff(previousValue, nextValue) ?? rawSelection
 }
 
 const buildToolCommandDraft = (tool: MagicPotAppToolDescriptor): string =>
@@ -221,6 +257,7 @@ const ChatComposer: React.FC<ChatComposerProps> = ({
   const isComposingInputRef = useRef(false)
   const latestInputSelectionRef = useRef<InputSelectionSnapshot | null>(null)
   const pendingInputSelectionRef = useRef<InputSelectionSnapshot | null>(null)
+  const beforeInputSelectionRef = useRef<InputSelectionSnapshot | null>(null)
   const [addMenuAnchorEl, setAddMenuAnchorEl] = useState<HTMLElement | null>(null)
   const [textareaMaxHeight, setTextareaMaxHeight] = useState<number | undefined>(undefined)
   const [attachmentPreviewMaxHeight, setAttachmentPreviewMaxHeight] = useState<number | undefined>(
@@ -283,23 +320,45 @@ const ChatComposer: React.FC<ChatComposerProps> = ({
     recalcMaxHeight()
   }, [visiblePendingAttachmentEntries.length, recalcMaxHeight])
 
+  const restoreInputSelection = useCallback(
+    (selection: InputSelectionSnapshot) => {
+      const input = composerInputRef.current
+      if (!input || document.activeElement !== input || input.value !== selection.value)
+        return false
+
+      const maxPosition = input.value.length
+      const nextSelection = {
+        ...selection,
+        start: Math.min(selection.start, maxPosition),
+        end: Math.min(selection.end, maxPosition)
+      }
+
+      input.setSelectionRange(nextSelection.start, nextSelection.end, nextSelection.direction)
+      latestInputSelectionRef.current = nextSelection
+      return true
+    },
+    [composerInputRef]
+  )
+
   useLayoutEffect(() => {
     const pendingSelection = pendingInputSelectionRef.current
     const selection = pendingSelection ?? latestInputSelectionRef.current
     if (!selection) return
 
-    const input = composerInputRef.current
     pendingInputSelectionRef.current = null
+    const input = composerInputRef.current
     if (!input || document.activeElement !== input) return
     if (!pendingSelection && (isComposingInputRef.current || input.value !== selection.value))
       return
 
-    const maxPosition = input.value.length
-    input.setSelectionRange(
-      Math.min(selection.start, maxPosition),
-      Math.min(selection.end, maxPosition),
-      selection.direction
-    )
+    restoreInputSelection(selection)
+    if (!pendingSelection || typeof window.requestAnimationFrame !== 'function') return
+
+    const frameId = window.requestAnimationFrame(() => {
+      restoreInputSelection(selection)
+    })
+
+    return () => window.cancelAnimationFrame(frameId)
   })
 
   const handleInputSelectionChange = (
@@ -308,12 +367,21 @@ const ChatComposer: React.FC<ChatComposerProps> = ({
     latestInputSelectionRef.current = readInputSelectionSnapshot(event.currentTarget)
   }
 
+  const handleBeforeInput = (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    beforeInputSelectionRef.current = readInputSelectionSnapshot(event.currentTarget)
+  }
+
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const previousValue = committedInputValueRef.current
     const nextValue = event.target.value
+    const selectionBeforeInput =
+      beforeInputSelectionRef.current?.value === previousValue
+        ? beforeInputSelectionRef.current
+        : null
+    beforeInputSelectionRef.current = null
     const nextSelection = inferSelectionAfterControlledInputChange(
       previousValue,
-      latestInputSelectionRef.current,
+      selectionBeforeInput ?? latestInputSelectionRef.current,
       nextValue,
       readInputSelectionSnapshot(event.target)
     )
@@ -682,8 +750,10 @@ const ChatComposer: React.FC<ChatComposerProps> = ({
               inputProps={{
                 'data-testid': 'chat-composer-input',
                 onFocus: handleInputSelectionChange,
+                onBeforeInput: handleBeforeInput,
                 onKeyUp: handleInputSelectionChange,
                 onMouseUp: handleInputSelectionChange,
+                onClick: handleInputSelectionChange,
                 onSelect: handleInputSelectionChange,
                 onCompositionStart: handleCompositionStart,
                 onCompositionEnd: handleCompositionEnd,

--- a/packages/app/src/renderer/src/pages/ChatPage/components/ChatMessageList.test.tsx
+++ b/packages/app/src/renderer/src/pages/ChatPage/components/ChatMessageList.test.tsx
@@ -699,3 +699,26 @@ describe('ChatMessageList text selection and reply actions', () => {
     })
   })
 })
+
+describe('ChatMessageList layout', () => {
+  it('allows long replies to scroll instead of pushing the composer out', () => {
+    renderChatMessageList({
+      id: 'session-long-reply',
+      title: 'Long reply',
+      messages: [
+        {
+          role: 'assistant',
+          content: Array.from({ length: 60 }, (_, index) => `${index + 1}. long reply line`).join(
+            '\n'
+          )
+        }
+      ]
+    })
+
+    expect(screen.getByTestId('chat-message-list')).toHaveStyle({
+      flex: '1',
+      minHeight: '0',
+      overflow: 'auto'
+    })
+  })
+})

--- a/packages/app/src/renderer/src/pages/ChatPage/components/ChatMessageList.test.tsx
+++ b/packages/app/src/renderer/src/pages/ChatPage/components/ChatMessageList.test.tsx
@@ -29,6 +29,9 @@ const buildChatMessageList = (
   options?: {
     active?: boolean
     isLoading?: boolean
+    editingMessageIndex?: number | null
+    editingContent?: string
+    onSendEditedMessage?: ReturnType<typeof vi.fn>
     onDownloadAttachment?: ReturnType<typeof vi.fn>
   }
 ) => (
@@ -37,11 +40,11 @@ const buildChatMessageList = (
       active={options?.active}
       currentSession={currentSession}
       isLoading={options?.isLoading ?? false}
-      editingMessageIndex={null}
-      editingContent=""
+      editingMessageIndex={options?.editingMessageIndex ?? null}
+      editingContent={options?.editingContent ?? ''}
       onSetEditingIndex={vi.fn()}
       onSetEditingContent={vi.fn()}
-      onSendEditedMessage={vi.fn()}
+      onSendEditedMessage={options?.onSendEditedMessage ?? vi.fn()}
       onPreviewImage={vi.fn()}
       onImageContextMenu={vi.fn()}
       onDownloadAttachment={options?.onDownloadAttachment ?? vi.fn()}
@@ -57,6 +60,9 @@ const renderChatMessageList = (
   options?: {
     active?: boolean
     isLoading?: boolean
+    editingMessageIndex?: number | null
+    editingContent?: string
+    onSendEditedMessage?: ReturnType<typeof vi.fn>
     onDownloadAttachment?: ReturnType<typeof vi.fn>
   }
 ) => render(buildChatMessageList(currentSession, options))
@@ -171,6 +177,49 @@ describe('ChatMessageList text selection and reply actions', () => {
 
     expect(writeTextMock).toHaveBeenCalledWith('Copy this reply.')
     expect(notifySuccessMock).toHaveBeenCalledWith('\u56de\u7b54\u5df2\u590d\u5236')
+  })
+
+  it('allows resubmitting an edited user message without changing its text', () => {
+    const onSendEditedMessage = vi.fn()
+    const attachment: ChatAttachment = {
+      type: 'image',
+      url: 'local-media:///demo/reference.png',
+      fileName: 'reference.png'
+    }
+    const session: ChatSession = {
+      id: 'session-resubmit-unchanged-edit',
+      title: 'Resubmit unchanged edit',
+      messages: [
+        {
+          role: 'user',
+          content: 'Try the same prompt again.',
+          attachments: [attachment],
+          hiddenContext: 'canvas context'
+        },
+        {
+          role: 'assistant',
+          content: 'First reply.'
+        }
+      ]
+    }
+
+    renderChatMessageList(session, {
+      editingMessageIndex: 0,
+      editingContent: 'Try the same prompt again.',
+      onSendEditedMessage
+    })
+
+    const submitButton = screen.getByRole('button', { name: '提交' })
+    expect(submitButton).not.toBeDisabled()
+
+    fireEvent.click(submitButton)
+
+    expect(onSendEditedMessage).toHaveBeenCalledWith(
+      'Try the same prompt again.',
+      [attachment],
+      'canvas context',
+      []
+    )
   })
 
   it('downloads assistant replies from the icon menu using the previous user context', () => {

--- a/packages/app/src/renderer/src/pages/ChatPage/components/ChatMessageList.tsx
+++ b/packages/app/src/renderer/src/pages/ChatPage/components/ChatMessageList.tsx
@@ -646,7 +646,7 @@ const UserMessageEditForm: React.FC<{
           <Button
             variant="contained"
             size="small"
-            disabled={!editingContent.trim() || editingContent.trim() === message.content}
+            disabled={!editingContent.trim()}
             onClick={() => {
               const newContent = editingContent.trim()
               if (!newContent) return

--- a/packages/app/src/renderer/src/pages/ChatPage/components/ChatMessageList.tsx
+++ b/packages/app/src/renderer/src/pages/ChatPage/components/ChatMessageList.tsx
@@ -129,8 +129,10 @@ const ChatMessageList: React.FC<ChatMessageListProps> = ({
   return (
     <Box
       ref={chatContainerRef}
+      data-testid="chat-message-list"
       sx={{
         flex: 1,
+        minHeight: 0,
         overflow: 'auto',
         overflowX: 'hidden',
         display: 'flex',

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/Canvas3DStage.cameraSync.test.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/Canvas3DStage.cameraSync.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it } from 'vitest'
 import * as THREE from 'three'
 
-import { resolveCanvas3DStageModelVisualMode, syncCanvas3DStageCamera } from './Canvas3DStage'
+import {
+  resolveCanvas3DStageModelVisualMode,
+  resolveCanvas3DStageViewportSummary,
+  syncCanvas3DStageCamera
+} from './Canvas3DStage'
 import { PROJECT_CANVAS_MIN_STAGE_SCALE } from '../projectCanvasViewportScale'
+import type { CanvasModel3DItem } from '../types'
 
 describe('syncCanvas3DStageCamera', () => {
   it('updates orthographic stage cameras using the current viewport transform', () => {
@@ -76,5 +81,44 @@ describe('syncCanvas3DStageCamera', () => {
         hasPreviewTexture: true
       })
     ).toBe('live-model')
+  })
+
+  it('keeps model items renderable during imperative viewport scrolls', () => {
+    const offscreenModel: CanvasModel3DItem = {
+      id: 'model-offscreen',
+      type: 'model3d',
+      src: 'model.glb',
+      fileName: 'model.glb',
+      x: 4000,
+      y: 3000,
+      width: 240,
+      height: 240,
+      rotation: 0,
+      scaleX: 1,
+      scaleY: 1,
+      zIndex: 1,
+      locked: false
+    }
+
+    expect(
+      resolveCanvas3DStageViewportSummary({
+        items: [offscreenModel],
+        selectedIds: new Set(),
+        stagePos: { x: 0, y: 0 },
+        stageScale: 1,
+        stageSize: { width: 800, height: 600 }
+      }).visibleItemIds.has(offscreenModel.id)
+    ).toBe(false)
+
+    expect(
+      resolveCanvas3DStageViewportSummary({
+        items: [offscreenModel],
+        selectedIds: new Set(),
+        stagePos: { x: 0, y: 0 },
+        stageScale: 1,
+        stageSize: { width: 800, height: 600 },
+        skipViewportCulling: true
+      }).visibleItemIds.has(offscreenModel.id)
+    ).toBe(true)
   })
 })

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/Canvas3DStage.renderer.test.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/Canvas3DStage.renderer.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { configureCanvas3DStageRenderer } from './Canvas3DStage'
+import { CANVAS_3D_STAGE_GL_OPTIONS, configureCanvas3DStageRenderer } from './Canvas3DStage'
 
 describe('configureCanvas3DStageRenderer', () => {
   it('forces transparent clears for the 3D stage renderer', () => {
@@ -13,5 +13,9 @@ describe('configureCanvas3DStageRenderer', () => {
 
     expect(gl.autoClear).toBe(true)
     expect(gl.setClearColor).toHaveBeenCalledWith(0x000000, 0)
+  })
+
+  it('uses the live WebGL canvas path during viewport scroll', () => {
+    expect(CANVAS_3D_STAGE_GL_OPTIONS.preserveDrawingBuffer).toBe(false)
   })
 })

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/Canvas3DStage.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/Canvas3DStage.tsx
@@ -81,7 +81,16 @@ const UNIT_BOX_EDGES_GEOMETRY = new THREE.EdgesGeometry(UNIT_BOX_GEOMETRY)
 const UNIT_PLANE_GEOMETRY = new THREE.PlaneGeometry(1, 1)
 
 const CANVAS_3D_STAGE_VISIBLE_OVERSCAN_PX = 240
-const ENABLE_CANVAS_3D_STAGE_VIEWPORT_FREEZE = true
+const ENABLE_CANVAS_3D_STAGE_VIEWPORT_FREEZE = false
+const FREEZE_FRAME_CONTENT_SAMPLE_SIZE = 96
+
+export const CANVAS_3D_STAGE_GL_OPTIONS = {
+  alpha: true,
+  antialias: false,
+  powerPreference: 'high-performance',
+  preserveDrawingBuffer: false,
+  stencil: false
+} as const
 
 type Canvas3DStageViewportSummary = {
   visibleItemIds: Set<string>
@@ -106,13 +115,14 @@ type Canvas3DStageFreezeFrameTransform = {
   transform: string
 }
 
-const resolveCanvas3DStageViewportSummary = ({
+export const resolveCanvas3DStageViewportSummary = ({
   items,
   selectedIds,
   stagePos,
   stageScale,
   stageSize,
-  overscanPx = CANVAS_3D_STAGE_VISIBLE_OVERSCAN_PX
+  overscanPx = CANVAS_3D_STAGE_VISIBLE_OVERSCAN_PX,
+  skipViewportCulling = false
 }: {
   items: CanvasModel3DItem[]
   selectedIds: ReadonlySet<string>
@@ -120,8 +130,9 @@ const resolveCanvas3DStageViewportSummary = ({
   stageScale: number
   stageSize: { width: number; height: number }
   overscanPx?: number
+  skipViewportCulling?: boolean
 }): Canvas3DStageViewportSummary => {
-  if (items.length === 0 || stageSize.width <= 0 || stageSize.height <= 0) {
+  if (items.length === 0 || stageSize.width <= 0 || stageSize.height <= 0 || skipViewportCulling) {
     return {
       visibleItemIds: new Set(items.map((item) => item.id)),
       viewportCulledCount: 0
@@ -177,6 +188,46 @@ const createCanvas3DStageViewportState = ({
     height: stageSize.height
   }
 })
+
+const hasCanvas3DStageFreezeFrameContent = (
+  snapshotCanvas: HTMLCanvasElement,
+  snapshotContext: CanvasRenderingContext2D
+) => {
+  const width = snapshotCanvas.width
+  const height = snapshotCanvas.height
+  if (width <= 0 || height <= 0) {
+    return false
+  }
+
+  const sampleWidth = Math.max(1, Math.min(FREEZE_FRAME_CONTENT_SAMPLE_SIZE, width))
+  const sampleHeight = Math.max(1, Math.min(FREEZE_FRAME_CONTENT_SAMPLE_SIZE, height))
+  let sampleContext = snapshotContext
+
+  if (sampleWidth !== width || sampleHeight !== height) {
+    const sampleCanvas = document.createElement('canvas')
+    sampleCanvas.width = sampleWidth
+    sampleCanvas.height = sampleHeight
+    const nextSampleContext = sampleCanvas.getContext('2d')
+    if (!nextSampleContext) {
+      return true
+    }
+
+    nextSampleContext.drawImage(snapshotCanvas, 0, 0, sampleWidth, sampleHeight)
+    sampleContext = nextSampleContext
+  }
+
+  try {
+    const pixels = sampleContext.getImageData(0, 0, sampleWidth, sampleHeight).data
+    for (let alphaIndex = 3; alphaIndex < pixels.length; alphaIndex += 4) {
+      if (pixels[alphaIndex] > 0) {
+        return true
+      }
+    }
+    return false
+  } catch {
+    return true
+  }
+}
 
 export const resolveCanvas3DStageFreezeFrameTransform = ({
   snapshotViewport,
@@ -1278,9 +1329,10 @@ const Canvas3DStage: React.FC<Canvas3DStageProps> = ({
         selectedIds,
         stagePos,
         stageScale,
-        stageSize
+        stageSize,
+        skipViewportCulling: isViewportInteracting
       }),
-    [items, selectedIds, stagePos, stageScale, stageSize]
+    [isViewportInteracting, items, selectedIds, stagePos, stageScale, stageSize]
   )
   const viewportVisibleItems = useMemo(
     () => items.filter((item) => visibleItemIds.has(item.id)),
@@ -1458,6 +1510,10 @@ const Canvas3DStage: React.FC<Canvas3DStageProps> = ({
     try {
       context.clearRect(0, 0, snapshotCanvas.width, snapshotCanvas.height)
       context.drawImage(sourceCanvas, 0, 0)
+      if (!hasCanvas3DStageFreezeFrameContent(snapshotCanvas, context)) {
+        setFreezeFrameSnapshot(null)
+        return
+      }
       setFreezeFrameSnapshot({
         canvas: snapshotCanvas,
         viewport: createCanvas3DStageViewportState(nextViewport)
@@ -1607,13 +1663,7 @@ const Canvas3DStage: React.FC<Canvas3DStageProps> = ({
         orthographic
         frameloop={stageFrameloop}
         dpr={adaptiveDpr}
-        gl={{
-          alpha: true,
-          antialias: false,
-          powerPreference: 'high-performance',
-          preserveDrawingBuffer: false,
-          stencil: false
-        }}
+        gl={CANVAS_3D_STAGE_GL_OPTIONS}
         camera={{
           position: [0, 0, 1000],
           zoom: Math.max(stageScale, PROJECT_CANVAS_MIN_STAGE_SCALE),

--- a/packages/app/src/renderer/src/pages/SettingsPage/PanelAbout.tsx
+++ b/packages/app/src/renderer/src/pages/SettingsPage/PanelAbout.tsx
@@ -19,7 +19,7 @@ import ExternalLink from '@renderer/components/ExternalLInk'
 import { PACKAGE_VERSION } from '@shared/config/viteEnv'
 import { useTranslation } from 'react-i18next'
 
-const SOURCE_CODE_URL = 'https://github.com/MagicPotTeam/MagicPot'
+const SOURCE_CODE_URL = 'https://github.com/MagicPotTeam/magicpot-open'
 const LICENSE_URL = `${SOURCE_CODE_URL}/blob/master/LICENSE`
 
 const PanelAbout: React.FC<PanelProps> = ({ settingsValue, saveSettings }: PanelProps) => {

--- a/packages/app/src/renderer/src/pages/SettingsPage/PanelEnvironment.tsx
+++ b/packages/app/src/renderer/src/pages/SettingsPage/PanelEnvironment.tsx
@@ -8,7 +8,6 @@ import {
   MenuItem,
   Alert,
   AlertTitle,
-  Collapse,
   Divider,
   TextField
 } from '@mui/material'
@@ -19,7 +18,6 @@ import EnvironmentInfo from './components/EnvironmentInfo'
 import DataStorageInfo from './components/DataStorageInfo'
 import PureConfigNotSetCallout from '@renderer/components/PureConfigNotSetCallout'
 import InputPath from '@renderer/components/inputs/InputPath'
-import { TransitionGroup } from 'react-transition-group'
 import { ConfigUtils } from '@shared/config/configUtils'
 import {
   Config,
@@ -76,6 +74,8 @@ type ManagedCanvasSnapshot = {
   groupBranches: CanvasGroupBranch[]
   binding: CanvasFigmaBinding | null
 }
+
+const DEFERRED_ENVIRONMENT_RENDER_DELAY_MS = 80
 
 const createProxyAccessTokenId = (): string =>
   globalThis.crypto?.randomUUID?.() ||
@@ -392,8 +392,11 @@ const PanelEnvironment: React.FC<PanelProps> = ({ settingsValue, saveSettings }:
   // const { t } = useI18n()
   const { t, i18n } = useTranslation()
   const isChineseUi = i18n.language?.toLowerCase().startsWith('zh') ?? true
-  const text = (fallbackChinese: string, fallbackEnglish: string) =>
-    isChineseUi ? fallbackChinese : fallbackEnglish
+  const text = useCallback(
+    (fallbackChinese: string, fallbackEnglish: string) =>
+      isChineseUi ? fallbackChinese : fallbackEnglish,
+    [isChineseUi]
+  )
 
   const configUtils = new ConfigUtils(settingsValue, buildEnv, window.path)
   const appRootDir = buildEnv.pathMap.file
@@ -427,6 +430,7 @@ const PanelEnvironment: React.FC<PanelProps> = ({ settingsValue, saveSettings }:
   const [figmaBindingError, setFigmaBindingError] = useState<string | null>(null)
   const lastActiveProjectId = useAppSelector((state) => state.layout.lastActiveProjectId)
   const openTabs = useAppSelector((state) => state.layout.openTabs)
+  const [renderDeferredSections, setRenderDeferredSections] = useState(false)
   const [proxyUsageState, setProxyUsageState] = useState<{
     running: boolean
     port?: number
@@ -473,8 +477,19 @@ const PanelEnvironment: React.FC<PanelProps> = ({ settingsValue, saveSettings }:
   )
 
   useEffect(() => {
+    const timerId = window.setTimeout(
+      () => setRenderDeferredSections(true),
+      DEFERRED_ENVIRONMENT_RENDER_DELAY_MS
+    )
+
+    return () => window.clearTimeout(timerId)
+  }, [])
+
+  useEffect(() => {
+    if (!renderDeferredSections) return
+
     void refreshProxyUsage(true)
-  }, [refreshProxyUsage, settingsValue.local_llm_server_config])
+  }, [refreshProxyUsage, renderDeferredSections, settingsValue.local_llm_server_config])
 
   const persistManagedCanvasSnapshot = useCallback(async (snapshot: ManagedCanvasSnapshot) => {
     await saveCanvasItems(
@@ -529,7 +544,7 @@ const PanelEnvironment: React.FC<PanelProps> = ({ settingsValue, saveSettings }:
   useEffect(() => {
     let cancelled = false
 
-    if (!lastActiveProjectId) {
+    if (!renderDeferredSections || !lastActiveProjectId) {
       setManagedCanvasSnapshot(null)
       return () => {
         cancelled = true
@@ -564,7 +579,7 @@ const PanelEnvironment: React.FC<PanelProps> = ({ settingsValue, saveSettings }:
     return () => {
       cancelled = true
     }
-  }, [lastActiveProjectId, managedCanvasLabel])
+  }, [lastActiveProjectId, managedCanvasLabel, renderDeferredSections])
 
   useEffect(() => {
     setFigmaBindingDraft(
@@ -1011,8 +1026,8 @@ const PanelEnvironment: React.FC<PanelProps> = ({ settingsValue, saveSettings }:
 
   return (
     <Box sx={{ p: 3 }}>
-      <TransitionGroup>
-        <Collapse key="comfy_mode">
+      <>
+        <Box key="comfy_mode">
           <SettingSection title={t('environment.comfy_mode_title')}>
             <Alert severity="info">
               <AlertTitle>{t('environment.comfy_mode_info_title')}</AlertTitle>
@@ -1026,10 +1041,10 @@ const PanelEnvironment: React.FC<PanelProps> = ({ settingsValue, saveSettings }:
               onChange={(value) => saveSettings({ use_remote_comfyui: value })}
             />
           </SettingSection>
-        </Collapse>
+        </Box>
 
         {settingsValue.use_remote_comfyui && (
-          <Collapse key="remote_comfyui">
+          <Box key="remote_comfyui">
             <SettingSection title={t('environment.remote_comfyui_title')}>
               <InputText
                 label={t('environment.remote_comfyui_origin_label')}
@@ -1055,649 +1070,666 @@ const PanelEnvironment: React.FC<PanelProps> = ({ settingsValue, saveSettings }:
                 placeholder={t('environment.placeholder_remote_comfyui_mapping_dir')}
               />
             </SettingSection>
-          </Collapse>
+          </Box>
         )}
 
-        <Collapse key="proxy_mode">
+        <Box key="proxy_mode">
           <ProxyModeSection
             saveSettings={saveSettings}
             settingsValue={settingsValue}
             t={t}
             text={text}
           />
-        </Collapse>
+        </Box>
 
-        <Collapse key="proxy_usage">
-          <SettingSection
-            title={text('代理使用情况', 'Proxy Usage')}
-            action={
-              <Button
-                size="small"
-                variant="outlined"
-                startIcon={<RefreshIcon />}
-                onClick={() => void refreshProxyUsage()}
-                disabled={proxyUsageLoading}
+        {renderDeferredSections && (
+          <>
+            <Box key="proxy_usage">
+              <SettingSection
+                title={text('代理使用情况', 'Proxy Usage')}
+                action={
+                  <Button
+                    size="small"
+                    variant="outlined"
+                    startIcon={<RefreshIcon />}
+                    onClick={() => void refreshProxyUsage()}
+                    disabled={proxyUsageLoading}
+                  >
+                    {text('刷新统计', 'Refresh Stats')}
+                  </Button>
+                }
               >
-                {text('刷新统计', 'Refresh Stats')}
-              </Button>
-            }
-          >
-            <Stack spacing={1.5}>
-              <Alert severity={proxyUsageState.running ? 'info' : 'warning'}>
-                <Typography variant="body2">
-                  {proxyUsageState.running
-                    ? text(
-                        `当前已启用本次运行统计，端口 ${proxyUsageState.port || 3721}`,
-                        `Live session stats are available on port ${proxyUsageState.port || 3721}`
-                      )
-                    : text(
-                        '代理服务当前未运行，因此这里只显示已持久化的资源统计。',
-                        'The proxy server is not running, so only persisted resource stats are shown.'
-                      )}
-                </Typography>
-              </Alert>
-
-              {localProxyAccessTokens.length > 0 ? (
                 <Stack spacing={1.5}>
-                  {localProxyAccessTokens.map((entry, index) => {
-                    const usageEntry = proxyUsageByTokenId.get(entry.id)
-                    const displayLabel = getDisplayProxyAccessTokenLabel(entry, index, text)
-                    return (
-                      <Box
-                        key={`usage-${entry.id}`}
-                        sx={{
-                          border: '1px solid',
-                          borderColor: 'divider',
-                          borderRadius: 2,
-                          p: 1.5
-                        }}
-                      >
-                        <Stack spacing={1}>
-                          <Typography variant="subtitle2">{displayLabel || entry.id}</Typography>
+                  <Alert severity={proxyUsageState.running ? 'info' : 'warning'}>
+                    <Typography variant="body2">
+                      {proxyUsageState.running
+                        ? text(
+                            `当前已启用本次运行统计，端口 ${proxyUsageState.port || 3721}`,
+                            `Live session stats are available on port ${proxyUsageState.port || 3721}`
+                          )
+                        : text(
+                            '代理服务当前未运行，因此这里只显示已持久化的资源统计。',
+                            'The proxy server is not running, so only persisted resource stats are shown.'
+                          )}
+                    </Typography>
+                  </Alert>
+
+                  {localProxyAccessTokens.length > 0 ? (
+                    <Stack spacing={1.5}>
+                      {localProxyAccessTokens.map((entry, index) => {
+                        const usageEntry = proxyUsageByTokenId.get(entry.id)
+                        const displayLabel = getDisplayProxyAccessTokenLabel(entry, index, text)
+                        return (
                           <Box
+                            key={`usage-${entry.id}`}
                             sx={{
-                              display: 'grid',
-                              gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
-                              gap: 1
+                              border: '1px solid',
+                              borderColor: 'divider',
+                              borderRadius: 2,
+                              p: 1.5
                             }}
                           >
-                            <Typography variant="caption">
-                              {text('请求数', 'Requests')}: {usageEntry?.requestCount || 0}
-                            </Typography>
-                            <Typography variant="caption">
-                              {text('聊天', 'Chat')}: {usageEntry?.chatRequestCount || 0}
-                            </Typography>
-                            <Typography variant="caption">
-                              OpenAI: {usageEntry?.openAiRequestCount || 0}
-                            </Typography>
-                            <Typography variant="caption">
-                              QApp:{' '}
-                              {(usageEntry?.quickAppListRequestCount || 0) +
-                                (usageEntry?.quickAppGetRequestCount || 0)}
-                            </Typography>
-                            <Typography variant="caption">
-                              {text('下载数', 'Downloads')}: {usageEntry?.mediaDownloadCount || 0}
-                            </Typography>
-                            <Typography variant="caption">
-                              {text('生成资源', 'Generated Media')}:{' '}
-                              {usageEntry?.generatedMediaCount || 0}
-                            </Typography>
-                            <Typography variant="caption">
-                              {text('已存资源', 'Stored Media')}:{' '}
-                              {usageEntry?.storedMediaCount || 0}
-                            </Typography>
-                            <Typography variant="caption">
-                              {text('已存大小', 'Stored Size')}:{' '}
-                              {formatProxyUsageBytes(usageEntry?.storedMediaBytes || 0)}
-                            </Typography>
+                            <Stack spacing={1}>
+                              <Typography variant="subtitle2">
+                                {displayLabel || entry.id}
+                              </Typography>
+                              <Box
+                                sx={{
+                                  display: 'grid',
+                                  gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+                                  gap: 1
+                                }}
+                              >
+                                <Typography variant="caption">
+                                  {text('请求数', 'Requests')}: {usageEntry?.requestCount || 0}
+                                </Typography>
+                                <Typography variant="caption">
+                                  {text('聊天', 'Chat')}: {usageEntry?.chatRequestCount || 0}
+                                </Typography>
+                                <Typography variant="caption">
+                                  OpenAI: {usageEntry?.openAiRequestCount || 0}
+                                </Typography>
+                                <Typography variant="caption">
+                                  QApp:{' '}
+                                  {(usageEntry?.quickAppListRequestCount || 0) +
+                                    (usageEntry?.quickAppGetRequestCount || 0)}
+                                </Typography>
+                                <Typography variant="caption">
+                                  {text('下载数', 'Downloads')}:{' '}
+                                  {usageEntry?.mediaDownloadCount || 0}
+                                </Typography>
+                                <Typography variant="caption">
+                                  {text('生成资源', 'Generated Media')}:{' '}
+                                  {usageEntry?.generatedMediaCount || 0}
+                                </Typography>
+                                <Typography variant="caption">
+                                  {text('已存资源', 'Stored Media')}:{' '}
+                                  {usageEntry?.storedMediaCount || 0}
+                                </Typography>
+                                <Typography variant="caption">
+                                  {text('已存大小', 'Stored Size')}:{' '}
+                                  {formatProxyUsageBytes(usageEntry?.storedMediaBytes || 0)}
+                                </Typography>
+                              </Box>
+                              <Typography variant="caption" color="text.secondary">
+                                {text('最后活跃', 'Last Active')}:{' '}
+                                {formatProxyUsageTime(usageEntry?.lastSeenAt)}
+                                {usageEntry?.lastRequesterAddress
+                                  ? ` / IP ${usageEntry.lastRequesterAddress}`
+                                  : ''}
+                                {usageEntry?.lastProfileId ? ` / ${usageEntry.lastProfileId}` : ''}
+                              </Typography>
+                            </Stack>
                           </Box>
-                          <Typography variant="caption" color="text.secondary">
-                            {text('最后活跃', 'Last Active')}:{' '}
-                            {formatProxyUsageTime(usageEntry?.lastSeenAt)}
-                            {usageEntry?.lastRequesterAddress
-                              ? ` / IP ${usageEntry.lastRequesterAddress}`
-                              : ''}
-                            {usageEntry?.lastProfileId ? ` / ${usageEntry.lastProfileId}` : ''}
-                          </Typography>
-                        </Stack>
-                      </Box>
-                    )
-                  })}
+                        )
+                      })}
+                    </Stack>
+                  ) : (
+                    <Alert severity="warning">
+                      <Typography variant="body2">
+                        {text(
+                          '请先添加代理访问令牌，才能查看按令牌拆分的使用情况。',
+                          'Add proxy access tokens first to view per-token usage.'
+                        )}
+                      </Typography>
+                    </Alert>
+                  )}
                 </Stack>
-              ) : (
-                <Alert severity="warning">
-                  <Typography variant="body2">
+              </SettingSection>
+            </Box>
+
+            <Box key="pure_config_not_set">
+              <PureConfigNotSetCallout needNavigate={false} />
+            </Box>
+
+            <Box key="remote_config_not_set">
+              <RemoteConfigNotSetCallout needNavigate={false} />
+            </Box>
+
+            <Box key="data_storage">
+              <SettingSection title={text('数据根目录', 'Data directory')}>
+                <DataStorageInfo />
+              </SettingSection>
+            </Box>
+
+            {!settingsValue.use_remote_comfyui && (
+              <Box key="monitor">
+                <SettingSection title={t('environment.monitor_title')}>
+                  <EnvironmentInfo />
+                </SettingSection>
+              </Box>
+            )}
+
+            {!settingsValue.use_remote_comfyui && (
+              <Box key="setup">
+                <SettingSection
+                  title={t('environment.setup_title')}
+                  action={
+                    <Stack direction="row" spacing={1}>
+                      <DropdownButton
+                        variant="outlined"
+                        size="small"
+                        startIcon={<CodeIcon />}
+                        buttonChildren={t('environment.setup_quick')}
+                      >
+                        {({ handleClose }) =>
+                          fastSettingTemplates.map((template) => (
+                            <MenuItem
+                              key={template.key}
+                              onClick={() => {
+                                handleFastSetting(template.key)
+                                handleClose()
+                              }}
+                            >
+                              {template.name}
+                            </MenuItem>
+                          ))
+                        }
+                      </DropdownButton>
+                      <Button
+                        variant="outlined"
+                        size="small"
+                        startIcon={<RefreshIcon />}
+                        onClick={handleResetAllPaths}
+                      >
+                        {t('environment.setup_reset_paths')}
+                      </Button>
+                    </Stack>
+                  }
+                >
+                  <InputPath
+                    label={t('environment.python_cmd_label')}
+                    value={settingsValue.local_comfyui_config.python_cmd.trim()}
+                    Icon={CodeIcon}
+                    pathType="file"
+                    defaultTo={configUtils.getPythonCmd()[0]}
+                    onChange={(value) =>
+                      saveSettings({
+                        local_comfyui_config: { python_cmd: toEmbeddedRelativePath(value) }
+                      })
+                    }
+                    placeholder={
+                      configUtils.getPythonCmd()[0] || t('environment.placeholder_python')
+                    }
+                    errorText={
+                      !configUtils.isPythonCmdAvailable()
+                        ? t('environment.err_pure_need_python')
+                        : undefined
+                    }
+                  />
+
+                  <InputPath
+                    label={t('environment.comfy_dir_label')}
+                    value={settingsValue.local_comfyui_config.comfyui_dir.trim()}
+                    Icon={FolderIcon}
+                    pathType="directory"
+                    defaultTo={configUtils.getComfyUIDir()[0]}
+                    onChange={(value) =>
+                      saveSettings({
+                        local_comfyui_config: { comfyui_dir: toEmbeddedRelativePath(value) }
+                      })
+                    }
+                    placeholder={
+                      configUtils.getComfyUIDir()[0] || t('environment.placeholder_comfy')
+                    }
+                    errorText={
+                      !configUtils.isComfyUIDirAvailable()
+                        ? t('environment.err_pure_need_comfy')
+                        : undefined
+                    }
+                  />
+
+                  <InputText
+                    label={t('environment.comfy_port_label')}
+                    value={settingsValue.local_comfyui_config.comfyui_port}
+                    Icon={CodeIcon}
+                    onChange={(value) =>
+                      saveSettings({ local_comfyui_config: { comfyui_port: value } })
+                    }
+                    placeholder={configUtils.getComfyUIPort()}
+                  />
+
+                  <InputText
+                    label={t('environment.comfy_args_label')}
+                    value={settingsValue.local_comfyui_config.comfyui_args?.join(' ') || ''}
+                    Icon={CodeIcon}
+                    onChange={(value) =>
+                      saveSettings({ local_comfyui_config: { comfyui_args: splitSpace(value) } })
+                    }
+                    placeholder={configUtils.getComfyUIArgs().join(' ')}
+                  />
+                </SettingSection>
+              </Box>
+            )}
+
+            {configUtils.isComfyUIDirAvailable() && (
+              <Box key="models">
+                <SettingSection
+                  title={t('environment.models_title')}
+                  action={
+                    <Stack direction="row" spacing={1}>
+                      <Button
+                        variant="outlined"
+                        size="small"
+                        startIcon={<RefreshIcon />}
+                        onClick={handleLoadExtraModelPaths}
+                      >
+                        {t('environment.models_load_extra_yaml')}
+                      </Button>
+                      <Button
+                        variant="outlined"
+                        size="small"
+                        startIcon={<RefreshIcon />}
+                        onClick={handleResetAllPaths}
+                      >
+                        {t('environment.models_reset_paths')}
+                      </Button>
+                    </Stack>
+                  }
+                >
+                  <Typography variant="caption" sx={{ ml: 0.5 }}>
+                    {t('environment.models_relative_tip')}
+                  </Typography>
+
+                  <InputPath
+                    label={t('environment.checkpoints_label')}
+                    value={settingsValue.checkpoints_dir.trim()}
+                    Icon={FolderIcon}
+                    pathType="directory"
+                    relativeTo={configUtils.getComfyUIDir()[0]}
+                    onChange={(value) => saveSettings({ checkpoints_dir: value })}
+                    placeholder={t('environment.placeholder_rel_or_abs')}
+                  />
+                  <InputPath
+                    label={t('environment.clip_label')}
+                    value={settingsValue.clip_dir.trim()}
+                    Icon={FolderIcon}
+                    pathType="directory"
+                    relativeTo={configUtils.getComfyUIDir()[0]}
+                    onChange={(value) => saveSettings({ clip_dir: value })}
+                    placeholder={t('environment.placeholder_rel_or_abs')}
+                  />
+                  <InputPath
+                    label={t('environment.vae_label')}
+                    value={settingsValue.vae_dir.trim()}
+                    Icon={FolderIcon}
+                    pathType="directory"
+                    relativeTo={configUtils.getComfyUIDir()[0]}
+                    onChange={(value) => saveSettings({ vae_dir: value })}
+                    placeholder={t('environment.placeholder_rel_or_abs')}
+                  />
+                  <InputPath
+                    label={t('environment.lora_label')}
+                    value={settingsValue.lora_dir.trim()}
+                    Icon={FolderIcon}
+                    pathType="directory"
+                    relativeTo={configUtils.getComfyUIDir()[0]}
+                    onChange={(value) => saveSettings({ lora_dir: value })}
+                    placeholder={t('environment.placeholder_rel_or_abs')}
+                  />
+                  <InputPath
+                    label={t('environment.controlnet_label')}
+                    value={settingsValue.controlnet_dir.trim()}
+                    Icon={FolderIcon}
+                    pathType="directory"
+                    relativeTo={configUtils.getComfyUIDir()[0]}
+                    onChange={(value) => saveSettings({ controlnet_dir: value })}
+                    placeholder={t('environment.placeholder_rel_or_abs')}
+                  />
+                  <InputPath
+                    label={t('environment.diffusion_models_label')}
+                    value={settingsValue.diffusion_models_dir.trim()}
+                    Icon={FolderIcon}
+                    pathType="directory"
+                    relativeTo={configUtils.getComfyUIDir()[0]}
+                    onChange={(value) => saveSettings({ diffusion_models_dir: value })}
+                    placeholder={t('environment.placeholder_rel_or_abs')}
+                  />
+                  <InputPath
+                    label={t('environment.unet_label')}
+                    value={settingsValue.unet_dir.trim()}
+                    Icon={FolderIcon}
+                    pathType="directory"
+                    relativeTo={configUtils.getComfyUIDir()[0]}
+                    onChange={(value) => saveSettings({ unet_dir: value })}
+                    placeholder={t('environment.placeholder_rel_or_abs')}
+                  />
+                  <InputPath
+                    label={t('environment.upscale_models_label')}
+                    value={settingsValue.upscale_models_dir.trim()}
+                    Icon={FolderIcon}
+                    pathType="directory"
+                    relativeTo={configUtils.getComfyUIDir()[0]}
+                    onChange={(value) => saveSettings({ upscale_models_dir: value })}
+                    placeholder={t('environment.placeholder_rel_or_abs')}
+                  />
+                  <InputPath
+                    label={t('environment.output_label')}
+                    value={settingsValue.output_dir.trim()}
+                    Icon={FolderIcon}
+                    pathType="directory"
+                    relativeTo={configUtils.getComfyUIDir()[0]}
+                    onChange={(value) => saveSettings({ output_dir: value })}
+                    placeholder={t('environment.placeholder_rel_or_abs')}
+                  />
+                  <InputPath
+                    label={t('environment.workflow_label')}
+                    value={settingsValue.workflow_dir.trim()}
+                    Icon={FolderIcon}
+                    pathType="directory"
+                    relativeTo={configUtils.getComfyUIDir()[0]}
+                    onChange={(value) => saveSettings({ workflow_dir: value })}
+                    placeholder={t('environment.placeholder_rel_or_abs')}
+                  />
+                </SettingSection>
+              </Box>
+            )}
+
+            <Box key="dcc_bridge">
+              <SettingSection title={text('DCC 桥接', 'DCC Bridge')}>
+                <Alert severity="info">
+                  <AlertTitle>{text('文件夹目标', 'Folder Targets')}</AlertTitle>
+                  <Typography sx={{ whiteSpace: 'pre-line', wordBreak: 'break-all' }}>
                     {text(
-                      '请先添加代理访问令牌，才能查看按令牌拆分的使用情况。',
-                      'Add proxy access tokens first to view per-token usage.'
+                      'Unity：指向项目的 Assets 文件夹，或 Assets 下的某个子文件夹。\nUnreal：指向 Auto Reimport 使用的监视源文件夹。',
+                      'Unity: point this at the project Assets folder or a subfolder inside Assets.\nUnreal: point this at a watched source folder used by Auto Reimport.'
                     )}
                   </Typography>
                 </Alert>
-              )}
-            </Stack>
-          </SettingSection>
-        </Collapse>
 
-        <Collapse key="pure_config_not_set">
-          <PureConfigNotSetCallout needNavigate={false} />
-        </Collapse>
-
-        <Collapse key="remote_config_not_set">
-          <RemoteConfigNotSetCallout needNavigate={false} />
-        </Collapse>
-
-        <Collapse key="data_storage">
-          <SettingSection title={text('数据根目录', 'Data directory')}>
-            <DataStorageInfo />
-          </SettingSection>
-        </Collapse>
-
-        {!settingsValue.use_remote_comfyui && (
-          <Collapse key="monitor">
-            <SettingSection title={t('environment.monitor_title')}>
-              <EnvironmentInfo />
-            </SettingSection>
-          </Collapse>
-        )}
-
-        {!settingsValue.use_remote_comfyui && (
-          <Collapse key="setup">
-            <SettingSection
-              title={t('environment.setup_title')}
-              action={
-                <Stack direction="row" spacing={1}>
-                  <DropdownButton
-                    variant="outlined"
-                    size="small"
-                    startIcon={<CodeIcon />}
-                    buttonChildren={t('environment.setup_quick')}
-                  >
-                    {({ handleClose }) =>
-                      fastSettingTemplates.map((template) => (
-                        <MenuItem
-                          key={template.key}
-                          onClick={() => {
-                            handleFastSetting(template.key)
-                            handleClose()
-                          }}
-                        >
-                          {template.name}
-                        </MenuItem>
-                      ))
-                    }
-                  </DropdownButton>
-                  <Button
-                    variant="outlined"
-                    size="small"
-                    startIcon={<RefreshIcon />}
-                    onClick={handleResetAllPaths}
-                  >
-                    {t('environment.setup_reset_paths')}
-                  </Button>
-                </Stack>
-              }
-            >
-              <InputPath
-                label={t('environment.python_cmd_label')}
-                value={settingsValue.local_comfyui_config.python_cmd.trim()}
-                Icon={CodeIcon}
-                pathType="file"
-                defaultTo={configUtils.getPythonCmd()[0]}
-                onChange={(value) =>
-                  saveSettings({
-                    local_comfyui_config: { python_cmd: toEmbeddedRelativePath(value) }
-                  })
-                }
-                placeholder={configUtils.getPythonCmd()[0] || t('environment.placeholder_python')}
-                errorText={
-                  !configUtils.isPythonCmdAvailable()
-                    ? t('environment.err_pure_need_python')
-                    : undefined
-                }
-              />
-
-              <InputPath
-                label={t('environment.comfy_dir_label')}
-                value={settingsValue.local_comfyui_config.comfyui_dir.trim()}
-                Icon={FolderIcon}
-                pathType="directory"
-                defaultTo={configUtils.getComfyUIDir()[0]}
-                onChange={(value) =>
-                  saveSettings({
-                    local_comfyui_config: { comfyui_dir: toEmbeddedRelativePath(value) }
-                  })
-                }
-                placeholder={configUtils.getComfyUIDir()[0] || t('environment.placeholder_comfy')}
-                errorText={
-                  !configUtils.isComfyUIDirAvailable()
-                    ? t('environment.err_pure_need_comfy')
-                    : undefined
-                }
-              />
-
-              <InputText
-                label={t('environment.comfy_port_label')}
-                value={settingsValue.local_comfyui_config.comfyui_port}
-                Icon={CodeIcon}
-                onChange={(value) =>
-                  saveSettings({ local_comfyui_config: { comfyui_port: value } })
-                }
-                placeholder={configUtils.getComfyUIPort()}
-              />
-
-              <InputText
-                label={t('environment.comfy_args_label')}
-                value={settingsValue.local_comfyui_config.comfyui_args?.join(' ') || ''}
-                Icon={CodeIcon}
-                onChange={(value) =>
-                  saveSettings({ local_comfyui_config: { comfyui_args: splitSpace(value) } })
-                }
-                placeholder={configUtils.getComfyUIArgs().join(' ')}
-              />
-            </SettingSection>
-          </Collapse>
-        )}
-
-        {configUtils.isComfyUIDirAvailable() && (
-          <Collapse key="models">
-            <SettingSection
-              title={t('environment.models_title')}
-              action={
-                <Stack direction="row" spacing={1}>
-                  <Button
-                    variant="outlined"
-                    size="small"
-                    startIcon={<RefreshIcon />}
-                    onClick={handleLoadExtraModelPaths}
-                  >
-                    {t('environment.models_load_extra_yaml')}
-                  </Button>
-                  <Button
-                    variant="outlined"
-                    size="small"
-                    startIcon={<RefreshIcon />}
-                    onClick={handleResetAllPaths}
-                  >
-                    {t('environment.models_reset_paths')}
-                  </Button>
-                </Stack>
-              }
-            >
-              <Typography variant="caption" sx={{ ml: 0.5 }}>
-                {t('environment.models_relative_tip')}
-              </Typography>
-
-              <InputPath
-                label={t('environment.checkpoints_label')}
-                value={settingsValue.checkpoints_dir.trim()}
-                Icon={FolderIcon}
-                pathType="directory"
-                relativeTo={configUtils.getComfyUIDir()[0]}
-                onChange={(value) => saveSettings({ checkpoints_dir: value })}
-                placeholder={t('environment.placeholder_rel_or_abs')}
-              />
-              <InputPath
-                label={t('environment.clip_label')}
-                value={settingsValue.clip_dir.trim()}
-                Icon={FolderIcon}
-                pathType="directory"
-                relativeTo={configUtils.getComfyUIDir()[0]}
-                onChange={(value) => saveSettings({ clip_dir: value })}
-                placeholder={t('environment.placeholder_rel_or_abs')}
-              />
-              <InputPath
-                label={t('environment.vae_label')}
-                value={settingsValue.vae_dir.trim()}
-                Icon={FolderIcon}
-                pathType="directory"
-                relativeTo={configUtils.getComfyUIDir()[0]}
-                onChange={(value) => saveSettings({ vae_dir: value })}
-                placeholder={t('environment.placeholder_rel_or_abs')}
-              />
-              <InputPath
-                label={t('environment.lora_label')}
-                value={settingsValue.lora_dir.trim()}
-                Icon={FolderIcon}
-                pathType="directory"
-                relativeTo={configUtils.getComfyUIDir()[0]}
-                onChange={(value) => saveSettings({ lora_dir: value })}
-                placeholder={t('environment.placeholder_rel_or_abs')}
-              />
-              <InputPath
-                label={t('environment.controlnet_label')}
-                value={settingsValue.controlnet_dir.trim()}
-                Icon={FolderIcon}
-                pathType="directory"
-                relativeTo={configUtils.getComfyUIDir()[0]}
-                onChange={(value) => saveSettings({ controlnet_dir: value })}
-                placeholder={t('environment.placeholder_rel_or_abs')}
-              />
-              <InputPath
-                label={t('environment.diffusion_models_label')}
-                value={settingsValue.diffusion_models_dir.trim()}
-                Icon={FolderIcon}
-                pathType="directory"
-                relativeTo={configUtils.getComfyUIDir()[0]}
-                onChange={(value) => saveSettings({ diffusion_models_dir: value })}
-                placeholder={t('environment.placeholder_rel_or_abs')}
-              />
-              <InputPath
-                label={t('environment.unet_label')}
-                value={settingsValue.unet_dir.trim()}
-                Icon={FolderIcon}
-                pathType="directory"
-                relativeTo={configUtils.getComfyUIDir()[0]}
-                onChange={(value) => saveSettings({ unet_dir: value })}
-                placeholder={t('environment.placeholder_rel_or_abs')}
-              />
-              <InputPath
-                label={t('environment.upscale_models_label')}
-                value={settingsValue.upscale_models_dir.trim()}
-                Icon={FolderIcon}
-                pathType="directory"
-                relativeTo={configUtils.getComfyUIDir()[0]}
-                onChange={(value) => saveSettings({ upscale_models_dir: value })}
-                placeholder={t('environment.placeholder_rel_or_abs')}
-              />
-              <InputPath
-                label={t('environment.output_label')}
-                value={settingsValue.output_dir.trim()}
-                Icon={FolderIcon}
-                pathType="directory"
-                relativeTo={configUtils.getComfyUIDir()[0]}
-                onChange={(value) => saveSettings({ output_dir: value })}
-                placeholder={t('environment.placeholder_rel_or_abs')}
-              />
-              <InputPath
-                label={t('environment.workflow_label')}
-                value={settingsValue.workflow_dir.trim()}
-                Icon={FolderIcon}
-                pathType="directory"
-                relativeTo={configUtils.getComfyUIDir()[0]}
-                onChange={(value) => saveSettings({ workflow_dir: value })}
-                placeholder={t('environment.placeholder_rel_or_abs')}
-              />
-            </SettingSection>
-          </Collapse>
-        )}
-
-        <Collapse key="dcc_bridge">
-          <SettingSection title={text('DCC 桥接', 'DCC Bridge')}>
-            <Alert severity="info">
-              <AlertTitle>{text('文件夹目标', 'Folder Targets')}</AlertTitle>
-              <Typography sx={{ whiteSpace: 'pre-line', wordBreak: 'break-all' }}>
-                {text(
-                  'Unity：指向项目的 Assets 文件夹，或 Assets 下的某个子文件夹。\nUnreal：指向 Auto Reimport 使用的监视源文件夹。',
-                  'Unity: point this at the project Assets folder or a subfolder inside Assets.\nUnreal: point this at a watched source folder used by Auto Reimport.'
-                )}
-              </Typography>
-            </Alert>
-
-            <InputPath
-              label={text('Unity 桥接文件夹', 'Unity bridge folder')}
-              value={settingsValue.dcc_bridge_config.unity_export_dir.trim()}
-              Icon={FolderIcon}
-              pathType="directory"
-              onChange={(value) => saveSettings({ dcc_bridge_config: { unity_export_dir: value } })}
-              placeholder={text(
-                '例如：C:/MyUnityProject/Assets/MagicPot',
-                'C:/MyUnityProject/Assets/MagicPot'
-              )}
-            />
-
-            <InputPath
-              label={text('Unreal 桥接文件夹', 'Unreal bridge folder')}
-              value={settingsValue.dcc_bridge_config.unreal_export_dir.trim()}
-              Icon={FolderIcon}
-              pathType="directory"
-              onChange={(value) =>
-                saveSettings({ dcc_bridge_config: { unreal_export_dir: value } })
-              }
-              placeholder={text(
-                '例如：D:/MyUnrealProject/BridgeInbox',
-                'D:/MyUnrealProject/BridgeInbox'
-              )}
-            />
-          </SettingSection>
-        </Collapse>
-
-        <Collapse key="adobe_bridge">
-          <SettingSection title={text('Adobe 桥接', 'Adobe Bridge')}>
-            <Alert severity="info">
-              <AlertTitle>{text('文件夹导入目标', 'Folder Inbox Targets')}</AlertTitle>
-              <Typography sx={{ whiteSpace: 'pre-line', wordBreak: 'break-all' }}>
-                {text(
-                  'After Effects / Premiere Pro：指向工作流可导入的文件夹。MagicPot 会把资源复制到 MagicPotImports，并在旁边写入清单。',
-                  'After Effects / Premiere Pro: point this at a folder your workflow can import from. MagicPot will copy assets into MagicPotImports and write a manifest beside them.'
-                )}
-              </Typography>
-            </Alert>
-
-            <InputPath
-              label={text('After Effects 导出文件夹', 'After Effects bridge folder')}
-              value={(settingsValue.adobe_bridge_config?.after_effects_export_dir || '').trim()}
-              Icon={FolderIcon}
-              pathType="directory"
-              onChange={(value) =>
-                saveSettings({ adobe_bridge_config: { after_effects_export_dir: value } })
-              }
-              placeholder={text(
-                '例如：D:/Creative/AfterEffects/BridgeInbox',
-                'D:/Creative/AfterEffects/BridgeInbox'
-              )}
-            />
-
-            <InputPath
-              label={text('Premiere Pro 导出文件夹', 'Premiere Pro bridge folder')}
-              value={(settingsValue.adobe_bridge_config?.premiere_export_dir || '').trim()}
-              Icon={FolderIcon}
-              pathType="directory"
-              onChange={(value) =>
-                saveSettings({ adobe_bridge_config: { premiere_export_dir: value } })
-              }
-              placeholder={text(
-                '例如：D:/Creative/Premiere/BridgeInbox',
-                'D:/Creative/Premiere/BridgeInbox'
-              )}
-            />
-          </SettingSection>
-        </Collapse>
-        <Collapse key="figma_bridge">
-          <SettingSection
-            title={text('\u0046\u0069\u0067\u006d\u0061 \u63a5\u5165', 'Figma Integration')}
-          >
-            <Alert
-              severity={
-                settingsValue.figma_config?.personal_access_token?.trim() ? 'success' : 'warning'
-              }
-            >
-              <AlertTitle>
-                {settingsValue.figma_config?.personal_access_token?.trim()
-                  ? text('Figma API 已配置', 'Figma API configured')
-                  : text('请先配置 Figma API', 'Set up Figma API first')}
-              </AlertTitle>
-              <Typography sx={{ whiteSpace: 'pre-line', wordBreak: 'break-all' }}>
-                {text(
-                  '在这里配置一次 Figma Personal Access Token 后，画布里就可以绑定某个 Figma 文件，后续由 MagicPot 主动拉取同步，并按设置自动检查更新。\n发送到 Figma 仍然会继续走剪贴板粘贴流程。',
-                  'Configure your Figma Personal Access Token here once. Then each canvas can bind a Figma file, sync it on demand from MagicPot, and automatically check for updates.\nSend to Figma still uses the clipboard paste flow.'
-                )}
-              </Typography>
-            </Alert>
-
-            <Stack spacing={2.5} sx={{ mt: 2 }}>
-              <TextField
-                fullWidth
-                type="password"
-                autoComplete="off"
-                label={text('Figma Personal Access Token', 'Figma Personal Access Token')}
-                value={settingsValue.figma_config?.personal_access_token || ''}
-                onChange={(event) =>
-                  saveSettings({
-                    figma_config: { personal_access_token: event.target.value }
-                  })
-                }
-                placeholder="figd_********************************"
-                helperText={text(
-                  '用于画布绑定 Figma 文件、手动同步和自动检查更新。',
-                  'Used for canvas-side Figma binding, manual sync, and automatic update checks.'
-                )}
-              />
-
-              <Box
-                sx={{
-                  display: 'grid',
-                  gap: 2,
-                  gridTemplateColumns: {
-                    xs: '1fr',
-                    md: 'minmax(260px, 1fr) minmax(220px, 320px)'
-                  }
-                }}
-              >
-                <InputSwitch
-                  label={text(
-                    '自动检查已绑定 Figma 文件更新',
-                    'Automatically check bound Figma files'
-                  )}
-                  value={settingsValue.figma_config?.auto_check_updates ?? true}
+                <InputPath
+                  label={text('Unity 桥接文件夹', 'Unity bridge folder')}
+                  value={settingsValue.dcc_bridge_config.unity_export_dir.trim()}
+                  Icon={FolderIcon}
+                  pathType="directory"
                   onChange={(value) =>
-                    saveSettings({
-                      figma_config: { auto_check_updates: value }
-                    })
+                    saveSettings({ dcc_bridge_config: { unity_export_dir: value } })
                   }
-                  tooltip={text(
-                    '开启后，画布侧已绑定的 Figma 文件会由 MagicPot 按间隔自动检查是否有新版本。',
-                    'When enabled, MagicPot automatically checks bound Figma files for updates on the canvas side.'
+                  placeholder={text(
+                    '例如：C:/MyUnityProject/Assets/MagicPot',
+                    'C:/MyUnityProject/Assets/MagicPot'
                   )}
                 />
 
-                <TextField
-                  fullWidth
-                  type="number"
-                  label={text('检查间隔（分钟）', 'Check interval (minutes)')}
-                  value={String(settingsValue.figma_config?.auto_check_interval_minutes ?? 15)}
-                  onChange={(event) => {
-                    const parsed = parseInt(event.target.value, 10)
-                    saveSettings({
-                      figma_config: {
-                        auto_check_interval_minutes: Number.isFinite(parsed)
-                          ? Math.min(1440, Math.max(5, parsed))
-                          : 15
-                      }
-                    })
-                  }}
-                  inputProps={{ min: 5, max: 1440, step: 1 }}
-                  helperText={text(
-                    '建议 5 到 60 分钟；绑定文件的自动检查会使用这个全局间隔。',
-                    'Recommended range: 5 to 60 minutes. Bound-file auto checks use this global interval.'
+                <InputPath
+                  label={text('Unreal 桥接文件夹', 'Unreal bridge folder')}
+                  value={settingsValue.dcc_bridge_config.unreal_export_dir.trim()}
+                  Icon={FolderIcon}
+                  pathType="directory"
+                  onChange={(value) =>
+                    saveSettings({ dcc_bridge_config: { unreal_export_dir: value } })
+                  }
+                  placeholder={text(
+                    '例如：D:/MyUnrealProject/BridgeInbox',
+                    'D:/MyUnrealProject/BridgeInbox'
                   )}
                 />
-              </Box>
+              </SettingSection>
+            </Box>
 
-              <Divider />
-
-              <Alert severity={lastActiveProjectId ? 'info' : 'warning'} variant="outlined">
-                <AlertTitle>
-                  {lastActiveProjectId
-                    ? text('当前画布绑定', 'Current canvas binding')
-                    : text('未打开画布', 'No canvas open')}
-                </AlertTitle>
-                <Typography variant="body2" sx={{ whiteSpace: 'pre-line' }}>
-                  {lastActiveProjectId
-                    ? currentCanvasBinding
-                      ? text(
-                          `当前操作对象：${managedCanvasLabel}\n绑定文件：${currentCanvasBinding.fileName}`,
-                          `Current target: ${managedCanvasLabel}\nBound file: ${currentCanvasBinding.fileName}`
-                        )
-                      : text(
-                          `当前操作对象：${managedCanvasLabel}\n尚未绑定 Figma 文件。`,
-                          `Current target: ${managedCanvasLabel}\nNo Figma file is bound yet.`
-                        )
-                    : text(
-                        '请先打开一个画布项目，再到这里管理该画布的 Figma 绑定和同步。',
-                        'Open a canvas project first, then manage that canvas Figma binding here.'
-                      )}
-                </Typography>
-              </Alert>
-
-              {lastActiveProjectId && displayedFigmaBinding?.updateAvailable && (
-                <Typography variant="body2" color="warning.main" sx={{ fontWeight: 600 }}>
-                  {text(
-                    '检测到已绑定 Figma 有更新，可在下方面板里同步。',
-                    'A newer bound Figma version is available. Use the panel below to sync it.'
-                  )}
-                </Typography>
-              )}
-
-              {lastActiveProjectId && (
-                <FigmaBindingDialog
-                  variant="inline"
-                  open
-                  accessTokenConfigured={Boolean(figmaAccessToken)}
-                  busyAction={figmaBusyAction}
-                  error={figmaBindingError}
-                  fileKeyOrUrl={figmaFileKeyOrUrlInput}
-                  binding={displayedFigmaBinding}
-                  globalAutoCheckEnabled={figmaGlobalAutoCheckEnabled}
-                  globalAutoCheckIntervalMinutes={figmaAutoCheckIntervalMinutes}
-                  onFileKeyOrUrlChange={setFigmaFileKeyOrUrlInput}
-                  onPageNodeIdChange={handleFigmaDraftPageChange}
-                  onAutoCheckUpdatesChange={handleFigmaDraftAutoCheckUpdatesChange}
-                  onResolve={() => void handleResolveFigmaBinding()}
-                  onBind={() => void handleSaveFigmaBinding()}
-                  onSync={() => void handleSyncFigmaBinding()}
-                  onCheck={() => void handleCheckFigmaUpdate()}
-                  onUnbind={() => void handleUnbindFigmaBinding()}
-                  onClose={handleCloseFigmaBindingDialog}
-                />
-              )}
-
-              <Stack
-                direction={{ xs: 'column', sm: 'row' }}
-                spacing={1.5}
-                alignItems={{ xs: 'stretch', sm: 'center' }}
-                sx={{ display: 'none' }}
-              >
-                <Button
-                  variant="outlined"
-                  startIcon={<CodeIcon />}
-                  onClick={() => void handleOpenFigmaBindingDialog()}
-                  disabled={!lastActiveProjectId}
-                >
-                  {text('管理当前画布绑定', 'Manage Current Canvas Binding')}
-                </Button>
-                {currentCanvasBinding?.updateAvailable && (
-                  <Typography variant="body2" color="warning.main" sx={{ fontWeight: 600 }}>
+            <Box key="adobe_bridge">
+              <SettingSection title={text('Adobe 桥接', 'Adobe Bridge')}>
+                <Alert severity="info">
+                  <AlertTitle>{text('文件夹导入目标', 'Folder Inbox Targets')}</AlertTitle>
+                  <Typography sx={{ whiteSpace: 'pre-line', wordBreak: 'break-all' }}>
                     {text(
-                      '检测到已绑定 Figma 有更新，可在上面的对话框里同步。',
-                      'A newer bound Figma version is available. Open the dialog above to sync it.'
+                      'After Effects / Premiere Pro：指向工作流可导入的文件夹。MagicPot 会把资源复制到 MagicPotImports，并在旁边写入清单。',
+                      'After Effects / Premiere Pro: point this at a folder your workflow can import from. MagicPot will copy assets into MagicPotImports and write a manifest beside them.'
                     )}
                   </Typography>
-                )}
-              </Stack>
-            </Stack>
-          </SettingSection>
-        </Collapse>
-      </TransitionGroup>
+                </Alert>
 
-      <FigmaBindingDialog
-        open={figmaBindingDialogOpen}
-        accessTokenConfigured={Boolean(figmaAccessToken)}
-        busyAction={figmaBusyAction}
-        error={figmaBindingError}
-        fileKeyOrUrl={figmaFileKeyOrUrlInput}
-        binding={figmaBindingDraft || currentCanvasBinding}
-        globalAutoCheckEnabled={figmaGlobalAutoCheckEnabled}
-        globalAutoCheckIntervalMinutes={figmaAutoCheckIntervalMinutes}
-        onFileKeyOrUrlChange={setFigmaFileKeyOrUrlInput}
-        onPageNodeIdChange={handleFigmaDraftPageChange}
-        onAutoCheckUpdatesChange={handleFigmaDraftAutoCheckUpdatesChange}
-        onResolve={() => void handleResolveFigmaBinding()}
-        onBind={() => void handleSaveFigmaBinding()}
-        onSync={() => void handleSyncFigmaBinding()}
-        onCheck={() => void handleCheckFigmaUpdate()}
-        onUnbind={() => void handleUnbindFigmaBinding()}
-        onClose={handleCloseFigmaBindingDialog}
-      />
+                <InputPath
+                  label={text('After Effects 导出文件夹', 'After Effects bridge folder')}
+                  value={(settingsValue.adobe_bridge_config?.after_effects_export_dir || '').trim()}
+                  Icon={FolderIcon}
+                  pathType="directory"
+                  onChange={(value) =>
+                    saveSettings({ adobe_bridge_config: { after_effects_export_dir: value } })
+                  }
+                  placeholder={text(
+                    '例如：D:/Creative/AfterEffects/BridgeInbox',
+                    'D:/Creative/AfterEffects/BridgeInbox'
+                  )}
+                />
+
+                <InputPath
+                  label={text('Premiere Pro 导出文件夹', 'Premiere Pro bridge folder')}
+                  value={(settingsValue.adobe_bridge_config?.premiere_export_dir || '').trim()}
+                  Icon={FolderIcon}
+                  pathType="directory"
+                  onChange={(value) =>
+                    saveSettings({ adobe_bridge_config: { premiere_export_dir: value } })
+                  }
+                  placeholder={text(
+                    '例如：D:/Creative/Premiere/BridgeInbox',
+                    'D:/Creative/Premiere/BridgeInbox'
+                  )}
+                />
+              </SettingSection>
+            </Box>
+            <Box key="figma_bridge">
+              <SettingSection
+                title={text('\u0046\u0069\u0067\u006d\u0061 \u63a5\u5165', 'Figma Integration')}
+              >
+                <Alert
+                  severity={
+                    settingsValue.figma_config?.personal_access_token?.trim()
+                      ? 'success'
+                      : 'warning'
+                  }
+                >
+                  <AlertTitle>
+                    {settingsValue.figma_config?.personal_access_token?.trim()
+                      ? text('Figma API 已配置', 'Figma API configured')
+                      : text('请先配置 Figma API', 'Set up Figma API first')}
+                  </AlertTitle>
+                  <Typography sx={{ whiteSpace: 'pre-line', wordBreak: 'break-all' }}>
+                    {text(
+                      '在这里配置一次 Figma Personal Access Token 后，画布里就可以绑定某个 Figma 文件，后续由 MagicPot 主动拉取同步，并按设置自动检查更新。\n发送到 Figma 仍然会继续走剪贴板粘贴流程。',
+                      'Configure your Figma Personal Access Token here once. Then each canvas can bind a Figma file, sync it on demand from MagicPot, and automatically check for updates.\nSend to Figma still uses the clipboard paste flow.'
+                    )}
+                  </Typography>
+                </Alert>
+
+                <Stack spacing={2.5} sx={{ mt: 2 }}>
+                  <TextField
+                    fullWidth
+                    type="password"
+                    autoComplete="off"
+                    label={text('Figma Personal Access Token', 'Figma Personal Access Token')}
+                    value={settingsValue.figma_config?.personal_access_token || ''}
+                    onChange={(event) =>
+                      saveSettings({
+                        figma_config: { personal_access_token: event.target.value }
+                      })
+                    }
+                    placeholder="figd_********************************"
+                    helperText={text(
+                      '用于画布绑定 Figma 文件、手动同步和自动检查更新。',
+                      'Used for canvas-side Figma binding, manual sync, and automatic update checks.'
+                    )}
+                  />
+
+                  <Box
+                    sx={{
+                      display: 'grid',
+                      gap: 2,
+                      gridTemplateColumns: {
+                        xs: '1fr',
+                        md: 'minmax(260px, 1fr) minmax(220px, 320px)'
+                      }
+                    }}
+                  >
+                    <InputSwitch
+                      label={text(
+                        '自动检查已绑定 Figma 文件更新',
+                        'Automatically check bound Figma files'
+                      )}
+                      value={settingsValue.figma_config?.auto_check_updates ?? true}
+                      onChange={(value) =>
+                        saveSettings({
+                          figma_config: { auto_check_updates: value }
+                        })
+                      }
+                      tooltip={text(
+                        '开启后，画布侧已绑定的 Figma 文件会由 MagicPot 按间隔自动检查是否有新版本。',
+                        'When enabled, MagicPot automatically checks bound Figma files for updates on the canvas side.'
+                      )}
+                    />
+
+                    <TextField
+                      fullWidth
+                      type="number"
+                      label={text('检查间隔（分钟）', 'Check interval (minutes)')}
+                      value={String(settingsValue.figma_config?.auto_check_interval_minutes ?? 15)}
+                      onChange={(event) => {
+                        const parsed = parseInt(event.target.value, 10)
+                        saveSettings({
+                          figma_config: {
+                            auto_check_interval_minutes: Number.isFinite(parsed)
+                              ? Math.min(1440, Math.max(5, parsed))
+                              : 15
+                          }
+                        })
+                      }}
+                      inputProps={{ min: 5, max: 1440, step: 1 }}
+                      helperText={text(
+                        '建议 5 到 60 分钟；绑定文件的自动检查会使用这个全局间隔。',
+                        'Recommended range: 5 to 60 minutes. Bound-file auto checks use this global interval.'
+                      )}
+                    />
+                  </Box>
+
+                  <Divider />
+
+                  <Alert severity={lastActiveProjectId ? 'info' : 'warning'} variant="outlined">
+                    <AlertTitle>
+                      {lastActiveProjectId
+                        ? text('当前画布绑定', 'Current canvas binding')
+                        : text('未打开画布', 'No canvas open')}
+                    </AlertTitle>
+                    <Typography variant="body2" sx={{ whiteSpace: 'pre-line' }}>
+                      {lastActiveProjectId
+                        ? currentCanvasBinding
+                          ? text(
+                              `当前操作对象：${managedCanvasLabel}\n绑定文件：${currentCanvasBinding.fileName}`,
+                              `Current target: ${managedCanvasLabel}\nBound file: ${currentCanvasBinding.fileName}`
+                            )
+                          : text(
+                              `当前操作对象：${managedCanvasLabel}\n尚未绑定 Figma 文件。`,
+                              `Current target: ${managedCanvasLabel}\nNo Figma file is bound yet.`
+                            )
+                        : text(
+                            '请先打开一个画布项目，再到这里管理该画布的 Figma 绑定和同步。',
+                            'Open a canvas project first, then manage that canvas Figma binding here.'
+                          )}
+                    </Typography>
+                  </Alert>
+
+                  {lastActiveProjectId && displayedFigmaBinding?.updateAvailable && (
+                    <Typography variant="body2" color="warning.main" sx={{ fontWeight: 600 }}>
+                      {text(
+                        '检测到已绑定 Figma 有更新，可在下方面板里同步。',
+                        'A newer bound Figma version is available. Use the panel below to sync it.'
+                      )}
+                    </Typography>
+                  )}
+
+                  {lastActiveProjectId && (
+                    <FigmaBindingDialog
+                      variant="inline"
+                      open
+                      accessTokenConfigured={Boolean(figmaAccessToken)}
+                      busyAction={figmaBusyAction}
+                      error={figmaBindingError}
+                      fileKeyOrUrl={figmaFileKeyOrUrlInput}
+                      binding={displayedFigmaBinding}
+                      globalAutoCheckEnabled={figmaGlobalAutoCheckEnabled}
+                      globalAutoCheckIntervalMinutes={figmaAutoCheckIntervalMinutes}
+                      onFileKeyOrUrlChange={setFigmaFileKeyOrUrlInput}
+                      onPageNodeIdChange={handleFigmaDraftPageChange}
+                      onAutoCheckUpdatesChange={handleFigmaDraftAutoCheckUpdatesChange}
+                      onResolve={() => void handleResolveFigmaBinding()}
+                      onBind={() => void handleSaveFigmaBinding()}
+                      onSync={() => void handleSyncFigmaBinding()}
+                      onCheck={() => void handleCheckFigmaUpdate()}
+                      onUnbind={() => void handleUnbindFigmaBinding()}
+                      onClose={handleCloseFigmaBindingDialog}
+                    />
+                  )}
+
+                  <Stack
+                    direction={{ xs: 'column', sm: 'row' }}
+                    spacing={1.5}
+                    alignItems={{ xs: 'stretch', sm: 'center' }}
+                    sx={{ display: 'none' }}
+                  >
+                    <Button
+                      variant="outlined"
+                      startIcon={<CodeIcon />}
+                      onClick={() => void handleOpenFigmaBindingDialog()}
+                      disabled={!lastActiveProjectId}
+                    >
+                      {text('管理当前画布绑定', 'Manage Current Canvas Binding')}
+                    </Button>
+                    {currentCanvasBinding?.updateAvailable && (
+                      <Typography variant="body2" color="warning.main" sx={{ fontWeight: 600 }}>
+                        {text(
+                          '检测到已绑定 Figma 有更新，可在上面的对话框里同步。',
+                          'A newer bound Figma version is available. Open the dialog above to sync it.'
+                        )}
+                      </Typography>
+                    )}
+                  </Stack>
+                </Stack>
+              </SettingSection>
+            </Box>
+          </>
+        )}
+      </>
+
+      {renderDeferredSections && (
+        <FigmaBindingDialog
+          open={figmaBindingDialogOpen}
+          accessTokenConfigured={Boolean(figmaAccessToken)}
+          busyAction={figmaBusyAction}
+          error={figmaBindingError}
+          fileKeyOrUrl={figmaFileKeyOrUrlInput}
+          binding={figmaBindingDraft || currentCanvasBinding}
+          globalAutoCheckEnabled={figmaGlobalAutoCheckEnabled}
+          globalAutoCheckIntervalMinutes={figmaAutoCheckIntervalMinutes}
+          onFileKeyOrUrlChange={setFigmaFileKeyOrUrlInput}
+          onPageNodeIdChange={handleFigmaDraftPageChange}
+          onAutoCheckUpdatesChange={handleFigmaDraftAutoCheckUpdatesChange}
+          onResolve={() => void handleResolveFigmaBinding()}
+          onBind={() => void handleSaveFigmaBinding()}
+          onSync={() => void handleSyncFigmaBinding()}
+          onCheck={() => void handleCheckFigmaUpdate()}
+          onUnbind={() => void handleUnbindFigmaBinding()}
+          onClose={handleCloseFigmaBindingDialog}
+        />
+      )}
 
       <FastSettingErrorModal
         errorMessage={fastSettingErrorMessage}

--- a/packages/app/src/renderer/src/pages/SettingsPage/PanelPlugin.test.tsx
+++ b/packages/app/src/renderer/src/pages/SettingsPage/PanelPlugin.test.tsx
@@ -48,7 +48,7 @@ const buildEnglishTranslations = (): Record<string, string> => ({
     'Choose Hunyuan3D from the Quick Apps panel on the right. The Tencent Cloud credentials configured here are used to turn the uploaded reference image into a 3D model.',
   'quickapp_api.open_quickapp_api': 'Open Quick App API',
   'quickapp_api.api_region': 'Tencent API Region',
-  'quickapp_api.api_region_hint': 'When left empty, MagicPot falls back to the COS region.',
+  'quickapp_api.api_region_hint': 'When left empty, MagicPot uses ap-guangzhou.',
   'quickapp_api.clear_cos_button': 'Clear Current Prefix',
   'quickapp_api.clear_cos_loading': 'Clearing...',
   'quickapp_api.clear_cos_dialog_title': 'Clear Hunyuan3D COS Cache',

--- a/packages/app/src/renderer/src/pages/SettingsPage/PanelPlugin.tsx
+++ b/packages/app/src/renderer/src/pages/SettingsPage/PanelPlugin.tsx
@@ -49,6 +49,7 @@ type HunyuanSectionProps = {
 }
 
 const DEFAULT_HY3D_COS_PREFIX = 'magicpot/hunyuan3d'
+const DEFAULT_HY3D_API_REGION = 'ap-guangzhou'
 
 const quickAppSectionSurfaceSx = {
   borderRadius: 3,
@@ -562,7 +563,6 @@ const HunyuanSection: React.FC<HunyuanSectionProps> = ({ saveSettings, settingsV
   const configuredBucket = settingsValue.aigc3d_config?.cos_bucket?.trim() || ''
   const configuredRegion = settingsValue.aigc3d_config?.cos_region?.trim() || ''
   const configuredKeyPrefix = settingsValue.aigc3d_config?.cos_key_prefix || DEFAULT_HY3D_COS_PREFIX
-  const effectiveApiRegion = configuredApiRegion || configuredRegion
   const effectiveKeyPrefix = normalizeHy3dCosPrefix(configuredKeyPrefix)
   const canClearCosPrefix = !!(
     configuredSecretId &&
@@ -682,10 +682,7 @@ const HunyuanSection: React.FC<HunyuanSectionProps> = ({ saveSettings, settingsV
                 placeholder="ap-guangzhou"
               />
               <Typography color="text.secondary" variant="caption">
-                {qt(
-                  'quickapp_api.api_region_hint',
-                  `留空时会先回退到 COS 地域。当前生效值：${effectiveApiRegion || '未配置'}`
-                )}
+                {qt('quickapp_api.api_region_hint', `留空时默认使用 ${DEFAULT_HY3D_API_REGION}。`)}
               </Typography>
             </Stack>
           </Box>

--- a/packages/app/src/renderer/src/pages/SettingsPage/PanelPlugin.tsx
+++ b/packages/app/src/renderer/src/pages/SettingsPage/PanelPlugin.tsx
@@ -668,18 +668,21 @@ const HunyuanSection: React.FC<HunyuanSectionProps> = ({ saveSettings, settingsV
                 value={settingsValue.aigc3d_config?.tencent_secret_id || ''}
                 onChange={(value) => saveSettings({ aigc3d_config: { tencent_secret_id: value } })}
                 placeholder="AKID..."
+                updateMode="change"
               />
               <InputText
                 label={qt('quickapp_api.tencent_secret_key', '腾讯云 SecretKey')}
                 value={settingsValue.aigc3d_config?.tencent_secret_key || ''}
                 onChange={(value) => saveSettings({ aigc3d_config: { tencent_secret_key: value } })}
                 placeholder={qt('quickapp_api.tencent_secret_key_placeholder', '请输入 SecretKey')}
+                updateMode="change"
               />
               <InputText
                 label={qt('quickapp_api.api_region', '腾讯云 API 地域')}
                 value={settingsValue.aigc3d_config?.api_region || ''}
                 onChange={(value) => saveSettings({ aigc3d_config: { api_region: value } })}
                 placeholder="ap-guangzhou"
+                updateMode="change"
               />
               <Typography color="text.secondary" variant="caption">
                 {qt('quickapp_api.api_region_hint', `留空时默认使用 ${DEFAULT_HY3D_API_REGION}。`)}
@@ -694,18 +697,21 @@ const HunyuanSection: React.FC<HunyuanSectionProps> = ({ saveSettings, settingsV
                 value={settingsValue.aigc3d_config?.cos_bucket || ''}
                 onChange={(value) => saveSettings({ aigc3d_config: { cos_bucket: value } })}
                 placeholder="examplebucket-1250000000"
+                updateMode="change"
               />
               <InputText
                 label={qt('quickapp_api.cos_region', 'COS 地域')}
                 value={settingsValue.aigc3d_config?.cos_region || ''}
                 onChange={(value) => saveSettings({ aigc3d_config: { cos_region: value } })}
                 placeholder="ap-guangzhou"
+                updateMode="change"
               />
               <InputText
                 label={qt('quickapp_api.cos_key_prefix', 'COS Key 前缀')}
                 value={settingsValue.aigc3d_config?.cos_key_prefix || 'magicpot/hunyuan3d'}
                 onChange={(value) => saveSettings({ aigc3d_config: { cos_key_prefix: value } })}
                 placeholder="magicpot/hunyuan3d"
+                updateMode="change"
               />
             </Stack>
           </Box>

--- a/packages/app/src/shared/locales/en-US/renderer.json
+++ b/packages/app/src/shared/locales/en-US/renderer.json
@@ -216,7 +216,7 @@
     "tencent_secret_key": "Tencent SecretKey",
     "tencent_secret_key_placeholder": "Please enter the SecretKey",
     "api_region": "Tencent API Region",
-    "api_region_hint": "When left empty, MagicPot falls back to the COS region.",
+    "api_region_hint": "When left empty, MagicPot uses ap-guangzhou.",
     "cos_bucket": "COS Bucket",
     "cos_region": "COS Region",
     "cos_key_prefix": "COS Key Prefix",

--- a/packages/app/src/shared/locales/en-US/renderer.json
+++ b/packages/app/src/shared/locales/en-US/renderer.json
@@ -216,7 +216,7 @@
     "tencent_secret_key": "Tencent SecretKey",
     "tencent_secret_key_placeholder": "Please enter the SecretKey",
     "api_region": "Tencent API Region",
-    "api_region_hint": "When left empty, MagicPot falls back to the COS region and then to ap-guangzhou.",
+    "api_region_hint": "When left empty, MagicPot falls back to the COS region.",
     "cos_bucket": "COS Bucket",
     "cos_region": "COS Region",
     "cos_key_prefix": "COS Key Prefix",

--- a/packages/app/src/shared/locales/zh-CN/renderer.json
+++ b/packages/app/src/shared/locales/zh-CN/renderer.json
@@ -783,7 +783,7 @@
     "tencent_secret_key": "腾讯云 SecretKey",
     "tencent_secret_key_placeholder": "请输入 SecretKey",
     "api_region": "腾讯云 API 地域",
-    "api_region_hint": "留空时会先回退到 COS 地域，再回退到 ap-guangzhou。",
+    "api_region_hint": "留空时会先回退到 COS 地域。",
     "cos_bucket": "COS Bucket",
     "cos_region": "COS Region",
     "cos_key_prefix": "COS Key 前缀",

--- a/packages/app/src/shared/locales/zh-CN/renderer.json
+++ b/packages/app/src/shared/locales/zh-CN/renderer.json
@@ -783,7 +783,7 @@
     "tencent_secret_key": "腾讯云 SecretKey",
     "tencent_secret_key_placeholder": "请输入 SecretKey",
     "api_region": "腾讯云 API 地域",
-    "api_region_hint": "留空时会先回退到 COS 地域。",
+    "api_region_hint": "留空时默认使用 ap-guangzhou。",
     "cos_bucket": "COS Bucket",
     "cos_region": "COS Region",
     "cos_key_prefix": "COS Key 前缀",

--- a/packages/runtime-assets/build/afterPack.js
+++ b/packages/runtime-assets/build/afterPack.js
@@ -24,6 +24,24 @@ function ensurePlaceholderFile(dirPath, fileName) {
   }
 }
 
+function pruneElectronLocales(unpackDir) {
+  const localesDir = path.join(unpackDir, 'locales')
+  if (!fs.existsSync(localesDir)) return
+
+  const keepLocales = new Set(['en-US.pak', 'zh-CN.pak', 'zh-TW.pak'])
+  let removed = 0
+  for (const fileName of fs.readdirSync(localesDir)) {
+    if (keepLocales.has(fileName)) continue
+    const localePath = path.join(localesDir, fileName)
+    if (fs.statSync(localePath).isFile()) {
+      fs.rmSync(localePath, { force: true })
+      removed += 1
+    }
+  }
+
+  console.log(`[afterPack] Pruned ${removed} Electron locale files`)
+}
+
 exports.default = async function (context) {
   // 只在 embedded 模式下运行
   if (process.env.PACKAGE_MODE !== 'embedded') return
@@ -101,4 +119,6 @@ exports.default = async function (context) {
     fs.copyFileSync(readmeSrc, readmeDst)
     console.log(`[afterPack] Copied README to root: ${readmeDst}`)
   }
+
+  pruneElectronLocales(unpackDir)
 }

--- a/scripts/comfy/embedded-sources.json
+++ b/scripts/comfy/embedded-sources.json
@@ -3,7 +3,7 @@
     {
       "name": "ComfyUI",
       "url": "https://github.com/Comfy-Org/ComfyUI.git",
-      "commit": "1b25f1289e6f48081b727083425791876ed0f39b",
+      "commit": "25757a53c93281e8e2462ced8795373f09e675bf",
       "relativePath": "vendor/comfyui/ComfyUI"
     },
     {

--- a/scripts/comfy/embedded-sources.json
+++ b/scripts/comfy/embedded-sources.json
@@ -3,7 +3,7 @@
     {
       "name": "ComfyUI",
       "url": "https://github.com/Comfy-Org/ComfyUI.git",
-      "commit": "6bcd8b96ab4650db6e834dcbb54357ebf72edfe6",
+      "commit": "1b25f1289e6f48081b727083425791876ed0f39b",
       "relativePath": "vendor/comfyui/ComfyUI"
     },
     {
@@ -40,7 +40,7 @@
     {
       "name": "ComfyUI-KJNodes",
       "url": "https://github.com/kijai/ComfyUI-KJNodes.git",
-      "commit": "9c3255f39cd2ea0ebf94a2016af4bd2e5d6eb91b",
+      "commit": "5fc6db6b39638a692f114c4bb5b6949f801b4efa",
       "relativePath": "vendor/comfyui/comfyui_data/custom_nodes/ComfyUI-KJNodes"
     },
     {

--- a/scripts/hunyuan3d/liveSmokeShared.test.ts
+++ b/scripts/hunyuan3d/liveSmokeShared.test.ts
@@ -51,7 +51,7 @@ describe('getRapidSmokeConfig', () => {
         secretId: 'sid',
         secretKey: 'skey'
       },
-      apiRegion: 'ap-shanghai',
+      apiRegion: 'ap-guangzhou',
       cos: {
         bucket: 'bucket-a',
         region: 'ap-shanghai',

--- a/scripts/hunyuan3d/liveSmokeShared.ts
+++ b/scripts/hunyuan3d/liveSmokeShared.ts
@@ -23,6 +23,8 @@ export type HunyuanProSmokeConfig = {
   modelName: string
 }
 
+const DEFAULT_HY3D_API_REGION = 'ap-guangzhou'
+
 const normalizeModeValue = (value: string): string =>
   String(value || '')
     .trim()
@@ -68,9 +70,7 @@ export const getRapidSmokeConfig = (config: Partial<Config>): HunyuanRapidSmokeC
 
   const secretId = String(aigc3dConfig?.tencent_secret_id || '').trim()
   const secretKey = String(aigc3dConfig?.tencent_secret_key || '').trim()
-  const apiRegion = String(
-    aigc3dConfig?.api_region || aigc3dConfig?.cos_region || 'ap-guangzhou'
-  ).trim()
+  const apiRegion = String(aigc3dConfig?.api_region || '').trim() || DEFAULT_HY3D_API_REGION
   const cosBucket = String(aigc3dConfig?.cos_bucket || '').trim()
   const cosRegion = String(aigc3dConfig?.cos_region || '').trim()
   const cosKeyPrefix = normalizeSmokePrefix(aigc3dConfig?.cos_key_prefix)

--- a/scripts/prepare-embedded-python.mjs
+++ b/scripts/prepare-embedded-python.mjs
@@ -34,6 +34,8 @@ const skipSmoke = process.env.EMBEDDED_SKIP_SMOKE === '1'
 const strictSmoke = process.env.EMBEDDED_STRICT_SMOKE !== '0'
 const dryRun = process.env.EMBEDDED_DRY_RUN === '1'
 const requirementsMode = process.env.EMBEDDED_REQUIREMENTS_MODE || 'prefer-fixed'
+const pruneRuntime = process.env.EMBEDDED_PRUNE_RUNTIME !== '0'
+const keepOnnxRuntimeGpu = process.env.EMBEDDED_KEEP_ONNXRUNTIME_GPU === '1'
 
 function assertInsideRepo(targetPath) {
   const resolved = path.resolve(targetPath)
@@ -53,6 +55,15 @@ function removeDir(dirPath) {
   if (fs.existsSync(resolved)) {
     fs.rmSync(resolved, { recursive: true, force: true })
   }
+}
+
+function assertInsideEmbeddedStage(targetPath) {
+  const resolved = path.resolve(targetPath)
+  const rootWithSep = stagingRoot.endsWith(path.sep) ? stagingRoot : `${stagingRoot}${path.sep}`
+  if (resolved !== stagingRoot && !resolved.startsWith(rootWithSep)) {
+    throw new Error(`Refusing to touch path outside embedded staging: ${resolved}`)
+  }
+  return resolved
 }
 
 function run(command, args, options = {}) {
@@ -242,6 +253,16 @@ function walkFiles(root, onFile) {
   }
 }
 
+function walkDirs(root, onDir) {
+  if (!fs.existsSync(root)) return
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue
+    const entryPath = path.join(root, entry.name)
+    onDir(entryPath, entry.name)
+    walkDirs(entryPath, onDir)
+  }
+}
+
 function getCustomNodeRequirementFiles() {
   const requirementFiles = []
   walkFiles(path.join(comfyDir, 'custom_nodes'), (filePath) => {
@@ -359,6 +380,122 @@ function removePythonCaches() {
   }
 }
 
+function directorySizeBytes(dirPath) {
+  let bytes = 0
+  walkFiles(dirPath, (filePath) => {
+    bytes += fs.statSync(filePath).size
+  })
+  return bytes
+}
+
+function removeRuntimePath(targetPath, stats) {
+  if (!fs.existsSync(targetPath)) return
+
+  const resolved = assertInsideEmbeddedStage(targetPath)
+  const fileStats = fs.statSync(resolved)
+  const bytes = fileStats.isDirectory() ? directorySizeBytes(resolved) : fileStats.size
+
+  fs.rmSync(resolved, { recursive: fileStats.isDirectory(), force: true })
+  stats.bytes += bytes
+  if (fileStats.isDirectory()) {
+    stats.directories += 1
+  } else {
+    stats.files += 1
+  }
+}
+
+function pruneEmbeddedRuntime() {
+  if (!pruneRuntime) {
+    console.log('[prepare-embedded-python] Skipping runtime pruning because EMBEDDED_PRUNE_RUNTIME=0')
+    return
+  }
+
+  const sitePackages = path.join(pythonDir, 'Lib', 'site-packages')
+  const stats = { bytes: 0, directories: 0, files: 0 }
+  const prunableExtensions = new Set(['.pyc', '.pyo', '.lib', '.pdb', '.exp', '.h', '.hpp', '.c', '.cpp', '.cu', '.map'])
+  const prunableDirectoryNames = new Set([
+    'benchmark',
+    'benchmarks',
+    'example',
+    'examples',
+    'test',
+    'tests'
+  ])
+
+  function shouldKeepPrunableDirectory(dirPath) {
+    const normalized = path.relative(sitePackages, dirPath).split(path.sep).join('/')
+    return normalized === 'torch/testing' || normalized.startsWith('torch/testing/')
+  }
+
+  for (const root of [pythonDir, comfyDir]) {
+    walkFiles(root, (filePath) => {
+      if (prunableExtensions.has(path.extname(filePath).toLowerCase())) {
+        removeRuntimePath(filePath, stats)
+      }
+    })
+  }
+
+  walkDirs(pythonDir, (dirPath, dirName) => {
+    if (dirName === '__pycache__' || dirName === '.pytest_cache') {
+      removeRuntimePath(dirPath, stats)
+    }
+  })
+
+  walkDirs(pythonDir, (dirPath, dirName) => {
+    if (dirName === 'include' || dirName === 'Include') {
+      removeRuntimePath(dirPath, stats)
+    }
+  })
+
+  for (const root of [pythonDir, comfyDir]) {
+    walkDirs(root, (dirPath, dirName) => {
+      if (prunableDirectoryNames.has(dirName) && !shouldKeepPrunableDirectory(dirPath)) {
+        removeRuntimePath(dirPath, stats)
+      }
+    })
+  }
+
+  if (fs.existsSync(sitePackages)) {
+    for (const entry of fs.readdirSync(sitePackages, { withFileTypes: true })) {
+      if (!entry.isDirectory() || !entry.name.startsWith('comfyui_workflow_templates_media_')) {
+        continue
+      }
+
+      removeRuntimePath(path.join(sitePackages, entry.name, 'templates'), stats)
+    }
+
+    const bitsAndBytesDir = path.join(sitePackages, 'bitsandbytes')
+    if (fs.existsSync(bitsAndBytesDir)) {
+      for (const entry of fs.readdirSync(bitsAndBytesDir, { withFileTypes: true })) {
+        if (entry.isFile() && /^libbitsandbytes_cuda.*\.dll$/i.test(entry.name)) {
+          removeRuntimePath(path.join(bitsAndBytesDir, entry.name), stats)
+        }
+      }
+    }
+
+    if (!keepOnnxRuntimeGpu) {
+      const onnxRuntimeCapiDir = path.join(sitePackages, 'onnxruntime', 'capi')
+      for (const fileName of ['onnxruntime_providers_cuda.dll', 'onnxruntime_providers_tensorrt.dll']) {
+        removeRuntimePath(path.join(onnxRuntimeCapiDir, fileName), stats)
+      }
+    }
+
+    for (const redundantPath of [
+      path.join(sitePackages, 'selenium', 'webdriver', 'common', 'linux'),
+      path.join(sitePackages, 'selenium', 'webdriver', 'common', 'macos'),
+      path.join(sitePackages, 'skimage', 'data'),
+      path.join(sitePackages, 'streamlit', 'static')
+    ]) {
+      removeRuntimePath(redundantPath, stats)
+    }
+  }
+
+  const removedMiB = (stats.bytes / 1024 / 1024).toFixed(1)
+  console.log(
+    `[prepare-embedded-python] Pruned ${removedMiB} MiB from embedded runtime (${stats.files} files, ${stats.directories} directories)`
+  )
+}
+
 function smokeTest() {
   if (skipSmoke) {
     console.log('[prepare-embedded-python] Skipping smoke test because EMBEDDED_SKIP_SMOKE=1')
@@ -378,8 +515,7 @@ function smokeTest() {
   if (strictSmoke) {
     const failurePatterns = [
       /\(IMPORT FAILED\)/i,
-      /^Cannot import .+custom nodes:/im,
-      /Traceback \(most recent call last\)/i
+      /^Cannot import .+custom nodes:/im
     ]
     const matched = failurePatterns.find((pattern) => pattern.test(output))
     if (matched) {
@@ -412,6 +548,8 @@ async function main() {
             `decorator==${decoratorVersion}`
           ],
           requirementsMode,
+          pruneRuntime,
+          keepOnnxRuntimeGpu,
           comfyRequirements: path.relative(stagingRoot, path.join(comfyDir, 'requirements.txt')),
           customNodeRequirements: getCustomNodeRequirementFiles().map((filePath) =>
             path.relative(stagingRoot, filePath)
@@ -438,6 +576,7 @@ async function main() {
   installTorchStack()
   installRequirements(constraintsPath)
   installSmokeRuntimeExtras()
+  pruneEmbeddedRuntime()
   removePythonCaches()
   smokeTest()
   removePythonCaches()

--- a/scripts/prepare-embedded-python.mjs
+++ b/scripts/prepare-embedded-python.mjs
@@ -37,6 +37,8 @@ const requirementsMode = process.env.EMBEDDED_REQUIREMENTS_MODE || 'prefer-fixed
 const pruneRuntime = process.env.EMBEDDED_PRUNE_RUNTIME !== '0'
 const keepOnnxRuntimeGpu = process.env.EMBEDDED_KEEP_ONNXRUNTIME_GPU === '1'
 const keepTorchMultiGpuSolver = process.env.EMBEDDED_KEEP_TORCH_MULTI_GPU_SOLVER === '1'
+const keepTorchNvrtcAlt = process.env.EMBEDDED_KEEP_TORCH_NVRTC_ALT === '1'
+const keepUvInstaller = process.env.EMBEDDED_KEEP_UV_INSTALLER === '1'
 
 function assertInsideRepo(targetPath) {
   const resolved = path.resolve(targetPath)
@@ -499,10 +501,27 @@ function pruneEmbeddedRuntime() {
     if (!keepTorchMultiGpuSolver) {
       removeRuntimePath(path.join(sitePackages, 'torch', 'lib', 'cusolverMg64_12.dll'), stats)
     }
+    if (!keepTorchNvrtcAlt) {
+      removeRuntimePath(path.join(sitePackages, 'torch', 'lib', 'nvrtc64_130_0.alt.dll'), stats)
+    }
+
+    if (!keepUvInstaller) {
+      for (const fileName of ['uv.exe', 'uvw.exe', 'uvx.exe']) {
+        removeRuntimePath(path.join(pythonDir, 'Scripts', fileName), stats)
+      }
+
+      removeRuntimePath(path.join(sitePackages, 'uv'), stats)
+      for (const entry of fs.readdirSync(sitePackages, { withFileTypes: true })) {
+        if (entry.isDirectory() && /^uv-.+\.dist-info$/i.test(entry.name)) {
+          removeRuntimePath(path.join(sitePackages, entry.name), stats)
+        }
+      }
+    }
 
     for (const redundantPath of [
       path.join(pythonDir, 'share', 'jupyter'),
       path.join(sitePackages, 'pydeck', 'nbextension'),
+      path.join(sitePackages, 'comfyui_frontend_package', 'static', 'assets', 'video-BvOHf4P9.mp4'),
       path.join(sitePackages, 'selenium', 'webdriver', 'common', 'linux'),
       path.join(sitePackages, 'selenium', 'webdriver', 'common', 'macos'),
       path.join(sitePackages, 'skimage', 'data'),
@@ -573,6 +592,8 @@ async function main() {
           pruneRuntime,
           keepOnnxRuntimeGpu,
           keepTorchMultiGpuSolver,
+          keepTorchNvrtcAlt,
+          keepUvInstaller,
           comfyRequirements: path.relative(stagingRoot, path.join(comfyDir, 'requirements.txt')),
           customNodeRequirements: getCustomNodeRequirementFiles().map((filePath) =>
             path.relative(stagingRoot, filePath)

--- a/scripts/prepare-embedded-python.mjs
+++ b/scripts/prepare-embedded-python.mjs
@@ -36,6 +36,7 @@ const dryRun = process.env.EMBEDDED_DRY_RUN === '1'
 const requirementsMode = process.env.EMBEDDED_REQUIREMENTS_MODE || 'prefer-fixed'
 const pruneRuntime = process.env.EMBEDDED_PRUNE_RUNTIME !== '0'
 const keepOnnxRuntimeGpu = process.env.EMBEDDED_KEEP_ONNXRUNTIME_GPU === '1'
+const keepTorchMultiGpuSolver = process.env.EMBEDDED_KEEP_TORCH_MULTI_GPU_SOLVER === '1'
 
 function assertInsideRepo(targetPath) {
   const resolved = path.resolve(targetPath)
@@ -412,7 +413,20 @@ function pruneEmbeddedRuntime() {
 
   const sitePackages = path.join(pythonDir, 'Lib', 'site-packages')
   const stats = { bytes: 0, directories: 0, files: 0 }
-  const prunableExtensions = new Set(['.pyc', '.pyo', '.lib', '.pdb', '.exp', '.h', '.hpp', '.c', '.cpp', '.cu', '.map'])
+  const prunableExtensions = new Set([
+    '.pyc',
+    '.pyo',
+    '.lib',
+    '.pdb',
+    '.exp',
+    '.h',
+    '.hpp',
+    '.c',
+    '.cpp',
+    '.cu',
+    '.map',
+    '.chm'
+  ])
   const prunableDirectoryNames = new Set([
     'benchmark',
     'benchmarks',
@@ -480,7 +494,15 @@ function pruneEmbeddedRuntime() {
       }
     }
 
+    removeRuntimePath(path.join(sitePackages, 'torch', 'bin', 'protoc.exe'), stats)
+    removeRuntimePath(path.join(sitePackages, 'torch', 'lib', 'nvperf_host.dll'), stats)
+    if (!keepTorchMultiGpuSolver) {
+      removeRuntimePath(path.join(sitePackages, 'torch', 'lib', 'cusolverMg64_12.dll'), stats)
+    }
+
     for (const redundantPath of [
+      path.join(pythonDir, 'share', 'jupyter'),
+      path.join(sitePackages, 'pydeck', 'nbextension'),
       path.join(sitePackages, 'selenium', 'webdriver', 'common', 'linux'),
       path.join(sitePackages, 'selenium', 'webdriver', 'common', 'macos'),
       path.join(sitePackages, 'skimage', 'data'),
@@ -550,6 +572,7 @@ async function main() {
           requirementsMode,
           pruneRuntime,
           keepOnnxRuntimeGpu,
+          keepTorchMultiGpuSolver,
           comfyRequirements: path.relative(stagingRoot, path.join(comfyDir, 'requirements.txt')),
           customNodeRequirements: getCustomNodeRequirementFiles().map((filePath) =>
             path.relative(stagingRoot, filePath)

--- a/scripts/prepare-embedded-staging.mjs
+++ b/scripts/prepare-embedded-staging.mjs
@@ -190,6 +190,41 @@ function validateStaging() {
   }
 }
 
+function applySeedVr2CpuDeviceFallback() {
+  const memoryManagerPath = path.join(
+    customNodesDst,
+    'ComfyUI-SeedVR2_VideoUpscaler',
+    'src',
+    'optimization',
+    'memory_manager.py'
+  )
+  if (!fs.existsSync(memoryManagerPath)) {
+    return
+  }
+
+  const source = fs.readFileSync(memoryManagerPath, 'utf8')
+  if (source.includes('SeedVR2 schema definitions index the first device')) {
+    return
+  }
+
+  const patched = source.replace(
+    /(\n\s*result\.extend\(devs\)\r?\n\s*)return result if result else \[\]/,
+    `$1if result:
+        return result
+
+    # SeedVR2 schema definitions index the first device during ComfyUI's quick test.
+    # GitHub-hosted Windows release runners are CPU-only, so keep registration alive.
+    return ["cpu"]`
+  )
+
+  if (patched === source) {
+    throw new Error(`Could not apply SeedVR2 CPU device fallback: ${memoryManagerPath}`)
+  }
+
+  fs.writeFileSync(memoryManagerPath, patched, 'utf8')
+  console.log('[prepare-embedded-staging] Applied SeedVR2 CPU device fallback')
+}
+
 function main() {
   if (!fs.existsSync(localComfyRepo)) {
     throw new Error(`Missing ComfyUI source repo: ${localComfyRepo}`)
@@ -204,6 +239,7 @@ function main() {
   cloneFreshComfySource()
   copyTree(customNodesSrc, customNodesDst, shouldSkipCustomNodeSource)
   removeRepositoryMetadata(customNodesDst)
+  applySeedVr2CpuDeviceFallback()
 
   validateStaging()
   console.log(`[prepare-embedded-staging] Wrote ${comfyDst}`)

--- a/scripts/release/bump-version.mjs
+++ b/scripts/release/bump-version.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url'
 const scriptDir = path.dirname(fileURLToPath(import.meta.url))
 const repoRoot = path.resolve(scriptDir, '..', '..')
 const packageJsonPath = path.join(repoRoot, 'package.json')
+const packageLockPath = path.join(repoRoot, 'package-lock.json')
 
 function parseVersion(version) {
   const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version)
@@ -41,6 +42,21 @@ function bumpMajorVersion(currentVersion) {
   return versionToString(versionArray)
 }
 
+function writeJsonFile(filePath, value) {
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8')
+}
+
+function updatePackageLockVersion(newVersion) {
+  const packageLock = JSON.parse(readFileSync(packageLockPath, 'utf8'))
+  packageLock.version = newVersion
+
+  if (packageLock.packages?.['']) {
+    packageLock.packages[''].version = newVersion
+  }
+
+  writeJsonFile(packageLockPath, packageLock)
+}
+
 function main(argv = process.argv.slice(2)) {
   const dryRun = argv.includes('--dry-run')
   const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'))
@@ -55,7 +71,8 @@ function main(argv = process.argv.slice(2)) {
   }
 
   packageJson.version = newVersion
-  writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`, 'utf8')
+  writeJsonFile(packageJsonPath, packageJson)
+  updatePackageLockVersion(newVersion)
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {


### PR DESCRIPTION
## What changed
- Restore `package.json` to the private workspace version `1.0.105`.
- Prepare the nightly version bump on `release/nightly`, then build and upload the release package from that unmerged release commit.
- Merge the release PR into `master` only after the release package is built and uploaded successfully.
- Retry an incomplete nightly release only when its version still matches the current `package.json` version.
- Switch the embedded Windows release archive from ZIP to a single `.7z` release asset.
- Fail release asset preparation with a clear error if the Windows archive exceeds GitHub's 2 GiB single-asset limit. The workflow does not split archives and does not upload checksum sidecar files.
- Prune redundant embedded runtime files before smoke testing: bytecode/caches, development headers/libs/maps/help files, examples/tests, non-Windows Selenium managers, sample data, Streamlit static UI assets, Jupyter/pydeck notebook assets, unused workflow template media, ComfyUI frontend demo video, bitsandbytes CUDA DLLs, ONNX Runtime CUDA/TensorRT providers, Torch profiling/protobuf tools, Torch's multi-GPU cuSOLVER DLL, Torch's NVRTC alt DLL, and the standalone `uv` installer by default.
- Prune unused Electron locale packs in `afterPack`, keeping English and Chinese locales.
- Keep `package-lock.json` root versions in sync when the release bump script updates `package.json`.
- Update About/source repository links to `https://github.com/MagicPotTeam/magicpot-open`.

## Why
The latest failed release had no usable Windows asset because GitHub rejected the embedded Windows archive for exceeding the single-asset 2 GiB limit. The old workflow also merged version bumps before publishing, so repeated workflow fixes caused the package version to drift ahead of the private workspace version.

With this flow, a failed package/release leaves `master` at the previous private version. The next run can retry the same next version instead of continuing to increment. The Windows embedded artifact is now small enough to upload as one `.7z` file in the tested package path.

## Impact
- ONNX Runtime keeps CPU execution available by default; CUDA/TensorRT provider DLLs are omitted to keep the release artifact under the GitHub asset limit. Set `EMBEDDED_KEEP_ONNXRUNTIME_GPU=1` if those providers need to be retained for a larger build.
- Torch CUDA remains available in local validation after pruning `cusolverMg64_12.dll` and `nvrtc64_130_0.alt.dll`; this removes the multi-GPU cuSOLVER DLL and the alternate NVRTC DLL while keeping the primary NVRTC DLL. Set `EMBEDDED_KEEP_TORCH_MULTI_GPU_SOLVER=1` or `EMBEDDED_KEEP_TORCH_NVRTC_ALT=1` if either needs to be retained for a larger build.
- The standalone `uv` installer is omitted because Windows ComfyUI-Manager defaults to pip and local validation confirms pip remains available. Set `EMBEDDED_KEEP_UV_INSTALLER=1` if the embedded runtime needs `python -m uv`.
- Removed workflow template media, Streamlit static assets, notebook/static assets, and the ComfyUI frontend demo video affect non-core/example UI flows, not ComfyUI startup or the packaged MagicPot app startup path.
- If a future `.7z` grows past GitHub's 2 GiB single-asset limit, the release job will fail instead of uploading split parts or sidecar files.

## Validation
- `npm run prepare:embedded-python:dry-run`
- `node --check scripts/prepare-embedded-python.mjs`
- ComfyUI quick smoke with the pruned embedded runtime: no `(IMPORT FAILED)` and no `Cannot import ... custom nodes`
- Pip sanity after pruning `uv`: `python -m pip --version` succeeds and `importlib.util.find_spec('uv')` returns `None`
- Torch CUDA sanity after pruning `cusolverMg64_12.dll` and `nvrtc64_130_0.alt.dll`: `torch.cuda.is_available()` is true and a small CUDA matrix multiply succeeds
- `npx cross-env PACKAGE_MODE=embedded npm run package:win -- --publish never`
- Final local archive: `dist/embedded/magicpot-embedded-1.0.105-win.7z` = `2,022,915,795` bytes, about `118.8 MiB` below GitHub's `2,147,483,648` byte asset limit
- `node_modules/7zip-bin/win/x64/7za.exe t dist/embedded/magicpot-embedded-1.0.105-win.7z` reports `Everything is Ok`
- `git diff --check -- .github/workflows/call-release.yml config/electron/electron-builder.config.js packages/runtime-assets/build/afterPack.js scripts/prepare-embedded-python.mjs`
- YAML parse for `.github/workflows/call-release.yml`