### PR TITLE
[codex] Strip ComfyUI frontend-only nodes

### DIFF
--- a/packages/app/src/main/api/svcComfyImpl.test.ts
+++ b/packages/app/src/main/api/svcComfyImpl.test.ts
@@ -191,6 +191,63 @@ describe('ComfySvcImpl', () => {
 
       randomUuidSpy.mockRestore()
     })
+
+    it('strips UI-only nodes before posting the prompt to ComfyUI', async () => {
+      const svc = new ComfySvcImpl()
+      ;(
+        svc as unknown as { cli: () => { objectInfo: () => Promise<Record<string, unknown>> } }
+      ).cli = () =>
+        ({
+          objectInfo: vi.fn().mockResolvedValue({})
+        }) as never
+
+      const postPromptSpy = vi.spyOn(svc, 'postPrompt').mockResolvedValue({
+        prompt_id: 'prompt-4'
+      })
+
+      await svc.submitWorkflow({
+        prompt: {
+          '10': {
+            class_type: 'SeedVR2VideoUpscaler',
+            inputs: {
+              image: ['31', 0]
+            }
+          },
+          '18': {
+            class_type: 'Note',
+            inputs: {
+              value: 'Enable to upscale alpha/mask channel along with RGB channel.'
+            }
+          },
+          '31': {
+            class_type: 'LoadImage',
+            inputs: {
+              image: 'input.png'
+            }
+          }
+        },
+        clientId: 'renderer-qapp'
+      })
+
+      expect(postPromptSpy).toHaveBeenCalledWith({
+        prompt: {
+          '10': {
+            class_type: 'SeedVR2VideoUpscaler',
+            inputs: {
+              image: ['31', 0]
+            }
+          },
+          '31': {
+            class_type: 'LoadImage',
+            inputs: {
+              image: 'input.png'
+            }
+          }
+        },
+        client_id: 'renderer-qapp',
+        extra_data: undefined
+      })
+    })
   })
 
   describe('connectWs', () => {

--- a/packages/app/src/main/api/svcComfyImpl.ts
+++ b/packages/app/src/main/api/svcComfyImpl.ts
@@ -46,6 +46,7 @@ import { comfyEventToTaskEvent, extractPromptId, taskToComfyQueueItem } from '..
 import { sleep } from '@shared/utils/utilFuncs'
 import { ComfyQueueResp, Workflow } from '@shared/comfy/types'
 import { processWorkflowLoras } from '../comfy/loraBypass'
+import { normalizeExecutableWorkflow } from '@shared/comfy/funcs'
 
 // Map to store qAppKey by task ID (for later retrieval when loading quick app)
 const taskQAppKeyMap = new Map<string, string>()
@@ -212,10 +213,10 @@ export class ComfySvcImpl implements ComfySvc {
     const workflowClientId = resolveWorkflowClientId(req)
 
     // 处理缺失的 LoRA：获取可用 LoRA 列表，绕过不存在的 LoRA 节点
-    let processedPrompt = req.prompt
+    let processedPrompt = normalizeExecutableWorkflow(req.prompt)
     try {
       const objectInfo = await this.cli().objectInfo()
-      const result = processWorkflowLoras(req.prompt, objectInfo)
+      const result = processWorkflowLoras(processedPrompt, objectInfo)
       processedPrompt = result.workflow
     } catch (error) {
       console.warn('[submitWorkflow] Failed to process LoRA bypass:', error)

--- a/packages/app/src/main/qApp/fs.ts
+++ b/packages/app/src/main/qApp/fs.ts
@@ -14,6 +14,7 @@ import { QAppCfg } from '@shared/qApp/cfgTypes'
 import { Workflow } from '@shared/comfy/types'
 import { isGuiWorkflow } from '@shared/comfy/guiWorkflowToPrompt'
 import { convertGuiWorkflowToPrompt } from '@shared/comfy/guiWorkflowToPrompt'
+import { normalizeExecutableWorkflow } from '@shared/comfy/funcs'
 import { isWorkflow } from '@shared/comfy/typeGuards'
 import { exists } from '../utils/fileUtils'
 import { QAppMenuItem } from '@shared/api/svcQApp'
@@ -276,7 +277,7 @@ export class QAppFSCli {
         const workflowPath = path.join(currentDir, `${name}.prompt.json`)
         const workflowData = JSON.parse(stripBom(await fs.readFile(workflowPath, 'utf8')))
         const workflow = isWorkflow(workflowData)
-          ? workflowData
+          ? normalizeExecutableWorkflow(workflowData)
           : isGuiWorkflow(workflowData)
             ? convertGuiWorkflowToPrompt(workflowData)
             : null
@@ -388,7 +389,7 @@ export class QAppFSCli {
         source: sources[i].isBuiltin ? 'builtin' : 'local'
       })
       if (isWorkflow(workflow)) {
-        return { cfg: qAppCfg, workflow, manifest }
+        return { cfg: qAppCfg, workflow: normalizeExecutableWorkflow(workflow), manifest }
       }
       if (isGuiWorkflow(workflow)) {
         const converted = convertGuiWorkflowToPrompt(workflow)

--- a/packages/app/src/renderer/src/pages/ChatPage/chatRequestUtils.test.ts
+++ b/packages/app/src/renderer/src/pages/ChatPage/chatRequestUtils.test.ts
@@ -734,6 +734,117 @@ describe('requestChatCompletion', () => {
     })
   })
 
+  it('forces image output mode to return only image attachments', async () => {
+    const config = createConfig()
+    config.use_remote_llm = false
+
+    const chat = vi.fn().mockResolvedValue({
+      content: 'Here is the generated image.',
+      attachments: [
+        {
+          type: 'image',
+          url: 'https://cdn.example.com/result.png',
+          fileName: 'result.png'
+        },
+        {
+          type: 'video',
+          url: 'https://cdn.example.com/result.mp4',
+          fileName: 'result.mp4'
+        }
+      ]
+    })
+    ;(window as typeof window & { api: unknown }).api = {
+      svcLLMProxy: { chat }
+    } as unknown as Window['api']
+
+    await expect(
+      requestChatCompletion({
+        config,
+        messages,
+        skillRuntime: {
+          skillId: 'image-skill',
+          execution: {
+            outputMode: 'image'
+          }
+        }
+      })
+    ).resolves.toEqual({
+      content: '',
+      sessionUrl: undefined,
+      attachments: [
+        {
+          type: 'image',
+          url: 'https://cdn.example.com/result.png',
+          fileName: 'result.png',
+          mimeType: 'image/png'
+        }
+      ]
+    })
+
+    expect(chat).toHaveBeenCalledWith(
+      expect.objectContaining({
+        imageGenerationOptions: expect.objectContaining({ enabled: true })
+      })
+    )
+  })
+
+  it('rejects forced media output when the model returns only text', async () => {
+    const config = createConfig()
+    config.use_remote_llm = false
+
+    const chat = vi.fn().mockResolvedValue({ content: 'I cannot make a video.' })
+    ;(window as typeof window & { api: unknown }).api = {
+      svcLLMProxy: { chat }
+    } as unknown as Window['api']
+
+    await expect(
+      requestChatCompletion({
+        config,
+        messages,
+        skillRuntime: {
+          skillId: 'video-skill',
+          execution: {
+            outputMode: 'video'
+          }
+        }
+      })
+    ).rejects.toThrow('该模型不支持该输出方式')
+  })
+
+  it('strips generated media when forced text output has usable text', async () => {
+    const config = createConfig()
+    config.use_remote_llm = false
+
+    const chat = vi.fn().mockResolvedValue({
+      content: 'caption text\n![generated](https://cdn.example.com/result.png)',
+      attachments: [
+        {
+          type: 'image',
+          url: 'https://cdn.example.com/result.png'
+        }
+      ]
+    })
+    ;(window as typeof window & { api: unknown }).api = {
+      svcLLMProxy: { chat }
+    } as unknown as Window['api']
+
+    await expect(
+      requestChatCompletion({
+        config,
+        messages,
+        skillRuntime: {
+          skillId: 'text-skill',
+          execution: {
+            outputMode: 'text'
+          }
+        }
+      })
+    ).resolves.toEqual({
+      content: 'caption text',
+      sessionUrl: undefined
+    })
+  })
+
   it('routes agent skills only through their configured external API', async () => {
     const config = createConfig()
     config.use_remote_llm = true

--- a/packages/app/src/renderer/src/pages/ChatPage/chatRequestUtils.ts
+++ b/packages/app/src/renderer/src/pages/ChatPage/chatRequestUtils.ts
@@ -25,6 +25,10 @@ import {
   getRemoteLlmServerOrigin
 } from '@renderer/utils/llmProfileUtils'
 import { normalizeLocalMediaUrl } from './chatPageShared'
+import {
+  applySkillOutputModeContract,
+  resolveSkillOutputImageGenerationOptions
+} from './chatSkillOutputMode'
 
 type ChatRequestPayload = {
   messages: Array<{
@@ -360,6 +364,10 @@ const buildChatRequestPayload = (input: RequestChatCompletionInput): ChatRequest
     input.externalAgentSkill?.type === 'agent'
       ? input.externalAgentSkill.prompt?.trim() || input.systemPrompt?.trim() || undefined
       : input.systemPrompt?.trim() || input.externalAgentSkill?.prompt?.trim() || undefined
+  const requestImageGenerationOptions = resolveSkillOutputImageGenerationOptions(
+    input.skillRuntime?.execution?.outputMode,
+    input.imageGenerationOptions
+  )
 
   return {
     messages: input.messages.map((message) => ({
@@ -373,8 +381,8 @@ const buildChatRequestPayload = (input: RequestChatCompletionInput): ChatRequest
     ...(input.reasoningEffort && input.externalAgentSkill?.type !== 'agent'
       ? { reasoningEffort: input.reasoningEffort }
       : {}),
-    ...(input.imageGenerationOptions && input.externalAgentSkill?.type !== 'agent'
-      ? { imageGenerationOptions: input.imageGenerationOptions }
+    ...(requestImageGenerationOptions && input.externalAgentSkill?.type !== 'agent'
+      ? { imageGenerationOptions: requestImageGenerationOptions }
       : {}),
     ...(input.skillRuntime ? { skillRuntime: input.skillRuntime } : {}),
     sessionUrl: input.sessionUrl,
@@ -941,15 +949,16 @@ const requestLocalChatCompletionStream = async (
 const dispatchChatCompletionRequest = async (
   input: RequestChatCompletionInput
 ): Promise<RequestChatCompletionResult> => {
+  let result: RequestChatCompletionResult
   if (input.externalAgentSkill?.type === 'agent') {
-    return requestExternalAgentSkillCompletion(input)
+    result = await requestExternalAgentSkillCompletion(input)
+  } else if (input.config.use_remote_llm) {
+    result = await requestRemoteChatCompletion(input)
+  } else {
+    result = await requestLocalChatCompletion(input)
   }
 
-  if (input.config.use_remote_llm) {
-    return requestRemoteChatCompletion(input)
-  }
-
-  return requestLocalChatCompletion(input)
+  return applySkillOutputModeContract(result, input.skillRuntime?.execution?.outputMode)
 }
 
 const dispatchChatCompletionStreamRequest = async (
@@ -1120,8 +1129,18 @@ export const requestChatCompletionStream = async (
       shouldSkipInlineAttachmentSummary(input.config, input.profileId, attachment)
   })
 
-  return dispatchChatCompletionStreamRequest({
+  const result = await dispatchChatCompletionStreamRequest({
     ...input,
     messages: requestMessages
   })
+
+  const normalizedResult = applySkillOutputModeContract(
+    result.result,
+    input.skillRuntime?.execution?.outputMode
+  )
+
+  return {
+    result: normalizedResult,
+    response: normalizedResult.content
+  }
 }

--- a/packages/app/src/renderer/src/pages/ChatPage/chatSkillOutputMode.ts
+++ b/packages/app/src/renderer/src/pages/ChatPage/chatSkillOutputMode.ts
@@ -1,0 +1,289 @@
+import type { CustomSkillOutputMode } from '@shared/config/config'
+import type {
+  ChatAttachment,
+  ChatMessage
+} from '../QuickAppPage/QAppExecutePanel/qAppExecuteInputs/api/LLM'
+
+type SkillOutputResult = {
+  content: string
+  sessionUrl?: string
+  attachments?: ChatAttachment[]
+  ocrResult?: ChatMessage['ocrResult']
+}
+
+type ForcedSkillOutputMode = Extract<CustomSkillOutputMode, 'text' | 'image' | 'video' | 'model3d'>
+
+const UNSUPPORTED_OUTPUT_MODE_MESSAGE = '该模型不支持该输出方式'
+
+const IMAGE_EXTENSIONS = ['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.svg']
+const VIDEO_EXTENSIONS = ['.mp4', '.webm', '.mov', '.m4v', '.avi', '.mkv']
+const MODEL3D_EXTENSIONS = [
+  '.glb',
+  '.gltf',
+  '.obj',
+  '.fbx',
+  '.dae',
+  '.3ds',
+  '.ply',
+  '.stl',
+  '.usdz'
+]
+const MARKDOWN_LINK_REGEX = /(!)?\[([^\]]*)\]\(([^)]+)\)/g
+const PLAIN_URL_REGEX = /\b(?:https?:\/\/|file:\/\/\/?|local-media:\/\/)[^\s<>)"']+/g
+const HUNYUAN_ARTIFACT_REGEX =
+  /^\[Hunyuan3D\]\s+(model|video|image|file):\s+type=([A-Za-z_]+)\s+url=([^\s]+)\s*$/gim
+
+const normalizeOutputMode = (mode: unknown): ForcedSkillOutputMode | null => {
+  switch (mode) {
+    case 'text':
+    case 'image':
+    case 'video':
+    case 'model3d':
+      return mode
+    default:
+      return null
+  }
+}
+
+export const resolveSkillOutputImageGenerationOptions = <T extends object | undefined>(
+  outputMode: unknown,
+  imageGenerationOptions: T
+): T | (NonNullable<T> & { enabled: true }) | { enabled: true } => {
+  if (outputMode !== 'image') {
+    return imageGenerationOptions
+  }
+
+  return {
+    ...(imageGenerationOptions || {}),
+    enabled: true
+  } as NonNullable<T> & { enabled: true }
+}
+
+const normalizeMediaUrl = (url: string): string => url.trim().replace(/[.,;:!?]+$/u, '')
+
+const getLowerPathBits = (url: string): string[] => {
+  const normalized = normalizeMediaUrl(url)
+  if (normalized.startsWith('data:image/')) {
+    return [normalized.toLowerCase()]
+  }
+
+  try {
+    const parsed = new URL(normalized)
+    return [parsed.pathname, parsed.search, parsed.hash].map((part) =>
+      decodeURIComponent(part).toLowerCase()
+    )
+  } catch {
+    return [normalized.toLowerCase()]
+  }
+}
+
+const hasExtension = (url: string, extensions: readonly string[]): boolean => {
+  const bits = getLowerPathBits(url)
+  return extensions.some((extension) => bits.some((part) => part.includes(extension)))
+}
+
+const inferMediaType = (
+  url: string,
+  options?: {
+    label?: string
+    mimeType?: string
+    forcedImage?: boolean
+    hunyuanKind?: string
+    hunyuanType?: string
+  }
+): Exclude<ChatAttachment['type'], 'file'> | null => {
+  const normalizedUrl = normalizeMediaUrl(url)
+  const label = options?.label?.toLowerCase() || ''
+  const mimeType = options?.mimeType?.toLowerCase() || ''
+  const hunyuanKind = options?.hunyuanKind?.toLowerCase() || ''
+  const hunyuanType = options?.hunyuanType?.toUpperCase() || ''
+
+  if (
+    options?.forcedImage ||
+    normalizedUrl.startsWith('data:image/') ||
+    mimeType.startsWith('image/') ||
+    hunyuanKind === 'image' ||
+    hunyuanType === 'IMAGE' ||
+    hunyuanType === 'TEXTURE_IMAGE' ||
+    hasExtension(normalizedUrl, IMAGE_EXTENSIONS)
+  ) {
+    return 'image'
+  }
+
+  if (
+    mimeType.startsWith('video/') ||
+    hunyuanKind === 'video' ||
+    hunyuanType === 'MP4' ||
+    label.includes('video') ||
+    hasExtension(normalizedUrl, VIDEO_EXTENSIONS)
+  ) {
+    return 'video'
+  }
+
+  if (
+    hunyuanKind === 'model' ||
+    label.includes('3d') ||
+    label.includes('model') ||
+    hasExtension(normalizedUrl, MODEL3D_EXTENSIONS)
+  ) {
+    return 'model3d'
+  }
+
+  return null
+}
+
+const getFileNameFromUrl = (url: string, fallback: string): string => {
+  try {
+    const parsed = new URL(normalizeMediaUrl(url))
+    const lastSegment = decodeURIComponent(parsed.pathname.split('/').filter(Boolean).pop() || '')
+    return lastSegment || fallback
+  } catch {
+    return fallback
+  }
+}
+
+const buildMediaAttachment = (
+  type: Exclude<ChatAttachment['type'], 'file'>,
+  url: string,
+  source?: Partial<ChatAttachment>
+): ChatAttachment => {
+  const normalizedUrl = normalizeMediaUrl(url)
+  if (type === 'image') {
+    return {
+      ...source,
+      type,
+      url: normalizedUrl,
+      mimeType: source?.mimeType || 'image/png'
+    }
+  }
+
+  return {
+    ...source,
+    type,
+    url: normalizedUrl,
+    fileName:
+      source?.fileName ||
+      getFileNameFromUrl(normalizedUrl, type === 'video' ? 'video.mp4' : 'model.glb')
+  }
+}
+
+const normalizeAttachmentAsMedia = (attachment: ChatAttachment): ChatAttachment | null => {
+  const mediaType =
+    attachment.type === 'image' || attachment.type === 'video' || attachment.type === 'model3d'
+      ? attachment.type
+      : inferMediaType(attachment.url, {
+          label: attachment.fileName,
+          mimeType: attachment.mimeType
+        })
+
+  return mediaType ? buildMediaAttachment(mediaType, attachment.url, attachment) : null
+}
+
+const collectContentMediaAttachments = (content: string): ChatAttachment[] => {
+  const attachments: ChatAttachment[] = []
+
+  HUNYUAN_ARTIFACT_REGEX.lastIndex = 0
+  let hunyuanMatch: RegExpExecArray | null = null
+  while ((hunyuanMatch = HUNYUAN_ARTIFACT_REGEX.exec(content)) !== null) {
+    const mediaType = inferMediaType(hunyuanMatch[3], {
+      hunyuanKind: hunyuanMatch[1],
+      hunyuanType: hunyuanMatch[2]
+    })
+    if (mediaType) {
+      attachments.push(buildMediaAttachment(mediaType, hunyuanMatch[3]))
+    }
+  }
+
+  MARKDOWN_LINK_REGEX.lastIndex = 0
+  let markdownMatch: RegExpExecArray | null = null
+  while ((markdownMatch = MARKDOWN_LINK_REGEX.exec(content)) !== null) {
+    const mediaType = inferMediaType(markdownMatch[3], {
+      forcedImage: markdownMatch[1] === '!',
+      label: markdownMatch[2]
+    })
+    if (mediaType) {
+      attachments.push(buildMediaAttachment(mediaType, markdownMatch[3]))
+    }
+  }
+
+  PLAIN_URL_REGEX.lastIndex = 0
+  let urlMatch: RegExpExecArray | null = null
+  while ((urlMatch = PLAIN_URL_REGEX.exec(content)) !== null) {
+    const mediaType = inferMediaType(urlMatch[0])
+    if (mediaType) {
+      attachments.push(buildMediaAttachment(mediaType, urlMatch[0]))
+    }
+  }
+
+  return dedupeAttachments(attachments)
+}
+
+const dedupeAttachments = (attachments: ChatAttachment[]): ChatAttachment[] => {
+  const seen = new Set<string>()
+  return attachments.filter((attachment) => {
+    const key = `${attachment.type}:${attachment.url}:${attachment.fileName || ''}`
+    if (seen.has(key)) {
+      return false
+    }
+    seen.add(key)
+    return true
+  })
+}
+
+const stripMediaReferences = (content: string): string => {
+  const withoutHunyuan = content.replace(HUNYUAN_ARTIFACT_REGEX, '')
+  const withoutMarkdown = withoutHunyuan.replace(MARKDOWN_LINK_REGEX, (match, bang, label, url) => {
+    const mediaType = inferMediaType(String(url), {
+      forcedImage: bang === '!',
+      label: String(label || '')
+    })
+    return mediaType ? '' : match
+  })
+
+  return withoutMarkdown
+    .replace(PLAIN_URL_REGEX, (match) => (inferMediaType(match) ? '' : match))
+    .trim()
+}
+
+export const applySkillOutputModeContract = (
+  result: SkillOutputResult,
+  outputMode: unknown
+): SkillOutputResult => {
+  const forcedMode = normalizeOutputMode(outputMode)
+  if (!forcedMode) {
+    return result
+  }
+
+  if (forcedMode === 'text') {
+    const content = stripMediaReferences(result.content)
+    if (!content) {
+      throw new Error(UNSUPPORTED_OUTPUT_MODE_MESSAGE)
+    }
+
+    return {
+      content,
+      sessionUrl: result.sessionUrl
+    }
+  }
+
+  const mediaAttachments = dedupeAttachments([
+    ...(result.attachments || []).flatMap((attachment) => {
+      const mediaAttachment = normalizeAttachmentAsMedia(attachment)
+      return mediaAttachment ? [mediaAttachment] : []
+    }),
+    ...collectContentMediaAttachments(result.content)
+  ])
+  const matchingAttachments = mediaAttachments.filter(
+    (attachment) => attachment.type === forcedMode
+  )
+
+  if (matchingAttachments.length === 0) {
+    throw new Error(UNSUPPORTED_OUTPUT_MODE_MESSAGE)
+  }
+
+  return {
+    content: '',
+    sessionUrl: result.sessionUrl,
+    attachments: matchingAttachments
+  }
+}

--- a/packages/app/src/renderer/src/pages/ChatPage/chatSkillOutputMode.ts
+++ b/packages/app/src/renderer/src/pages/ChatPage/chatSkillOutputMode.ts
@@ -13,7 +13,19 @@ type SkillOutputResult = {
 
 type ForcedSkillOutputMode = Extract<CustomSkillOutputMode, 'text' | 'image' | 'video' | 'model3d'>
 
-const UNSUPPORTED_OUTPUT_MODE_MESSAGE = '该模型不支持该输出方式'
+const UNSUPPORTED_OUTPUT_MODE_MESSAGE = String.fromCharCode(
+  0x8be5,
+  0x6a21,
+  0x578b,
+  0x4e0d,
+  0x652f,
+  0x6301,
+  0x8be5,
+  0x8f93,
+  0x51fa,
+  0x65b9,
+  0x5f0f
+)
 
 const IMAGE_EXTENSIONS = ['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.svg']
 const VIDEO_EXTENSIONS = ['.mp4', '.webm', '.mov', '.m4v', '.avi', '.mkv']

--- a/packages/app/src/renderer/src/pages/ChatPage/chatSkillRuntime.test.ts
+++ b/packages/app/src/renderer/src/pages/ChatPage/chatSkillRuntime.test.ts
@@ -45,7 +45,7 @@ describe('chatSkillRuntime', () => {
       expect.objectContaining({
         mode: 'inherit',
         allowHistory: true,
-        outputMode: 'chat',
+        outputMode: 'default',
         fallbackStrategy: 'default',
         persistSessionUrl: true
       })
@@ -75,7 +75,7 @@ describe('chatSkillRuntime', () => {
       expect.objectContaining({
         mode: 'inherit',
         allowHistory: true,
-        outputMode: 'chat',
+        outputMode: 'default',
         fallbackStrategy: 'default',
         persistSessionUrl: true
       })
@@ -403,11 +403,11 @@ describe('chatSkillRuntime', () => {
         resourceUris: []
       })
     ])
-    expect(serializeSkillRuntimeSpec(runtime)).toEqual({
+    expect(serializeSkillRuntimeSpec(runtime)).toMatchObject({
       skillId: 'ops-review',
       execution: expect.objectContaining({
         mode: 'inherit',
-        outputMode: 'chat'
+        outputMode: 'default'
       }),
       bindings: [
         expect.objectContaining({

--- a/packages/app/src/renderer/src/pages/ChatPage/chatSkillRuntime.ts
+++ b/packages/app/src/renderer/src/pages/ChatPage/chatSkillRuntime.ts
@@ -56,7 +56,7 @@ const DEFAULT_EXECUTION_POLICY: Required<Omit<CustomSkillExecutionPolicy, 'conte
   {
     mode: 'inherit',
     allowHistory: true,
-    outputMode: 'chat',
+    outputMode: 'default',
     fallbackStrategy: 'default',
     persistSessionUrl: true
   }
@@ -282,8 +282,30 @@ export const buildSkillRuntimeCapabilityContext = (
 ): string | undefined => {
   const lines: string[] = []
 
-  if (runtime.execution.outputMode !== 'chat') {
-    lines.push(`Skill output mode: ${runtime.execution.outputMode}.`)
+  switch (runtime.execution.outputMode) {
+    case 'text':
+      lines.push('Skill output mode: text. Return text only; do not return generated media.')
+      break
+    case 'image':
+      lines.push(
+        'Skill output mode: image. Return only actual image output. A text description is not a completed image deliverable.'
+      )
+      break
+    case 'video':
+      lines.push(
+        'Skill output mode: video. Return only actual video output. A text description is not a completed video deliverable.'
+      )
+      break
+    case 'model3d':
+      lines.push(
+        'Skill output mode: 3D. Return only actual 3D model output. A text description is not a completed 3D deliverable.'
+      )
+      break
+    case 'chat':
+    case 'default':
+      break
+    default:
+      lines.push(`Skill output mode: ${runtime.execution.outputMode}.`)
   }
 
   if (runtime.execution.outputMode === 'structured' && runtime.outputSchema) {

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/ProjectCanvasPage.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/ProjectCanvasPage.tsx
@@ -1209,7 +1209,6 @@ const ProjectCanvasPage: React.FC = () => {
       addVideoToCanvas,
       addFileToCanvas,
       addOcrResultToCanvas,
-      addHtmlToCanvas,
       addTextToCanvas,
       handleImportCanvasSceneFile,
       handleImportPsdFile,

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasWebGLImageLayer.test.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasWebGLImageLayer.test.tsx
@@ -199,6 +199,8 @@ function installPixiMock() {
 
         let scaleMode: 'nearest' | 'linear' = 'linear'
         const source = {
+          destroyed: false,
+          unload: vi.fn(),
           image,
           get scaleMode() {
             textureScaleModeReadCount += 1
@@ -533,6 +535,62 @@ describe('ProjectCanvasWebGLImageLayer', () => {
     expect(sprite.scale.y).toBe(2)
     expect(sprite.rotation).toBe(0)
     expect(app.render).toHaveBeenCalledTimes(renderCountBeforeClear + 1)
+  }, 15000)
+
+  it('refreshes the texture source when a tiny preview grows back to visible size', async () => {
+    const { default: ProjectCanvasWebGLImageLayer } = await import('./ProjectCanvasWebGLImageLayer')
+    const ref = React.createRef<ProjectCanvasWebGLImageLayerHandle>()
+
+    render(
+      <ProjectCanvasWebGLImageLayer
+        ref={ref}
+        items={[createItem()]}
+        stagePos={{ x: 0, y: 0 }}
+        stageScale={1}
+        stageSize={{ width: 1280, height: 720 }}
+      />
+    )
+
+    await waitFor(
+      () => {
+        expect(ref.current).not.toBeNull()
+        expect(createdSprites).toHaveLength(1)
+      },
+      { timeout: 15000 }
+    )
+
+    const sprite = createdSprites[0]
+    const source = sprite.texture.source as { unload: ReturnType<typeof vi.fn> }
+
+    act(() => {
+      ref.current?.syncItemPreview('image-1', {
+        x: 24,
+        y: 36,
+        width: 200,
+        height: 120,
+        scaleX: 0.1,
+        scaleY: 0.1,
+        rotation: 0
+      })
+    })
+
+    expect(source.unload).not.toHaveBeenCalled()
+
+    act(() => {
+      ref.current?.syncItemPreview('image-1', {
+        x: 24,
+        y: 36,
+        width: 200,
+        height: 120,
+        scaleX: 1,
+        scaleY: 1,
+        rotation: 0
+      })
+    })
+
+    expect(source.unload).toHaveBeenCalledTimes(1)
+    expect(sprite.scale.x).toBe(2)
+    expect(sprite.scale.y).toBe(2)
   }, 15000)
 
   it('recreates sprite state when the texture key changes', async () => {

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasWebGLImageLayer.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasWebGLImageLayer.tsx
@@ -67,6 +67,7 @@ type SpriteRecord = {
   textureHeight: number
   textureByteSize: number
   lastUsedAt: number
+  sawTinyPreview: boolean
 }
 
 type SourceUpgradeQueueEntry = {
@@ -101,6 +102,8 @@ const PROJECT_CANVAS_WEBGL_DENSE_SOURCE_UPGRADE_MAX_SCALE = 0.5
 const PROJECT_CANVAS_WEBGL_IMAGE_ELEMENT_SOURCE_DECODE_MAX_BYTES = 256 * 1024 * 1024
 const PROJECT_CANVAS_WEBGL_IMAGE_ELEMENT_LOAD_TIMEOUT_MS = 15_000
 const PROJECT_CANVAS_WEBGL_SOURCE_TEXTURE_LOAD_TIMEOUT_MS = 12_000
+const PROJECT_CANVAS_WEBGL_TINY_PREVIEW_SCREEN_EDGE_PX = 24
+const PROJECT_CANVAS_WEBGL_TINY_PREVIEW_RECOVERY_SCREEN_EDGE_PX = 48
 export const PROJECT_CANVAS_WEBGL_INITIAL_IMAGE_LOAD_CONCURRENCY = 8
 export const PROJECT_CANVAS_WEBGL_SPRITE_RECONCILE_BATCH_SIZE = 16
 export const PROJECT_CANVAS_WEBGL_OVERVIEW_SPRITE_RECONCILE_BATCH_SIZE = 128
@@ -262,6 +265,51 @@ function applyProjectCanvasTextureScaleMode(record: SpriteRecord) {
   if (textureSource.scaleMode !== nextScaleMode) {
     textureSource.scaleMode = nextScaleMode
   }
+}
+
+function getProjectCanvasPreviewScreenMaxEdge(
+  preview: ProjectCanvasImagePreview,
+  stageScale: number
+) {
+  const safeScale = Math.max(Math.abs(stageScale), PROJECT_CANVAS_MIN_STAGE_SCALE)
+  return (
+    Math.max(Math.abs(preview.width * preview.scaleX), Math.abs(preview.height * preview.scaleY)) *
+    safeScale
+  )
+}
+
+function isProjectCanvasTinyPreview(preview: ProjectCanvasImagePreview, stageScale: number) {
+  return (
+    getProjectCanvasPreviewScreenMaxEdge(preview, stageScale) <=
+    PROJECT_CANVAS_WEBGL_TINY_PREVIEW_SCREEN_EDGE_PX
+  )
+}
+
+function refreshProjectCanvasTextureAfterTinyPreview(
+  record: SpriteRecord,
+  preview: ProjectCanvasImagePreview,
+  stageScale: number
+) {
+  const screenMaxEdge = getProjectCanvasPreviewScreenMaxEdge(preview, stageScale)
+  if (screenMaxEdge <= PROJECT_CANVAS_WEBGL_TINY_PREVIEW_SCREEN_EDGE_PX) {
+    record.sawTinyPreview = true
+    return
+  }
+
+  if (
+    !record.sawTinyPreview ||
+    screenMaxEdge < PROJECT_CANVAS_WEBGL_TINY_PREVIEW_RECOVERY_SCREEN_EDGE_PX
+  ) {
+    return
+  }
+
+  const textureSource = (record.sourceTexture ?? record.texture).source as
+    | { destroyed?: boolean; unload?: () => void }
+    | undefined
+  if (textureSource && !textureSource.destroyed && typeof textureSource.unload === 'function') {
+    textureSource.unload()
+  }
+  record.sawTinyPreview = false
 }
 
 function getProjectCanvasRenderDeviceScale() {
@@ -1532,6 +1580,7 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
           previewStateRef.current.delete(itemId)
           const renderItem = renderItemsRef.current.get(itemId)
           if (renderItem) {
+            refreshProjectCanvasTextureAfterTinyPreview(record, renderItem, stageScaleRef.current)
             applySpriteTransform(
               record.sprite,
               { textureWidth: record.textureWidth, textureHeight: record.textureHeight },
@@ -1546,6 +1595,7 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
         }
 
         previewStateRef.current.set(itemId, preview)
+        refreshProjectCanvasTextureAfterTinyPreview(record, preview, stageScaleRef.current)
         applySpriteTransform(
           record.sprite,
           { textureWidth: record.textureWidth, textureHeight: record.textureHeight },
@@ -2559,6 +2609,11 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
           )
           existingRecord.transformKey = transformKey
         }
+        refreshProjectCanvasTextureAfterTinyPreview(
+          existingRecord,
+          transformState,
+          stageScaleRef.current
+        )
         markSpriteRecordUsed(existingRecord)
         return
       }
@@ -2649,7 +2704,8 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
           textureWidth,
           textureHeight,
           textureByteSize,
-          lastUsedAt: 0
+          lastUsedAt: 0,
+          sawTinyPreview: isProjectCanvasTinyPreview(transformState, stageScaleRef.current)
         })
         if (shouldBatchNewSpriteCreation) {
           newSpriteCreationBudget -= 1

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/useCanvasFileIntake.test.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/useCanvasFileIntake.test.tsx
@@ -139,7 +139,6 @@ function FileIntakeHarness({
   addTextToCanvas,
   addImageToCanvas = vi.fn().mockResolvedValue(undefined),
   addImagesToCanvas = vi.fn().mockResolvedValue(undefined),
-  addHtmlToCanvas = vi.fn(),
   addFileToCanvas = vi.fn().mockResolvedValue(undefined),
   notifyWarning = vi.fn(),
   onImageBatchImportProgress = vi.fn(),
@@ -150,7 +149,6 @@ function FileIntakeHarness({
   addTextToCanvas: ReturnType<typeof vi.fn>
   addImageToCanvas?: ReturnType<typeof vi.fn>
   addImagesToCanvas?: ReturnType<typeof vi.fn>
-  addHtmlToCanvas?: ReturnType<typeof vi.fn>
   addFileToCanvas?: ReturnType<typeof vi.fn>
   notifyWarning?: ReturnType<typeof vi.fn>
   onImageBatchImportProgress?: ReturnType<typeof vi.fn>
@@ -173,7 +171,6 @@ function FileIntakeHarness({
     addVideoToCanvas: vi.fn().mockResolvedValue(undefined),
     addFileToCanvas,
     addOcrResultToCanvas: vi.fn().mockResolvedValue(undefined),
-    addHtmlToCanvas,
     addTextToCanvas,
     handleImportCanvasSceneFile: vi.fn().mockResolvedValue(undefined),
     handleImportPsdFile: vi.fn().mockResolvedValue(undefined),
@@ -430,16 +427,13 @@ describe('useCanvasFileIntake', () => {
     })
   })
 
-  it('pastes structured clipboard HTML as a canvas html item', async () => {
+  it('pastes structured clipboard HTML as canvas text', async () => {
     const addTextToCanvas = vi.fn()
-    const addHtmlToCanvas = vi.fn()
     const clipboard = window.navigator.clipboard as unknown as ClipboardMock
     clipboard.read.mockRejectedValue(new Error('blocked'))
     clipboard.readText.mockRejectedValue(new Error('blocked'))
 
-    render(
-      <FileIntakeHarness addTextToCanvas={addTextToCanvas} addHtmlToCanvas={addHtmlToCanvas} />
-    )
+    render(<FileIntakeHarness addTextToCanvas={addTextToCanvas} />)
 
     const canvas = screen.getByTestId('canvas-paste-surface')
     canvas.focus()
@@ -453,11 +447,8 @@ describe('useCanvasFileIntake', () => {
     )
 
     await waitFor(() => {
-      expect(addHtmlToCanvas).toHaveBeenCalledTimes(1)
+      expect(addTextToCanvas).toHaveBeenCalledWith('Name\tScore\nAlice\t95')
     })
-
-    expect(addTextToCanvas).not.toHaveBeenCalled()
-    expect(addHtmlToCanvas.mock.calls[0]?.[0]).toContain('<table')
   })
 
   it('accepts pasted clipboard files for canvas-supported office/text formats', async () => {
@@ -997,24 +988,19 @@ describe('useCanvasFileIntake', () => {
     ])
   })
 
-  it('falls back to navigator clipboard text and preserves tabular data as html', async () => {
+  it('falls back to navigator clipboard text and keeps tabular data as text', async () => {
     const addTextToCanvas = vi.fn()
-    const addHtmlToCanvas = vi.fn()
     const clipboard = window.navigator.clipboard as unknown as ClipboardMock
     clipboard.read.mockRejectedValue(new Error('blocked'))
     clipboard.readText.mockResolvedValue('Name\tScore\nAlice\t95')
 
-    render(
-      <FileIntakeHarness addTextToCanvas={addTextToCanvas} addHtmlToCanvas={addHtmlToCanvas} />
-    )
+    render(<FileIntakeHarness addTextToCanvas={addTextToCanvas} />)
 
     fireEvent.keyDown(window, { key: 'v', code: 'KeyV', ctrlKey: true })
 
     await waitFor(() => {
-      expect(addHtmlToCanvas).toHaveBeenCalledTimes(1)
+      expect(addTextToCanvas).toHaveBeenCalledWith('Name\tScore\nAlice\t95')
     })
-
-    expect(addTextToCanvas).not.toHaveBeenCalled()
   })
 
   it('falls back to the native clipboard API when web clipboard access is unavailable', async () => {
@@ -1034,9 +1020,8 @@ describe('useCanvasFileIntake', () => {
     })
   })
 
-  it('falls back to native clipboard HTML for structured external tables', async () => {
+  it('falls back to native clipboard HTML as plain canvas text', async () => {
     const addTextToCanvas = vi.fn()
-    const addHtmlToCanvas = vi.fn()
     const clipboard = window.navigator.clipboard as unknown as ClipboardMock
     const nativeClipboard = window.api.svcHyper as unknown as NativeClipboardMock
     clipboard.read.mockRejectedValue(new Error('blocked'))
@@ -1046,21 +1031,13 @@ describe('useCanvasFileIntake', () => {
     })
     nativeClipboard.readClipboardText.mockResolvedValue({ text: '' })
 
-    render(
-      <FileIntakeHarness
-        addTextToCanvas={addTextToCanvas}
-        addHtmlToCanvas={addHtmlToCanvas}
-        initialCanvasActive={false}
-      />
-    )
+    render(<FileIntakeHarness addTextToCanvas={addTextToCanvas} initialCanvasActive={false} />)
 
     fireEvent.keyDown(window, { key: 'v', code: 'KeyV', ctrlKey: true })
 
     await waitFor(() => {
-      expect(addHtmlToCanvas).toHaveBeenCalledTimes(1)
+      expect(addTextToCanvas).toHaveBeenCalledWith('Name\tScore\nAlice\t95')
     })
-
-    expect(addTextToCanvas).not.toHaveBeenCalled()
   })
 
   it('accepts a native paste event routed through the hidden canvas paste proxy', async () => {

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/useCanvasFileIntake.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/useCanvasFileIntake.ts
@@ -86,13 +86,6 @@ type AddFileToCanvasFn = (
   }
 ) => Promise<unknown>
 type AddVideoToCanvasFn = (file: File) => Promise<unknown> | unknown
-type AddHtmlToCanvasFn = (
-  htmlData: string,
-  options?: {
-    clientX?: number
-    clientY?: number
-  }
-) => void
 type AddTextToCanvasFn = (text: string, clientX?: number, clientY?: number) => void
 
 type AddOcrResultToCanvasFn = (options: {
@@ -303,7 +296,6 @@ type UseCanvasFileIntakeOptions = {
   addVideoToCanvas: AddVideoToCanvasFn
   addFileToCanvas: AddFileToCanvasFn
   addOcrResultToCanvas: AddOcrResultToCanvasFn
-  addHtmlToCanvas: AddHtmlToCanvasFn
   addTextToCanvas: AddTextToCanvasFn
   handleImportCanvasSceneFile: ImportCanvasSceneFileFn
   handleImportPsdFile: ImportPsdFileFn
@@ -466,6 +458,17 @@ function normalizeClipboardHtmlText(html: string): string {
 
   if (typeof DOMParser !== 'undefined') {
     const doc = new DOMParser().parseFromString(trimmed, 'text/html')
+    const tableRows = Array.from(doc.body?.querySelectorAll('tr') || [])
+      .map((row) =>
+        Array.from(row.querySelectorAll('th,td'))
+          .map((cell) => cell.textContent?.trim() || '')
+          .join('\t')
+      )
+      .filter((row) => row.trim())
+    if (tableRows.length > 0) {
+      return tableRows.join('\n')
+    }
+
     const text = doc.body?.textContent?.trim()
     if (text) {
       return text
@@ -500,135 +503,6 @@ function getClipboardPlainText(clipboardData?: DataTransfer | null): string {
   return normalizeClipboardHtmlText(clipboardData.getData('text/html'))
 }
 
-function escapeClipboardHtml(value: string): string {
-  return value
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;')
-}
-
-function buildClipboardTableHtml(text: string): string {
-  const normalized = text.replace(/\r\n?/g, '\n').trim()
-  if (!normalized || !normalized.includes('\n') || !normalized.includes('\t')) {
-    return ''
-  }
-
-  const rows = normalized.split('\n').map((row) => row.split('\t').map((cell) => cell.trim()))
-  const columnCount = rows[0]?.length ?? 0
-  if (rows.length < 2 || columnCount < 2 || rows.some((row) => row.length !== columnCount)) {
-    return ''
-  }
-
-  const rowHtml = rows
-    .map(
-      (cells) =>
-        `<tr>${cells
-          .map(
-            (cell) =>
-              `<td style="border:1px solid #d1d5db;padding:8px 10px;vertical-align:top;">${escapeClipboardHtml(
-                cell
-              )}</td>`
-          )
-          .join('')}</tr>`
-    )
-    .join('')
-
-  return `
-    <div style="width:100%;height:100%;padding:12px;box-sizing:border-box;background:#ffffff;color:#111827;font:14px/1.5 system-ui,sans-serif;">
-      <table style="width:100%;border-collapse:collapse;border-spacing:0;background:#ffffff;">
-        <tbody>${rowHtml}</tbody>
-      </table>
-    </div>
-  `.trim()
-}
-
-function sanitizeClipboardHtml(html: string): string {
-  const trimmed = html.trim()
-  if (!trimmed) {
-    return ''
-  }
-
-  if (typeof DOMParser === 'undefined') {
-    return trimmed
-  }
-
-  const doc = new DOMParser().parseFromString(trimmed, 'text/html')
-  const body = doc.body
-  if (!body) {
-    return trimmed
-  }
-
-  body
-    .querySelectorAll('script,style,link,meta,title,iframe,object,embed,base')
-    .forEach((node) => node.remove())
-
-  for (const element of Array.from(body.querySelectorAll<HTMLElement>('*'))) {
-    for (const attribute of Array.from(element.attributes)) {
-      const name = attribute.name.toLowerCase()
-      const value = attribute.value.trim()
-
-      if (name.startsWith('on')) {
-        element.removeAttribute(attribute.name)
-        continue
-      }
-
-      if (
-        (name === 'href' || name === 'src' || name === 'xlink:href') &&
-        /^javascript:/i.test(value)
-      ) {
-        element.removeAttribute(attribute.name)
-        continue
-      }
-
-      if (name === 'style' && /(expression\s*\(|url\s*\(\s*['"]?\s*javascript:)/i.test(value)) {
-        element.removeAttribute(attribute.name)
-      }
-    }
-  }
-
-  return body.innerHTML.trim()
-}
-
-function shouldUseClipboardHtml(html: string, plainText = ''): boolean {
-  const trimmed = html.trim()
-  if (!trimmed) {
-    return false
-  }
-
-  if (/<table[\s>]/i.test(trimmed) || plainText.includes('\t')) {
-    return true
-  }
-
-  if (typeof DOMParser === 'undefined') {
-    return false
-  }
-
-  const doc = new DOMParser().parseFromString(trimmed, 'text/html')
-  return Boolean(doc.body?.querySelector('ul,ol,blockquote,pre,code,img,figure'))
-}
-
-function getStructuredClipboardHtmlFromPayload(html: string, plainText = ''): string {
-  const sanitizedHtml = shouldUseClipboardHtml(html, plainText) ? sanitizeClipboardHtml(html) : ''
-  if (sanitizedHtml) {
-    return sanitizedHtml
-  }
-
-  return buildClipboardTableHtml(plainText)
-}
-
-function getStructuredClipboardHtml(clipboardData?: Pick<DataTransfer, 'getData'> | null): string {
-  if (!clipboardData) {
-    return ''
-  }
-
-  return getStructuredClipboardHtmlFromPayload(
-    clipboardData.getData('text/html'),
-    getDirectClipboardPlainText(clipboardData)
-  )
-}
-
 export function useCanvasFileIntake({
   canvasId,
   canvasContainerRef,
@@ -641,7 +515,6 @@ export function useCanvasFileIntake({
   addVideoToCanvas,
   addFileToCanvas,
   addOcrResultToCanvas,
-  addHtmlToCanvas,
   addTextToCanvas,
   handleImportCanvasSceneFile,
   handleImportPsdFile,
@@ -1072,16 +945,6 @@ export function useCanvasFileIntake({
           return
         }
 
-        const structuredHtml = getStructuredClipboardHtml(dropDataTransfer)
-        if (structuredHtml) {
-          focusCanvasStage()
-          addHtmlToCanvas(structuredHtml, {
-            clientX,
-            clientY
-          })
-          return
-        }
-
         if (!text) {
           text =
             dropDataTransfer.getData('text') ||
@@ -1103,7 +966,6 @@ export function useCanvasFileIntake({
     },
     [
       addFileToCanvas,
-      addHtmlToCanvas,
       addImageToCanvas,
       addModel3DToCanvas,
       addModel3DUrlToCanvas,
@@ -1264,12 +1126,6 @@ export function useCanvasFileIntake({
         }
       }
 
-      const structuredClipboardHtml = getStructuredClipboardHtml(clipboardData)
-      if (structuredClipboardHtml) {
-        addHtmlToCanvas(structuredClipboardHtml)
-        return true
-      }
-
       if (!clipboardItems || clipboardItems.length === 0) {
         const directClipboardText = getClipboardPlainText(clipboardData)
         if (directClipboardText) {
@@ -1323,7 +1179,6 @@ export function useCanvasFileIntake({
       return false
     },
     [
-      addHtmlToCanvas,
       addImageToCanvas,
       addImagesToCanvas,
       addTextToCanvas,
@@ -1402,24 +1257,17 @@ export function useCanvasFileIntake({
             ? await (await clipItem.getType('text/plain')).text()
             : ''
 
-          if (clipItem.types.includes('text/html')) {
-            const html = await (await clipItem.getType('text/html')).text()
-            const structuredClipboardHtml = getStructuredClipboardHtmlFromPayload(html, plainText)
-            if (structuredClipboardHtml) {
-              addHtmlToCanvas(structuredClipboardHtml)
-              return true
-            }
-          }
-
-          const tabularTextHtml = buildClipboardTableHtml(plainText)
-          if (tabularTextHtml) {
-            addHtmlToCanvas(tabularTextHtml)
+          if (plainText.trim()) {
+            addTextToCanvas(plainText.trim())
             return true
           }
 
-          if (clipItem.types.includes('text/plain')) {
-            if (plainText.trim()) {
-              addTextToCanvas(plainText.trim())
+          if (clipItem.types.includes('text/html')) {
+            const htmlText = normalizeClipboardHtmlText(
+              await (await clipItem.getType('text/html')).text()
+            )
+            if (htmlText.trim()) {
+              addTextToCanvas(htmlText.trim())
               return true
             }
           }
@@ -1432,11 +1280,6 @@ export function useCanvasFileIntake({
     try {
       if (typeof navigator.clipboard.readText === 'function') {
         const text = await navigator.clipboard.readText()
-        const tabularTextHtml = buildClipboardTableHtml(text)
-        if (tabularTextHtml) {
-          addHtmlToCanvas(tabularTextHtml)
-          return true
-        }
         if (text.trim()) {
           addTextToCanvas(text.trim())
           return true
@@ -1447,14 +1290,7 @@ export function useCanvasFileIntake({
     }
 
     return false
-  }, [
-    addHtmlToCanvas,
-    addImageToCanvas,
-    addImagesToCanvas,
-    addTextToCanvas,
-    handleFile,
-    readFileAsDataURL
-  ])
+  }, [addImageToCanvas, addImagesToCanvas, addTextToCanvas, handleFile, readFileAsDataURL])
 
   const handleNativeClipboardPaste = useCallback(async () => {
     try {
@@ -1475,33 +1311,26 @@ export function useCanvasFileIntake({
         return true
       }
 
-      if (typeof hyperSvc.readClipboardHtml === 'function') {
-        const nativeClipboardHtml = await hyperSvc.readClipboardHtml({})
-        const structuredClipboardHtml = getStructuredClipboardHtmlFromPayload(
-          nativeClipboardHtml.html
-        )
-        if (structuredClipboardHtml) {
-          addHtmlToCanvas(structuredClipboardHtml)
-          return true
-        }
-      }
-
       const nativeClipboardText = await hyperSvc.readClipboardText({})
-      const tabularTextHtml = buildClipboardTableHtml(nativeClipboardText.text)
-      if (tabularTextHtml) {
-        addHtmlToCanvas(tabularTextHtml)
-        return true
-      }
       if (nativeClipboardText.text.trim()) {
         addTextToCanvas(nativeClipboardText.text.trim())
         return true
+      }
+
+      if (typeof hyperSvc.readClipboardHtml === 'function') {
+        const nativeClipboardHtml = await hyperSvc.readClipboardHtml({})
+        const htmlText = normalizeClipboardHtmlText(nativeClipboardHtml.html)
+        if (htmlText.trim()) {
+          addTextToCanvas(htmlText.trim())
+          return true
+        }
       }
     } catch {
       // Ignore native clipboard access failures and continue.
     }
 
     return false
-  }, [addHtmlToCanvas, addImageToCanvas, addTextToCanvas, readFileAsDataURL])
+  }, [addImageToCanvas, addTextToCanvas, readFileAsDataURL])
 
   const handlePasteFromClipboard = useCallback(
     async (event?: ClipboardEvent) => {

--- a/packages/app/src/renderer/src/pages/QuickAppPage/CustomSkillManagerPage.test.tsx
+++ b/packages/app/src/renderer/src/pages/QuickAppPage/CustomSkillManagerPage.test.tsx
@@ -428,6 +428,18 @@ describe('CustomSkillManagerPage', () => {
       fireEvent.click(screen.getByTestId('custom-skill-card-skill-2'))
 
       const editDialog = await screen.findByTestId('custom-skill-edit-dialog')
+      const outputModeSelect = within(editDialog).getByLabelText('Output Mode')
+      const outputModeOptions = within(outputModeSelect).getAllByRole(
+        'option'
+      ) as HTMLOptionElement[]
+      expect(outputModeOptions.map((option) => option.value)).toEqual([
+        'default',
+        'text',
+        'image',
+        'video',
+        'model3d'
+      ])
+
       fireEvent.change(within(editDialog).getByLabelText('Input Strategy'), {
         target: { value: 'single-file' }
       })
@@ -591,7 +603,7 @@ describe('CustomSkillManagerPage', () => {
         target: { value: '0' }
       })
       fireEvent.change(within(editDialog).getByLabelText('Output Mode'), {
-        target: { value: 'structured' }
+        target: { value: 'image' }
       })
 
       await waitFor(() =>
@@ -608,7 +620,7 @@ describe('CustomSkillManagerPage', () => {
                 mode: 'isolated',
                 allowHistory: false,
                 contextMessageLimit: 0,
-                outputMode: 'structured'
+                outputMode: 'image'
               })
             })
           ])
@@ -795,6 +807,9 @@ describe('CustomSkillManagerPage', () => {
               prompt: 'Collect loose inspiration notes.',
               instructions: expect.objectContaining({
                 systemPrompt: 'Collect loose inspiration notes.'
+              }),
+              execution: expect.objectContaining({
+                outputMode: 'default'
               })
             })
           ])

--- a/packages/app/src/renderer/src/pages/QuickAppPage/CustomSkillManagerPage.tsx
+++ b/packages/app/src/renderer/src/pages/QuickAppPage/CustomSkillManagerPage.tsx
@@ -59,6 +59,54 @@ import {
 const DEFAULT_PROMPT_ROWS = 14
 const COLLAPSED_PROMPT_ROWS = 3
 
+const CUSTOM_SKILL_OUTPUT_MODE_OPTIONS = [
+  { value: 'default', zh: '默认', en: 'Default' },
+  { value: 'text', zh: '文本', en: 'Text' },
+  { value: 'image', zh: '图片', en: 'Image' },
+  { value: 'video', zh: '视频', en: 'Video' },
+  { value: 'model3d', zh: '3D', en: '3D' }
+] as const
+
+type WorkshopOutputMode = (typeof CUSTOM_SKILL_OUTPUT_MODE_OPTIONS)[number]['value']
+
+const normalizeWorkshopOutputMode = (
+  value: NonNullable<CustomSkill['execution']>['outputMode'] | undefined
+): WorkshopOutputMode => {
+  switch (value) {
+    case 'default':
+    case 'text':
+    case 'image':
+    case 'video':
+    case 'model3d':
+      return value
+    case 'chat':
+    case 'sidecar':
+    case 'structured':
+      return 'text'
+    default:
+      return 'default'
+  }
+}
+
+const normalizeWorkshopSkillOutputMode = (skill: CustomSkill): CustomSkill => {
+  if (isBuiltInSkillId(skill.id)) {
+    return skill
+  }
+
+  const outputMode = skill.execution?.outputMode
+  if (outputMode !== 'chat' && outputMode !== 'sidecar' && outputMode !== 'structured') {
+    return skill
+  }
+
+  return {
+    ...skill,
+    execution: {
+      ...(skill.execution || {}),
+      outputMode: 'text'
+    }
+  }
+}
+
 // ==========================================
 // 样式常量
 // ==========================================
@@ -86,15 +134,17 @@ const getSkillReferenceAttachmentLabel = (
   return attachment.fileName ? `${prefix} - ${attachment.fileName}` : prefix
 }
 
-const sanitizeSkillEditorState = (skill: CustomSkill): CustomSkill =>
-  skill.type === 'agent'
+const sanitizeSkillEditorState = (skill: CustomSkill): CustomSkill => {
+  const normalizedSkill = normalizeWorkshopSkillOutputMode(skill)
+  return normalizedSkill.type === 'agent'
     ? {
-        ...skill,
+        ...normalizedSkill,
         prompt: '',
         instructions: undefined,
         referenceAttachments: []
       }
-    : skill
+    : normalizedSkill
+}
 
 type QuickAppPromptPatch = {
   plugin_config: {
@@ -436,7 +486,7 @@ const CustomSkillManagerPage: React.FC = () => {
 
   const mergeDefaultSkills = useCallback(
     (skills: CustomSkill[]) =>
-      mergeBuiltInSkills(skills, {
+      mergeBuiltInSkills(skills.map(normalizeWorkshopSkillOutputMode), {
         language,
         config
       }),
@@ -732,7 +782,7 @@ const CustomSkillManagerPage: React.FC = () => {
       execution: {
         mode: 'inherit',
         allowHistory: true,
-        outputMode: 'chat',
+        outputMode: 'default',
         fallbackStrategy: 'default',
         persistSessionUrl: true,
         contextMessageLimit: 'all'
@@ -1704,7 +1754,7 @@ const CustomSkillManagerPage: React.FC = () => {
               label={t('custom_workshop.skill_output_mode_label', {
                 defaultValue: uiText('输出模式', 'Output Mode')
               })}
-              value={selectedSkill?.execution?.outputMode || 'chat'}
+              value={normalizeWorkshopOutputMode(selectedSkill?.execution?.outputMode)}
               onChange={(event) =>
                 handleUpdateSelectedSkillExecution({
                   outputMode: event.target.value as NonNullable<
@@ -1716,9 +1766,11 @@ const CustomSkillManagerPage: React.FC = () => {
               sx={workshopFieldSx}
               fullWidth
             >
-              <option value="chat">{uiText('聊天文本', 'chat')}</option>
-              <option value="sidecar">{uiText('附属文本', 'sidecar')}</option>
-              <option value="structured">{uiText('结构化输出', 'structured')}</option>
+              {CUSTOM_SKILL_OUTPUT_MODE_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {uiText(option.zh, option.en)}
+                </option>
+              ))}
             </TextField>
             <TextField
               select

--- a/packages/app/src/renderer/src/pages/QuickAppPage/CustomSkillManagerPage.tsx
+++ b/packages/app/src/renderer/src/pages/QuickAppPage/CustomSkillManagerPage.tsx
@@ -60,10 +60,10 @@ const DEFAULT_PROMPT_ROWS = 14
 const COLLAPSED_PROMPT_ROWS = 3
 
 const CUSTOM_SKILL_OUTPUT_MODE_OPTIONS = [
-  { value: 'default', zh: '默认', en: 'Default' },
-  { value: 'text', zh: '文本', en: 'Text' },
-  { value: 'image', zh: '图片', en: 'Image' },
-  { value: 'video', zh: '视频', en: 'Video' },
+  { value: 'default', zh: String.fromCharCode(0x9ed8, 0x8ba4), en: 'Default' },
+  { value: 'text', zh: String.fromCharCode(0x6587, 0x672c), en: 'Text' },
+  { value: 'image', zh: String.fromCharCode(0x56fe, 0x7247), en: 'Image' },
+  { value: 'video', zh: String.fromCharCode(0x89c6, 0x9891), en: 'Video' },
   { value: 'model3d', zh: '3D', en: '3D' }
 ] as const
 

--- a/packages/app/src/renderer/src/pages/QuickAppPage/components/QAppMenu.tsx
+++ b/packages/app/src/renderer/src/pages/QuickAppPage/components/QAppMenu.tsx
@@ -40,6 +40,7 @@ import { useMessage } from '@renderer/hooks/useMessage'
 import { useComfyEventCallback } from '@renderer/hooks/useComfyEvent'
 import { api } from '@renderer/utils/windowUtils'
 import { QAppMenuItem } from '@shared/api/svcQApp'
+import { isComfyFrontendOnlyNodeClassType } from '@shared/comfy/funcs'
 import type { Config } from '@shared/config/config'
 import { useConfig } from '@renderer/hooks/useConfig'
 import { useTranslation } from 'react-i18next'
@@ -1098,7 +1099,11 @@ export default function QAppMenu({
 
           // 如果是 LoRA 相关节点，不计入匹配（因为这些节点可能被动态增减）
           const classType = String(templateNode.class_type)
-          if (classType === 'LoraLoader' || classType === 'LoraLoaderModelOnly') {
+          if (
+            classType === 'LoraLoader' ||
+            classType === 'LoraLoaderModelOnly' ||
+            isComfyFrontendOnlyNodeClassType(classType)
+          ) {
             skipped++
             continue
           }
@@ -1116,7 +1121,11 @@ export default function QAppMenu({
         const imageNonLoraKeys = imageKeys.filter((k) => {
           const n = imageWf[k] as Record<string, unknown> | undefined
           const ct = String(n?.class_type || '')
-          return ct !== 'LoraLoader' && ct !== 'LoraLoaderModelOnly'
+          return (
+            ct !== 'LoraLoader' &&
+            ct !== 'LoraLoaderModelOnly' &&
+            !isComfyFrontendOnlyNodeClassType(ct)
+          )
         })
         const sizeDiffRatio =
           Math.abs(imageNonLoraKeys.length - coreTemplateNodes) / coreTemplateNodes

--- a/packages/app/src/renderer/src/pages/QuickAppPage/utils/qAppSubmitWorkflow.test.ts
+++ b/packages/app/src/renderer/src/pages/QuickAppPage/utils/qAppSubmitWorkflow.test.ts
@@ -33,4 +33,44 @@ describe('buildQAppSubmitWorkflowRequest', () => {
       prompt: {} as never
     })
   })
+
+  it('removes ComfyUI front-end-only nodes before submission', () => {
+    const request = buildQAppSubmitWorkflowRequest({
+      prompt: {
+        '10': {
+          class_type: 'SeedVR2VideoUpscaler',
+          inputs: {
+            image: ['31', 0]
+          }
+        },
+        '18': {
+          class_type: 'Note',
+          inputs: {
+            value: 'Enable to upscale alpha/mask channel along with RGB channel.'
+          }
+        },
+        '31': {
+          class_type: 'LoadImage',
+          inputs: {
+            image: 'input.png'
+          }
+        }
+      }
+    })
+
+    expect(request.prompt).toEqual({
+      '10': {
+        class_type: 'SeedVR2VideoUpscaler',
+        inputs: {
+          image: ['31', 0]
+        }
+      },
+      '31': {
+        class_type: 'LoadImage',
+        inputs: {
+          image: 'input.png'
+        }
+      }
+    })
+  })
 })

--- a/packages/app/src/renderer/src/pages/QuickAppPage/utils/qAppSubmitWorkflow.ts
+++ b/packages/app/src/renderer/src/pages/QuickAppPage/utils/qAppSubmitWorkflow.ts
@@ -1,4 +1,5 @@
 import type { SubmitWorkflowReq } from '@shared/api/svcComfy'
+import { normalizeExecutableWorkflow } from '@shared/comfy/funcs'
 import type { Workflow } from '@shared/comfy/types'
 import type { JsonDict } from '@shared/utils/utilTypes'
 
@@ -18,7 +19,7 @@ const cleanString = (value?: string | null): string | undefined => {
 export const buildQAppSubmitWorkflowRequest = (
   options: BuildQAppSubmitWorkflowRequestOptions
 ): SubmitWorkflowReq => ({
-  prompt: options.prompt,
+  prompt: normalizeExecutableWorkflow(options.prompt),
   ...(cleanString(options.qAppKey) ? { qAppKey: cleanString(options.qAppKey) } : {}),
   ...(cleanString(options.clientId) ? { clientId: cleanString(options.clientId) } : {}),
   ...(cleanString(options.sessionKey) ? { sessionKey: cleanString(options.sessionKey) } : {}),

--- a/packages/app/src/renderer/src/utils/qappUtils.ts
+++ b/packages/app/src/renderer/src/utils/qappUtils.ts
@@ -1,4 +1,5 @@
 import { QAppMenuItem } from '@shared/api/svcQApp'
+import { isComfyFrontendOnlyNodeClassType } from '@shared/comfy/funcs'
 
 export const flattenQAppItems = (items: QAppMenuItem[]): QAppMenuItem[] => {
   const res: QAppMenuItem[] = []
@@ -73,7 +74,11 @@ export const compareWorkflows = (
 
       // 如果是 LoRA 相关节点，不计入匹配（因为这些节点可能被动态增减）
       const classType = String(templateNode.class_type)
-      if (classType === 'LoraLoader' || classType === 'LoraLoaderModelOnly') {
+      if (
+        classType === 'LoraLoader' ||
+        classType === 'LoraLoaderModelOnly' ||
+        isComfyFrontendOnlyNodeClassType(classType)
+      ) {
         skipped++
         continue
       }
@@ -91,7 +96,9 @@ export const compareWorkflows = (
     const imageNonLoraKeys = imageKeys.filter((k) => {
       const n = imageWf[k] as Record<string, unknown> | undefined
       const ct = String(n?.class_type || '')
-      return ct !== 'LoraLoader' && ct !== 'LoraLoaderModelOnly'
+      return (
+        ct !== 'LoraLoader' && ct !== 'LoraLoaderModelOnly' && !isComfyFrontendOnlyNodeClassType(ct)
+      )
     })
     const sizeDiffRatio = Math.abs(imageNonLoraKeys.length - coreTemplateNodes) / coreTemplateNodes
 

--- a/packages/app/src/renderer/src/utils/resolveImportedWorkflow.ts
+++ b/packages/app/src/renderer/src/utils/resolveImportedWorkflow.ts
@@ -1,4 +1,5 @@
 import { buildQAppCfgFromAppMode, extractAppModeMetadata } from '@shared/comfy/appModeInterop'
+import { normalizeExecutableWorkflow } from '@shared/comfy/funcs'
 import { convertGuiWorkflowToPrompt, isGuiWorkflow } from '@shared/comfy/guiWorkflowToPrompt'
 import { isWorkflow } from '@shared/comfy/typeGuards'
 import { ObjectInfoMap, Workflow } from '@shared/comfy/types'
@@ -74,6 +75,8 @@ export async function resolveImportedWorkflow(
 ): Promise<ResolveImportedWorkflowResult> {
   const { prompt: promptCandidate, gui } = unwrapCandidates(input)
   let workflow: Workflow | undefined = promptCandidate
+    ? normalizeExecutableWorkflow(promptCandidate)
+    : undefined
   let objectInfos = options.objectInfos
 
   if (!workflow && gui) {

--- a/packages/app/src/shared/comfy/funcs.test.ts
+++ b/packages/app/src/shared/comfy/funcs.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { fileItemToValue, findNotInstalledNodeInfo, valueToFileItem } from './funcs'
+import {
+  fileItemToValue,
+  findNotInstalledNodeInfo,
+  normalizeExecutableWorkflow,
+  parseAllNodeIdAndField,
+  valueToFileItem
+} from './funcs'
 import { ObjectInfoMap, Workflow } from './types'
 
 describe('valueToFileItem', () => {
@@ -65,5 +71,45 @@ describe('findNotInstalledNodeCls', () => {
     }
     // Note 和 Reroute 应该被排除，只有 Node1 应该被标记为未安装
     expect(findNotInstalledNodeInfo(workflow, objectInfos)).toEqual(['Node1'])
+  })
+})
+
+describe('normalizeExecutableWorkflow', () => {
+  it('removes Note nodes before a workflow is submitted', () => {
+    const workflow: Workflow = {
+      '1': { class_type: 'LoadImage', inputs: { image: 'input.png' } },
+      '18': { class_type: 'Note', inputs: { value: 'This is a UI-only note.' } },
+      '5': { class_type: 'SaveImage', inputs: { images: ['1', 0] } }
+    }
+
+    expect(normalizeExecutableWorkflow(workflow)).toEqual({
+      '1': { class_type: 'LoadImage', inputs: { image: 'input.png' } },
+      '5': { class_type: 'SaveImage', inputs: { images: ['1', 0] } }
+    })
+  })
+
+  it('removes Reroute nodes and reconnects downstream inputs to their source', () => {
+    const workflow: Workflow = {
+      '1': { class_type: 'LoadImage', inputs: { image: 'input.png' } },
+      '2': { class_type: 'Reroute', inputs: { input: ['1', 0] } },
+      '3': { class_type: 'Reroute', inputs: { input: ['2', 0] } },
+      '5': { class_type: 'SaveImage', inputs: { images: ['3', 0] } }
+    }
+
+    expect(normalizeExecutableWorkflow(workflow)).toEqual({
+      '1': { class_type: 'LoadImage', inputs: { image: 'input.png' } },
+      '5': { class_type: 'SaveImage', inputs: { images: ['1', 0] } }
+    })
+  })
+})
+
+describe('parseAllNodeIdAndField', () => {
+  it('does not offer UI-only nodes as selectable workflow inputs', () => {
+    const workflow: Workflow = {
+      '1': { class_type: 'LoadImage', inputs: { image: 'input.png' } },
+      '18': { class_type: 'Note', inputs: { value: 'This is a UI-only note.' } }
+    }
+
+    expect(parseAllNodeIdAndField(workflow)).toEqual([{ nodeId: '1', field: 'image' }])
   })
 })

--- a/packages/app/src/shared/comfy/funcs.ts
+++ b/packages/app/src/shared/comfy/funcs.ts
@@ -1,5 +1,5 @@
 import { JsonPath, parseJsonPath } from '@shared/utils/jsonPath'
-import { ObjectInfoMap, FileItem, Workflow } from './types'
+import { ObjectInfoMap, FileItem, Workflow, WorkflowInputRef, WorkflowInputValue } from './types'
 
 /**
  * Find the comfy input option list by class type and field
@@ -137,6 +137,7 @@ export const fieldByJsonPath = (jsonPath: JsonPath, workflow: Workflow): string 
 export function parseAllNodeIdAndField(workflow: Workflow): { nodeId: string; field: string }[] {
   return Object.entries(workflow)
     .filter(([key]) => !key.startsWith('__')) // Filter out metadata keys
+    .filter(([, node]) => !isComfyFrontendOnlyNodeClassType(node.class_type))
     .flatMap(([nodeId, node]) => {
       return Object.keys(node.inputs).map((field) => {
         return { nodeId, field }
@@ -148,7 +149,110 @@ export function parseAllNodeIdAndField(workflow: Workflow): { nodeId: string; fi
  * ComfyUI 内置核心节点列表
  * 这些节点是 ComfyUI 自带的，不需要安装，应该被排除在未安装节点检查之外
  */
-const COMFYUI_BUILTIN_NODES = new Set(['Note', 'Reroute'])
+export const COMFYUI_FRONTEND_ONLY_NODE_TYPES = new Set(['Note', 'Reroute'])
+
+const COMFYUI_BUILTIN_NODES = COMFYUI_FRONTEND_ONLY_NODE_TYPES
+
+export function isComfyFrontendOnlyNodeClassType(classType: string | undefined): boolean {
+  return !!classType && COMFYUI_FRONTEND_ONLY_NODE_TYPES.has(classType)
+}
+
+function isWorkflowInputRef(value: unknown): value is WorkflowInputRef {
+  return (
+    Array.isArray(value) &&
+    value.length === 2 &&
+    (typeof value[0] === 'string' || typeof value[0] === 'number') &&
+    typeof value[1] === 'number'
+  )
+}
+
+function normalizeWorkflowInputRef(value: WorkflowInputRef): WorkflowInputRef {
+  return [String(value[0]), value[1]]
+}
+
+function getFirstInputRef(node: { inputs?: Record<string, unknown> }): WorkflowInputRef | null {
+  for (const inputValue of Object.values(node.inputs ?? {})) {
+    if (isWorkflowInputRef(inputValue)) {
+      return normalizeWorkflowInputRef(inputValue)
+    }
+  }
+  return null
+}
+
+function resolveExecutableInputRef(
+  workflow: Workflow,
+  inputRef: WorkflowInputRef,
+  visitedNodeIds: Set<string> = new Set()
+): WorkflowInputRef | null {
+  const normalizedRef = normalizeWorkflowInputRef(inputRef)
+  const [sourceNodeId] = normalizedRef
+  const sourceNode = workflow[sourceNodeId]
+
+  if (!sourceNode) {
+    return normalizedRef
+  }
+
+  if (sourceNode.class_type === 'Reroute') {
+    if (visitedNodeIds.has(sourceNodeId)) {
+      return null
+    }
+    visitedNodeIds.add(sourceNodeId)
+
+    const rerouteInputRef = getFirstInputRef(sourceNode)
+    return rerouteInputRef
+      ? resolveExecutableInputRef(workflow, rerouteInputRef, visitedNodeIds)
+      : null
+  }
+
+  if (isComfyFrontendOnlyNodeClassType(sourceNode.class_type)) {
+    return null
+  }
+
+  return normalizedRef
+}
+
+/**
+ * Remove ComfyUI UI-only nodes from an API prompt.
+ *
+ * GUI exports can contain nodes such as Note and Reroute. They are useful in the
+ * editor, but ComfyUI's prompt endpoint does not execute them and reports
+ * "Node type not found" when they are submitted as class_type entries.
+ */
+export function normalizeExecutableWorkflow(workflow: Workflow): Workflow {
+  const normalized: Workflow = {}
+  const normalizedRecord = normalized as unknown as Record<string, unknown>
+
+  for (const [nodeId, node] of Object.entries(workflow)) {
+    if (nodeId.startsWith('__')) {
+      normalizedRecord[nodeId] = node
+      continue
+    }
+
+    if (isComfyFrontendOnlyNodeClassType(node.class_type)) {
+      continue
+    }
+
+    const inputs: Record<string, WorkflowInputValue> = {}
+    for (const [inputName, inputValue] of Object.entries(node.inputs)) {
+      if (isWorkflowInputRef(inputValue)) {
+        const resolvedInputRef = resolveExecutableInputRef(workflow, inputValue)
+        if (resolvedInputRef) {
+          inputs[inputName] = resolvedInputRef
+        }
+        continue
+      }
+
+      inputs[inputName] = inputValue
+    }
+
+    normalized[nodeId] = {
+      ...node,
+      inputs
+    }
+  }
+
+  return normalized
+}
 
 /**
  * Find the not installed node class type in the workflow

--- a/packages/app/src/shared/comfy/guiWorkflowToPrompt.test.ts
+++ b/packages/app/src/shared/comfy/guiWorkflowToPrompt.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import { convertGuiWorkflowToPrompt } from './guiWorkflowToPrompt'
+
+describe('convertGuiWorkflowToPrompt', () => {
+  it('does not carry Note nodes from GUI workflow exports into executable prompts', () => {
+    const workflow = convertGuiWorkflowToPrompt({
+      nodes: [
+        {
+          id: 1,
+          type: 'LoadImage',
+          title: 'Load Image',
+          inputs: [],
+          outputs: [],
+          widgets_values: ['input.png'],
+          properties: {
+            widget_ue_connectable: {
+              image: {}
+            }
+          }
+        },
+        {
+          id: 18,
+          type: 'Note',
+          inputs: [],
+          outputs: [],
+          widgets_values: ['Enable to upscale alpha/mask channel along with RGB channel.']
+        },
+        {
+          id: 5,
+          type: 'SaveImage',
+          title: 'Save Image',
+          inputs: [{ name: 'images', link: 1 }],
+          outputs: []
+        }
+      ],
+      links: [[1, 1, 0, 5, 0, 'IMAGE']]
+    })
+
+    expect(workflow).toEqual({
+      '1': {
+        class_type: 'LoadImage',
+        inputs: {
+          image: 'input.png'
+        },
+        _meta: {
+          title: 'Load Image'
+        }
+      },
+      '5': {
+        class_type: 'SaveImage',
+        inputs: {
+          images: ['1', 0]
+        },
+        _meta: {
+          title: 'Save Image'
+        }
+      }
+    })
+  })
+})

--- a/packages/app/src/shared/comfy/guiWorkflowToPrompt.ts
+++ b/packages/app/src/shared/comfy/guiWorkflowToPrompt.ts
@@ -1,4 +1,5 @@
 import { ObjectInfo, ObjectInfoMap, Workflow, WorkflowInputValue, WorkflowNode } from './types'
+import { normalizeExecutableWorkflow } from './funcs'
 
 export type GuiNode = {
   id: number
@@ -261,5 +262,5 @@ export function convertGuiWorkflowToPrompt(
     workflow[nodeId] = wfNode
   }
 
-  return workflow
+  return normalizeExecutableWorkflow(workflow)
 }

--- a/packages/app/src/shared/config/config.ts
+++ b/packages/app/src/shared/config/config.ts
@@ -72,7 +72,15 @@ export type SkillReferenceAttachment = {
 }
 
 export type CustomSkillExecutionMode = 'inherit' | 'isolated'
-export type CustomSkillOutputMode = 'chat' | 'sidecar' | 'structured'
+export type CustomSkillOutputMode =
+  | 'default'
+  | 'text'
+  | 'image'
+  | 'video'
+  | 'model3d'
+  | 'chat'
+  | 'sidecar'
+  | 'structured'
 export type CustomSkillFallbackStrategy = 'default' | 'smaller-batches' | 'single-file'
 export type CustomSkillContextMessageLimit = 0 | 3 | 5 | 10 | 'all'
 export type CustomSkillOutputSchema = JsonValue


### PR DESCRIPTION
﻿## What changed
- Strip ComfyUI frontend-only workflow nodes before converting/saving/submitting QApp workflows.
- Add coverage for frontend-only node cleanup across shared workflow helpers, import resolution, submit flow, and Comfy API handling.
- Keep the QuickApp menu export path aligned with the cleanup behavior.

## Why
Frontend-only UI nodes can leak into prompt conversion or persisted workflows, which can produce invalid backend prompts or noisy workflow payloads.

## Impact
Users can paste, import, save, and submit affected QApp workflows without carrying non-backend ComfyUI UI-only nodes into backend execution paths.

## Validation
- `npm run typecheck:web`
- `npx vitest run --config config/vitest/vitest.node.config.mjs packages/app/src/main/api/svcComfyImpl.test.ts packages/app/src/shared/comfy/funcs.test.ts packages/app/src/shared/comfy/guiWorkflowToPrompt.test.ts`
- `npx vitest run --config config/vitest/vitest.web.config.mjs packages/app/src/renderer/src/pages/QuickAppPage/utils/qAppSubmitWorkflow.test.ts`
