### PR TITLE
[codex] Fix Hono audit override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10229,9 +10229,9 @@
       "license": "MIT"
     },
     "node_modules/hono": {
-      "version": "4.12.17",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.17.tgz",
-      "integrity": "sha512-FbJJNb/XgX7YW0hX/V8w5oYLztKEsRLykCMZWt1WdLtsfjzMvmoqWBA4H4t5norinq8/rh20oiZYr+WSl4UzAQ==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
       "peer": true,
       "engines": {

--- a/package.json
+++ b/package.json
@@ -208,7 +208,7 @@
     },
     "fast-xml-parser": "5.7.3",
     "follow-redirects": "1.16.0",
-    "hono": "4.12.17",
+    "hono": "4.12.18",
     "ip-address": "10.2.0",
     "postcss": "8.5.14",
     "protobufjs": "7.5.6"


### PR DESCRIPTION
## Summary
- Update the Hono override from `4.12.17` to `4.12.18`.
- Refresh `package-lock.json` so production audit no longer flags the Hono advisories.

## Validation
- `npm audit --omit=dev`
- `npm run check:text-encoding -- package.json package-lock.json`
