### PR TITLE
[codex] Add quick app image clear and model download progress

### DIFF
--- a/packages/app/src/main/api/svcShellImpl.test.ts
+++ b/packages/app/src/main/api/svcShellImpl.test.ts
@@ -3,6 +3,7 @@ import os from 'os'
 import path from 'path'
 import { describe, expect, it, vi, afterEach } from 'vitest'
 
+import { DownloadFileProgressEvent } from '@shared/api/svcShell'
 import { ShellSvcImpl } from './svcShellImpl'
 
 function makeStats({
@@ -106,6 +107,52 @@ describe('ShellSvcImpl', () => {
 
     expect(result.alreadyExists).toBe(false)
     expect(fs.readFileSync(result.fullPath)).toEqual(Buffer.from(bytes))
+
+    await fs.promises.rm(tempDir, { recursive: true, force: true })
+  })
+
+  it('emits download progress while streaming files', async () => {
+    const tempDir = await makeTempDir('magicpot-shell-download-progress')
+    const bytes = new Uint8Array([1, 2, 3, 4, 5])
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(bytes, {
+            status: 200,
+            statusText: 'OK',
+            headers: { 'content-length': String(bytes.byteLength) }
+          })
+      )
+    )
+
+    const events: DownloadFileProgressEvent[] = []
+    const svc = new ShellSvcImpl()
+    await svc.downloadFileWithProgress(
+      {
+        url: 'https://example.com/model.bin',
+        outputDir: tempDir,
+        filename: 'model.bin'
+      },
+      { onData: (event) => events.push(event) }
+    )
+
+    const progressEvents = events.filter((event) => event.type === 'progress')
+    const completeEvent = events.find((event) => event.type === 'complete')
+
+    expect(progressEvents.length).toBeGreaterThan(0)
+    expect(progressEvents.at(-1)).toMatchObject({
+      downloadedBytes: bytes.byteLength,
+      totalBytes: bytes.byteLength,
+      percent: 100
+    })
+    expect(progressEvents.at(-1)?.bytesPerSecond).toBeGreaterThan(0)
+    expect(completeEvent).toMatchObject({
+      type: 'complete',
+      result: {
+        alreadyExists: false
+      }
+    })
 
     await fs.promises.rm(tempDir, { recursive: true, force: true })
   })

--- a/packages/app/src/main/api/svcShellImpl.ts
+++ b/packages/app/src/main/api/svcShellImpl.ts
@@ -1,5 +1,6 @@
 import {
   DownloadFileReq,
+  DownloadFileProgressEvent,
   DownloadFileResp,
   EnsureDirectoryReq,
   EnsureDirectoryResp,
@@ -7,12 +8,13 @@ import {
   InstallGitRepositoryResp,
   ShellSvc
 } from '@shared/api/svcShell'
+import { ServerStreaming } from '@shared/api/apiUtils/streaming'
 import { spawn } from 'child_process'
 import { shell } from 'electron'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
-import { Readable } from 'stream'
+import { Readable, Transform } from 'stream'
 import { pipeline } from 'stream/promises'
 
 function isLocallyAvailable(filePath: string): boolean {
@@ -48,6 +50,16 @@ function trimErrorOutput(value: string): string {
     return trimmed
   }
   return `${trimmed.slice(0, 1000)}...`
+}
+
+function getContentLength(headers: Headers): number | undefined {
+  const value = headers.get('content-length')
+  if (!value) {
+    return undefined
+  }
+
+  const parsed = Number(value)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined
 }
 
 function runGitClone(url: string, targetDir: string): Promise<void> {
@@ -99,7 +111,10 @@ export class ShellSvcImpl implements ShellSvc {
     await fs.promises.mkdir(resolvedPath, { recursive: true })
     return { path: resolvedPath }
   }
-  downloadFile = async (req: DownloadFileReq): Promise<DownloadFileResp> => {
+  private downloadFileInternal = async (
+    req: DownloadFileReq,
+    onProgress?: (event: Extract<DownloadFileProgressEvent, { type: 'progress' }>) => void
+  ): Promise<DownloadFileResp> => {
     const url = requireHttpUrl(req.url)
     const filename = sanitizePathSegment(req.filename)
     if (!filename) {
@@ -122,12 +137,52 @@ export class ShellSvcImpl implements ShellSvc {
       throw new Error('Download failed: empty response body')
     }
 
+    const totalBytes = getContentLength(response.headers)
+    let downloadedBytes = 0
+    const startTime = Date.now()
+    let lastProgressAt = 0
+    const emitProgress = (force = false) => {
+      if (!onProgress) {
+        return
+      }
+
+      const now = Date.now()
+      if (!force && now - lastProgressAt < 250) {
+        return
+      }
+
+      lastProgressAt = now
+      const elapsedSeconds = Math.max((now - startTime) / 1000, 0.001)
+      onProgress({
+        type: 'progress',
+        downloadedBytes,
+        ...(totalBytes ? { totalBytes } : {}),
+        ...(totalBytes
+          ? { percent: Math.min(100, Math.round((downloadedBytes / totalBytes) * 100)) }
+          : {}),
+        bytesPerSecond: Math.round(downloadedBytes / elapsedSeconds)
+      })
+    }
+
     const tempPath = `${fullPath}.download-${process.pid}-${Date.now()}`
     try {
+      emitProgress(true)
       await pipeline(
         Readable.fromWeb(response.body as Parameters<typeof Readable.fromWeb>[0]),
+        new Transform({
+          transform(
+            chunk: Buffer,
+            _encoding: BufferEncoding,
+            callback: (error?: Error | null, data?: Buffer) => void
+          ) {
+            downloadedBytes += chunk.length
+            emitProgress()
+            callback(null, chunk)
+          }
+        }),
         fs.createWriteStream(tempPath)
       )
+      emitProgress(true)
       await fs.promises.rename(tempPath, fullPath)
     } catch (error) {
       await fs.promises.rm(tempPath, { force: true }).catch(() => undefined)
@@ -135,6 +190,16 @@ export class ShellSvcImpl implements ShellSvc {
     }
 
     return { fullPath, alreadyExists: false }
+  }
+  downloadFile = async (req: DownloadFileReq): Promise<DownloadFileResp> => {
+    return this.downloadFileInternal(req)
+  }
+  downloadFileWithProgress = async (
+    req: DownloadFileReq,
+    resp: ServerStreaming<DownloadFileProgressEvent>
+  ): Promise<void> => {
+    const result = await this.downloadFileInternal(req, (event) => resp.onData(event))
+    resp.onData({ type: 'complete', result })
   }
   installGitRepository = async (
     req: InstallGitRepositoryReq

--- a/packages/app/src/renderer/src/components/inputs/BaseInputComfyImage.test.tsx
+++ b/packages/app/src/renderer/src/components/inputs/BaseInputComfyImage.test.tsx
@@ -248,6 +248,54 @@ describe('BaseInputComfyImage', () => {
     })
   })
 
+  it('calls onClear from the preview delete button', () => {
+    const onClear = vi.fn()
+
+    render(
+      <BaseInputComfyImage
+        label="Image"
+        internalValue="demo.png"
+        isLoading={false}
+        previewUrl="blob:preview"
+        doUpload={vi.fn()}
+        onClear={onClear}
+        placeholder="Drop an image"
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'input.image.clear' }))
+
+    expect(onClear).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears the paste-target highlight when deleting the preview', () => {
+    const ControlledInput = () => {
+      const [previewUrl, setPreviewUrl] = React.useState<string | null>('blob:preview')
+      return (
+        <BaseInputComfyImage
+          label="Image"
+          internalValue={previewUrl ? 'demo.png' : ''}
+          isLoading={false}
+          previewUrl={previewUrl}
+          doUpload={vi.fn()}
+          onClear={() => setPreviewUrl(null)}
+          placeholder="Drop an image"
+        />
+      )
+    }
+
+    render(<ControlledInput />)
+
+    const dropZone = screen.getByRole('img', { name: 'demo.png' }).closest('[tabindex="0"]')
+    expect(dropZone).toBeTruthy()
+    fireEvent.mouseEnter(dropZone as Element)
+
+    fireEvent.click(screen.getByRole('button', { name: 'input.image.clear' }))
+
+    expect(screen.getByText('Drop an image')).toBeInTheDocument()
+    expect(screen.queryByText('input.image.paste_hint')).not.toBeInTheDocument()
+  })
+
   it('uploads a pasted image while the load area is hovered', async () => {
     const doUpload = vi.fn().mockResolvedValue(undefined)
 

--- a/packages/app/src/renderer/src/components/inputs/BaseInputComfyImage.tsx
+++ b/packages/app/src/renderer/src/components/inputs/BaseInputComfyImage.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
-import { Box, IconButton, Typography } from '@mui/material'
-import { UploadOutlined } from '@mui/icons-material'
+import { Box, IconButton, Tooltip, Typography } from '@mui/material'
+import { DeleteOutline, UploadOutlined } from '@mui/icons-material'
 import { useTranslation } from 'react-i18next'
 import { useMessage } from '@renderer/hooks/useMessage'
 import {
@@ -23,6 +23,7 @@ type BaseInputComfyImageProps = {
   doUpload: (file: File) => Promise<void>
   placeholder: string
   buttonSlot?: React.ReactNode
+  onClear?: () => void
 }
 
 const isPasteShortcut = (
@@ -49,6 +50,7 @@ const BaseInputComfyImage: React.FC<BaseInputComfyImageProps> = ({
   placeholder,
   Icon,
   buttonSlot,
+  onClear,
   doUpload
 }) => {
   const { t } = useTranslation()
@@ -89,7 +91,19 @@ const BaseInputComfyImage: React.FC<BaseInputComfyImageProps> = ({
   }, [])
 
   const handleSelectClick = () => {
+    if (isLoading) return
     fileInputRef.current?.click()
+  }
+
+  const handleClearClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault()
+    event.stopPropagation()
+    if (isLoading) return
+    setIsDragging(false)
+    setIsHovered(false)
+    setIsKeyboardFocused(false)
+    containerRef.current?.blur()
+    onClear?.()
   }
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -269,18 +283,46 @@ const BaseInputComfyImage: React.FC<BaseInputComfyImageProps> = ({
         }}
       >
         {previewUrl ? (
-          <img
-            src={previewUrl}
-            alt={internalValue}
-            style={{
-              display: 'block',
-              maxWidth: '100%',
-              maxHeight: '100%',
-              width: 'auto',
-              height: 'auto',
-              objectFit: 'contain'
-            }}
-          />
+          <>
+            {onClear && (
+              <Tooltip title={t('input.image.clear')}>
+                <IconButton
+                  aria-label={t('input.image.clear')}
+                  size="small"
+                  onClick={handleClearClick}
+                  disabled={isLoading}
+                  sx={{
+                    position: 'absolute',
+                    top: 6,
+                    right: 6,
+                    zIndex: 1,
+                    width: 26,
+                    height: 26,
+                    bgcolor: 'rgba(0,0,0,0.6)',
+                    color: '#ff4d4f',
+                    '&:hover': {
+                      bgcolor: 'rgba(0,0,0,0.8)',
+                      color: '#ff4d4f'
+                    }
+                  }}
+                >
+                  <DeleteOutline sx={{ fontSize: 15 }} />
+                </IconButton>
+              </Tooltip>
+            )}
+            <img
+              src={previewUrl}
+              alt={internalValue}
+              style={{
+                display: 'block',
+                maxWidth: '100%',
+                maxHeight: '100%',
+                width: 'auto',
+                height: 'auto',
+                objectFit: 'contain'
+              }}
+            />
+          </>
         ) : (
           <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 0.5 }}>
             <IconButton color="default" disabled={isLoading}>

--- a/packages/app/src/renderer/src/components/inputs/InputComfyImage.test.tsx
+++ b/packages/app/src/renderer/src/components/inputs/InputComfyImage.test.tsx
@@ -1,11 +1,30 @@
 import React from 'react'
 import { render, fireEvent, waitFor, screen } from '@testing-library/react'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
-import InputComfyImage from './InputComfyImage'
 import {
   QAPP_IMAGE_DRAG_MIME,
   UNSUPPORTED_INTERNAL_FILE_DROP_MESSAGE
 } from '@renderer/utils/droppedImageUtils'
+
+const apiMocks = vi.hoisted(() => ({
+  getView: vi.fn(),
+  uploadImage: vi.fn(),
+  loadImageFromPhotoshop: vi.fn()
+}))
+
+vi.mock('@renderer/utils/windowUtils', () => ({
+  api: () => ({
+    svcComfy: {
+      getView: apiMocks.getView,
+      uploadImage: apiMocks.uploadImage
+    },
+    svcPhotoshop: {
+      loadImageFromPhotoshop: apiMocks.loadImageFromPhotoshop
+    }
+  })
+}))
+
+import InputComfyImage from './InputComfyImage'
 
 const notifyErrorMock = vi.fn()
 const notifySuccessMock = vi.fn()
@@ -34,6 +53,9 @@ describe('InputComfyImage', () => {
   beforeEach(() => {
     notifyErrorMock.mockReset()
     notifySuccessMock.mockReset()
+    apiMocks.getView.mockReset()
+    apiMocks.uploadImage.mockReset()
+    apiMocks.loadImageFromPhotoshop.mockReset()
   })
 
   it('rejects unsupported external files with a clear error from the Quick App image-input path', async () => {
@@ -94,5 +116,51 @@ describe('InputComfyImage', () => {
     })
 
     expect(notifyErrorMock.mock.calls[0][0]).toBe(UNSUPPORTED_INTERNAL_FILE_DROP_MESSAGE)
+  })
+
+  it('clears a selected image from the preview delete button', async () => {
+    const createObjectURLMock = vi.fn(() => 'blob:preview')
+    const revokeObjectURLMock = vi.fn()
+
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: createObjectURLMock
+    })
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: revokeObjectURLMock
+    })
+
+    apiMocks.getView.mockResolvedValue({ result: new Uint8Array([1, 2, 3]) })
+    const changes: string[] = []
+
+    const ControlledInput = () => {
+      const [value, setValue] = React.useState('demo.png')
+      return (
+        <InputComfyImage
+          label="Quick App Image"
+          value={value}
+          onChange={(nextValue) => {
+            changes.push(nextValue)
+            setValue(nextValue)
+          }}
+          placeholder="Drop an image"
+        />
+      )
+    }
+
+    render(<ControlledInput />)
+
+    expect(await screen.findByRole('img', { name: 'demo.png' })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'input.image.clear' }))
+
+    await waitFor(() => {
+      expect(changes).toContain('')
+    })
+
+    expect(screen.queryByRole('img', { name: 'demo.png' })).not.toBeInTheDocument()
+    expect(screen.getByText('Drop an image')).toBeInTheDocument()
+    expect(revokeObjectURLMock).toHaveBeenCalledWith('blob:preview')
   })
 })

--- a/packages/app/src/renderer/src/components/inputs/InputComfyImage.tsx
+++ b/packages/app/src/renderer/src/components/inputs/InputComfyImage.tsx
@@ -97,11 +97,23 @@ const InputComfyImage: React.FC<InputComfyImageProps> = ({
     }
   }
 
+  const handleClear = useCallback(() => {
+    setInternalValue('')
+    onChange('')
+    setPreviewUrl((prev) => {
+      if (prev) URL.revokeObjectURL(prev)
+      return null
+    })
+  }, [onChange])
+
   useEffect(() => {
     let active = true
     ;(async () => {
       if (!internalValue) {
-        setPreviewUrl(null)
+        setPreviewUrl((prev) => {
+          if (prev) URL.revokeObjectURL(prev)
+          return null
+        })
         return
       }
       try {
@@ -119,7 +131,10 @@ const InputComfyImage: React.FC<InputComfyImageProps> = ({
         if (active) {
           setInternalValue('')
           onChange('')
-          setPreviewUrl(null)
+          setPreviewUrl((prev) => {
+            if (prev) URL.revokeObjectURL(prev)
+            return null
+          })
         }
       }
     })()
@@ -137,6 +152,7 @@ const InputComfyImage: React.FC<InputComfyImageProps> = ({
       isLoading={isLoading}
       previewUrl={previewUrl}
       doUpload={doUpload}
+      onClear={handleClear}
       buttonSlot={
         <Button
           size="small"

--- a/packages/app/src/renderer/src/components/inputs/InputComfyImageMask.tsx
+++ b/packages/app/src/renderer/src/components/inputs/InputComfyImageMask.tsx
@@ -94,11 +94,24 @@ const InputComfyImageMask: React.FC<InputComfyImageMaskProps> = ({
     return image
   }, [internalValue])
 
+  const handleClear = useCallback(() => {
+    setModalOpen(false)
+    setInternalValue('')
+    onChange('')
+    setPreviewUrl((prev) => {
+      if (prev) URL.revokeObjectURL(prev)
+      return null
+    })
+  }, [onChange])
+
   useEffect(() => {
     let active = true
     ;(async () => {
       if (!internalValue) {
-        setPreviewUrl(null)
+        setPreviewUrl((prev) => {
+          if (prev) URL.revokeObjectURL(prev)
+          return null
+        })
         return
       }
       try {
@@ -152,6 +165,7 @@ const InputComfyImageMask: React.FC<InputComfyImageMaskProps> = ({
       isLoading={isLoading}
       previewUrl={previewUrl}
       doUpload={doUpload}
+      onClear={handleClear}
       buttonSlot={
         previewUrl && (
           <ModalLayout buttonText="Open Mask Editor" open={modalOpen} setOpen={setModalOpen}>

--- a/packages/app/src/renderer/src/pages/QuickAppPage/components/CalloutMissingModels.tsx
+++ b/packages/app/src/renderer/src/pages/QuickAppPage/components/CalloutMissingModels.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, CircularProgress, Stack, Typography } from '@mui/material'
+import { Box, Button, Stack, Typography } from '@mui/material'
 import {
   CloudDownload as CloudDownloadIcon,
   FolderOpen as FolderOpenIcon,
@@ -7,6 +7,7 @@ import {
 import { useConfig } from '@renderer/hooks/useConfig'
 import { useMessage } from '@renderer/hooks/useMessage'
 import { api } from '@renderer/utils/windowUtils'
+import { DownloadFileProgressEvent, DownloadFileResp } from '@shared/api/svcShell'
 import { QAppRequiredModel } from '@shared/qApp/cfgTypes'
 import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -14,6 +15,33 @@ import { checkRequiredModels, type MissingRequiredModel } from '../utils/qAppDep
 
 type CalloutMissingModelsProps = {
   requiredModels?: QAppRequiredModel[]
+}
+
+type ModelDownloadProgress = Extract<DownloadFileProgressEvent, { type: 'progress' }>
+
+const formatBytes = (bytes: number) => {
+  if (!Number.isFinite(bytes) || bytes <= 0) {
+    return '0 B'
+  }
+
+  const units = ['B', 'KB', 'MB', 'GB']
+  let value = bytes
+  let unitIndex = 0
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024
+    unitIndex += 1
+  }
+
+  const digits = unitIndex === 0 || value >= 10 ? 0 : 1
+  return `${value.toFixed(digits)} ${units[unitIndex]}`
+}
+
+const formatDownloadButtonText = (progress: ModelDownloadProgress, downloadingLabel: string) => {
+  const speed = `${formatBytes(progress.bytesPerSecond)}/s`
+  if (progress.percent !== undefined) {
+    return `${progress.percent}% | ${speed}`
+  }
+  return `${downloadingLabel} | ${speed}`
 }
 
 export const CalloutMissingModels = ({ requiredModels }: CalloutMissingModelsProps) => {
@@ -25,6 +53,9 @@ export const CalloutMissingModels = ({ requiredModels }: CalloutMissingModelsPro
   const [missingModels, setMissingModels] = useState<MissingRequiredModel[]>([])
   const busyModelKeysRef = useRef<Set<string>>(new Set())
   const [busyModelKeys, setBusyModelKeys] = useState<Set<string>>(new Set())
+  const [downloadProgressByKey, setDownloadProgressByKey] = useState<
+    Record<string, ModelDownloadProgress>
+  >({})
 
   useEffect(() => {
     if (!requiredModels || requiredModels.length === 0) {
@@ -81,6 +112,18 @@ export const CalloutMissingModels = ({ requiredModels }: CalloutMissingModelsPro
     setBusyModelKeys(next)
   }
 
+  const setDownloadProgress = (key: string, progress: ModelDownloadProgress) => {
+    setDownloadProgressByKey((prev) => ({ ...prev, [key]: progress }))
+  }
+
+  const clearDownloadProgress = (key: string) => {
+    setDownloadProgressByKey((prev) => {
+      const next = { ...prev }
+      delete next[key]
+      return next
+    })
+  }
+
   const openModelDir = async (item: MissingRequiredModel) => {
     const key = getModelKey(item)
     if (!addBusyModelKey(key)) {
@@ -105,11 +148,26 @@ export const CalloutMissingModels = ({ requiredModels }: CalloutMissingModelsPro
       return
     }
     try {
-      const result = await api().svcShell.downloadFile({
-        url: item.model.url,
-        outputDir: item.dirPath,
-        filename: item.model.name
-      })
+      let result: DownloadFileResp | undefined
+      await api().svcShell.downloadFileWithProgress(
+        {
+          url: item.model.url,
+          outputDir: item.dirPath,
+          filename: item.model.name
+        },
+        {
+          onData: (event) => {
+            if (event.type === 'progress') {
+              setDownloadProgress(key, event)
+            } else {
+              result = event.result
+            }
+          }
+        }
+      )
+      if (!result) {
+        throw new Error('Download completed without a result')
+      }
       notifySuccess(
         result.alreadyExists
           ? t('qapp.callout.model_exists')
@@ -119,6 +177,7 @@ export const CalloutMissingModels = ({ requiredModels }: CalloutMissingModelsPro
     } catch (error) {
       notifyError(t('qapp.callout.model_download_failed', { error: String(error) }))
     } finally {
+      clearDownloadProgress(key)
       removeBusyModelKey(key)
     }
   }
@@ -155,6 +214,11 @@ export const CalloutMissingModels = ({ requiredModels }: CalloutMissingModelsPro
           const { model, displayDir } = item
           const key = getModelKey(item)
           const busy = busyModelKeys.has(key)
+          const downloadProgress = downloadProgressByKey[key]
+          const progressWidth =
+            downloadProgress?.percent === undefined
+              ? '100%'
+              : `${Math.max(4, Math.min(100, downloadProgress.percent))}%`
           const urlFileName = getUrlFileName(model.url)
           const needsRename = urlFileName && urlFileName !== model.name
 
@@ -196,13 +260,68 @@ export const CalloutMissingModels = ({ requiredModels }: CalloutMissingModelsPro
                 <Button
                   size="small"
                   variant="contained"
-                  startIcon={
-                    busy ? <CircularProgress size={14} color="inherit" /> : <CloudDownloadIcon />
-                  }
+                  startIcon={downloadProgress ? undefined : <CloudDownloadIcon />}
                   disabled={busy}
                   onClick={() => void downloadModel(item)}
+                  sx={{
+                    minWidth: downloadProgress ? 156 : undefined,
+                    overflow: 'hidden',
+                    position: 'relative',
+                    ...(downloadProgress
+                      ? {
+                          '&.Mui-disabled': {
+                            bgcolor: '#6f5cff',
+                            color: '#fff'
+                          },
+                          '&::before': {
+                            content: '""',
+                            position: 'absolute',
+                            left: 0,
+                            top: 0,
+                            bottom: 0,
+                            width: progressWidth,
+                            bgcolor:
+                              downloadProgress.percent === undefined
+                                ? 'rgba(255,255,255,0.18)'
+                                : 'rgba(255,255,255,0.24)',
+                            transition: 'width 0.2s ease'
+                          },
+                          ...(downloadProgress.percent === undefined
+                            ? {
+                                '&::after': {
+                                  animation: 'qapp-download-progress-sweep 1.2s linear infinite',
+                                  bgcolor: 'rgba(255,255,255,0.12)',
+                                  content: '""',
+                                  inset: 0,
+                                  position: 'absolute',
+                                  transform: 'translateX(-100%)',
+                                  width: '60%'
+                                },
+                                '@keyframes qapp-download-progress-sweep': {
+                                  '0%': { transform: 'translateX(-100%)' },
+                                  '100%': { transform: 'translateX(220%)' }
+                                }
+                              }
+                            : {})
+                        }
+                      : {})
+                  }}
                 >
-                  {t('qapp.callout.download')}
+                  {downloadProgress ? (
+                    <Box
+                      component="span"
+                      sx={{
+                        fontVariantNumeric: 'tabular-nums',
+                        position: 'relative',
+                        whiteSpace: 'nowrap',
+                        zIndex: 1
+                      }}
+                    >
+                      {formatDownloadButtonText(downloadProgress, t('qapp.callout.downloading'))}
+                    </Box>
+                  ) : (
+                    t('qapp.callout.download')
+                  )}
                 </Button>
                 <Button
                   size="small"

--- a/packages/app/src/shared/api/svcShell.ts
+++ b/packages/app/src/shared/api/svcShell.ts
@@ -4,6 +4,7 @@
  */
 
 import { ServiceDefSheet } from './apiUtils/serviceDefSheet'
+import { ServerStreaming } from './apiUtils/streaming'
 
 export type DownloadFileReq = {
   url: string
@@ -15,6 +16,19 @@ export type DownloadFileResp = {
   fullPath: string
   alreadyExists: boolean
 }
+
+export type DownloadFileProgressEvent =
+  | {
+      type: 'progress'
+      downloadedBytes: number
+      totalBytes?: number
+      percent?: number
+      bytesPerSecond: number
+    }
+  | {
+      type: 'complete'
+      result: DownloadFileResp
+    }
 
 export type EnsureDirectoryReq = {
   path: string
@@ -44,6 +58,10 @@ export type ShellSvc = {
   fileExistsBatch(paths: string[]): Promise<boolean[]>
   ensureDirectory(req: EnsureDirectoryReq): Promise<EnsureDirectoryResp>
   downloadFile(req: DownloadFileReq): Promise<DownloadFileResp>
+  downloadFileWithProgress(
+    req: DownloadFileReq,
+    resp: ServerStreaming<DownloadFileProgressEvent>
+  ): Promise<void>
   installGitRepository(req: InstallGitRepositoryReq): Promise<InstallGitRepositoryResp>
 }
 
@@ -71,6 +89,9 @@ export const shellSvcDef: ServiceDefSheet<ShellSvc> = {
   },
   downloadFile: {
     type: 'unary'
+  },
+  downloadFileWithProgress: {
+    type: 'serverStreaming'
   },
   installGitRepository: {
     type: 'unary'

--- a/packages/app/src/shared/locales/en-US/renderer.json
+++ b/packages/app/src/shared/locales/en-US/renderer.json
@@ -834,7 +834,8 @@
       "photoshop_loaded": "Loaded image from the Photoshop clipboard",
       "photoshop_load_failed_log": "Failed to load image from Photoshop:",
       "load_failed_short": "Load failed: {{error}}",
-      "load_from_photoshop": "Load from Photoshop"
+      "load_from_photoshop": "Load from Photoshop",
+      "clear": "Delete image"
     }
   },
   "project": {

--- a/packages/app/src/shared/locales/en-US/renderer.json
+++ b/packages/app/src/shared/locales/en-US/renderer.json
@@ -563,6 +563,7 @@
       "missing_models_subtitle": "Missing Model Files",
       "put_to": "Place in: {{dir}}",
       "download": "Download",
+      "downloading": "Downloading",
       "open_directory": "Open Folder",
       "open_link": "Open Link",
       "model_exists": "Model file already exists",

--- a/packages/app/src/shared/locales/zh-CN/renderer.json
+++ b/packages/app/src/shared/locales/zh-CN/renderer.json
@@ -466,6 +466,7 @@
       "missing_models_subtitle": "Missing Model Files",
       "put_to": "放到: {{dir}}",
       "download": "下载",
+      "downloading": "\u4e0b\u8f7d\u4e2d",
       "open_directory": "打开目录",
       "open_link": "打开链接",
       "model_exists": "模型文件已存在",

--- a/packages/app/src/shared/locales/zh-CN/renderer.json
+++ b/packages/app/src/shared/locales/zh-CN/renderer.json
@@ -640,7 +640,8 @@
       "photoshop_loaded": "已从 Photoshop 加载图像",
       "photoshop_load_failed_log": "从 Photoshop 加载图像失败：",
       "load_failed_short": "加载失败：{{error}}",
-      "load_from_photoshop": "从 Photoshop 加载"
+      "load_from_photoshop": "从 Photoshop 加载",
+      "clear": "\u5220\u9664\u56fe\u50cf"
     }
   },
   "project": {


### PR DESCRIPTION
﻿## Summary
- Add a 3D-style delete button to shared Comfy image preview inputs and reset image/mask quick app values cleanly.
- Add streaming shell downloads so qApp required model downloads can report bytes, percent, and transfer speed.
- Replace the model download spinner with an in-button progress bar and speed text, with independent state per concurrent download.

## Impact
Users can remove selected image inputs without reloading the panel, and large required model downloads now show useful progress directly in each download button.

## Validation
- `npx vitest run --config config/vitest/vitest.web.config.mjs packages/app/src/renderer/src/components/inputs/BaseInputComfyImage.test.tsx packages/app/src/renderer/src/components/inputs/InputComfyImage.test.tsx`
- `npm run check:i18n`
- `npm run check:text-encoding`
- `npm run typecheck:web`
- `npm run typecheck:node`
- `npm run test:node -- packages/app/src/main/api/svcShellImpl.test.ts`
