### PR TITLE
[codex] Fix chat composer input stability

### DIFF
--- a/packages/app/src/renderer/src/pages/ChatPage/ChatPage.runtimeFlow.test.tsx
+++ b/packages/app/src/renderer/src/pages/ChatPage/ChatPage.runtimeFlow.test.tsx
@@ -767,6 +767,93 @@ describe('ChatPage runtime workflow integration', () => {
     })
   })
 
+  it('routes unscoped send-to-agent input only into the active mounted ChatPage', async () => {
+    render(
+      <ThemeProvider theme={theme}>
+        <div data-testid="agent-a">
+          <ChatPage compact storageScope="runtime-flow-a" active={false} />
+        </div>
+        <div data-testid="agent-b">
+          <ChatPage compact storageScope="runtime-flow-b" active />
+        </div>
+      </ThemeProvider>
+    )
+
+    const agentA = screen.getByTestId('agent-a')
+    const agentB = screen.getByTestId('agent-b')
+
+    await waitFor(() =>
+      expect(within(agentA).getByTestId('chat-composer-mock')).toBeInTheDocument()
+    )
+    await waitFor(() =>
+      expect(within(agentB).getByTestId('chat-composer-mock')).toBeInTheDocument()
+    )
+
+    await act(async () => {
+      window.dispatchEvent(
+        new CustomEvent('send-to-agent', {
+          detail: {
+            text: 'active agent only',
+            attachment: createImageAttachment('active-only.png')
+          }
+        })
+      )
+    })
+
+    await waitFor(() => {
+      expect(within(agentA).getByTestId('chat-composer-input-mock')).toHaveValue('')
+      expect(within(agentA).getByTestId('chat-composer-attachment-count').textContent).toBe('0')
+      expect(within(agentB).getByTestId('chat-composer-input-mock')).toHaveValue(
+        'active agent only'
+      )
+      expect(within(agentB).getByTestId('chat-composer-attachment-count').textContent).toBe('1')
+      expect(within(agentB).getByTestId('chat-composer-attachment-names').textContent).toContain(
+        'active-only.png'
+      )
+    })
+  })
+
+  it('allows scoped send-to-agent input to mutate an explicit inactive target scope', async () => {
+    render(
+      <ThemeProvider theme={theme}>
+        <div data-testid="agent-a">
+          <ChatPage compact storageScope="runtime-flow-a" active />
+        </div>
+        <div data-testid="agent-b">
+          <ChatPage compact storageScope="runtime-flow-b" active={false} />
+        </div>
+      </ThemeProvider>
+    )
+
+    const agentA = screen.getByTestId('agent-a')
+    const agentB = screen.getByTestId('agent-b')
+
+    await waitFor(() =>
+      expect(within(agentA).getByTestId('chat-composer-mock')).toBeInTheDocument()
+    )
+    await waitFor(() =>
+      expect(within(agentB).getByTestId('chat-composer-mock')).toBeInTheDocument()
+    )
+
+    await act(async () => {
+      window.dispatchEvent(
+        new CustomEvent('send-to-agent', {
+          detail: {
+            text: 'explicit inactive target',
+            targetScope: 'runtime-flow-b'
+          }
+        })
+      )
+    })
+
+    await waitFor(() => {
+      expect(within(agentA).getByTestId('chat-composer-input-mock')).toHaveValue('')
+      expect(within(agentB).getByTestId('chat-composer-input-mock')).toHaveValue(
+        'explicit inactive target'
+      )
+    })
+  })
+
   it('handles unscoped compact chat events only in the active mounted ChatPage', async () => {
     render(
       <ThemeProvider theme={theme}>
@@ -1141,6 +1228,90 @@ describe('ChatPage runtime workflow integration', () => {
     await act(async () => {
       releaseSaveSessionToDB?.()
       hoisted.saveSessionToDBGate.value = null
+    })
+  })
+
+  it('does not let an older async draft persistence restore over newer composer input', async () => {
+    const user = userEvent.setup()
+    const originalFetch = globalThis.fetch
+    let releaseFetch: (() => void) | null = null
+    const fetchMock = vi.fn(
+      () =>
+        new Promise<Response>((resolve) => {
+          releaseFetch = () =>
+            resolve(new Response(new Blob(['old'], { type: 'model/gltf-binary' })))
+        })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    try {
+      renderChatPage('runtime-flow-stale-draft')
+
+      await waitFor(() => expect(screen.getByTestId('chat-composer-mock')).toBeInTheDocument())
+      await waitFor(() => expect(readCurrentSessionState()?.id).toBeTruthy())
+
+      await user.type(screen.getByTestId('chat-composer-input-mock'), 'stale draft')
+
+      hoisted.selectFileMock.mockResolvedValueOnce(
+        new File(['stale'], 'stale.glb', { type: 'model/gltf-binary' })
+      )
+      await user.click(screen.getByTestId('chat-composer-upload-mock'))
+
+      await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+
+      await user.type(screen.getByTestId('chat-composer-input-mock'), ' plus fresh edit')
+
+      await act(async () => {
+        releaseFetch?.()
+        await Promise.resolve()
+      })
+
+      expect(screen.getByTestId('chat-composer-input-mock')).toHaveValue(
+        'stale draft plus fresh edit'
+      )
+
+      await act(async () => {
+        await new Promise((resolve) => window.setTimeout(resolve, 250))
+      })
+      if (fetchMock.mock.calls.length > 1) {
+        await act(async () => {
+          releaseFetch?.()
+          await Promise.resolve()
+        })
+      }
+    } finally {
+      vi.stubGlobal('fetch', originalFetch)
+    }
+  })
+
+  it('does not keep another session draft when returning to a session with an empty draft', async () => {
+    const user = userEvent.setup()
+    renderChatPage('runtime-flow-empty-draft')
+
+    await waitFor(() => expect(screen.getByTestId('chat-composer-mock')).toBeInTheDocument())
+
+    let firstSessionId: string | undefined
+    await waitFor(() => {
+      firstSessionId = readCurrentSessionState()?.id
+      expect(firstSessionId).toBeTruthy()
+    })
+
+    const input = screen.getByTestId('chat-composer-input-mock')
+    await user.type(input, 'temporary draft')
+    await user.clear(input)
+
+    await dispatchNewSession({}, 'runtime-flow-empty-draft')
+    await waitFor(() => {
+      expect(readCurrentSessionState()?.id).not.toBe(firstSessionId)
+    })
+
+    await user.type(screen.getByTestId('chat-composer-input-mock'), 'second session draft')
+
+    await dispatchSwitchSession(firstSessionId as string, 'runtime-flow-empty-draft')
+
+    await waitFor(() => {
+      expect(readCurrentSessionState()?.id).toBe(firstSessionId)
+      expect(screen.getByTestId('chat-composer-input-mock')).toHaveValue('')
     })
   })
 

--- a/packages/app/src/renderer/src/pages/ChatPage/ChatPage.tsx
+++ b/packages/app/src/renderer/src/pages/ChatPage/ChatPage.tsx
@@ -191,6 +191,8 @@ type ExternalSendToAgentDetail = {
   hiddenText?: string
   attachment?: ChatAttachment
   attachments?: ChatAttachment[]
+  scope?: string
+  targetScope?: string
   autoSend?: boolean
 }
 
@@ -1173,6 +1175,21 @@ const ChatPage: React.FC<ChatPageProps> = ({
   const pendingAttachmentsRef = useRef<ChatAttachment[]>(pendingAttachments)
   const pendingHiddenContextRef = useRef(pendingHiddenContext)
   const pendingExternalSendToAgentRef = useRef<ExternalSendToAgentDetail[]>([])
+  const isApplyingDraftRef = useRef(false)
+  const composerDraftSessionIdRef = useRef<string | null>(currentSessionIdRef.current)
+  const composerDraftMutationRef = useRef<{ sessionId: string | null; updatedAt: number }>({
+    sessionId: currentSessionIdRef.current,
+    updatedAt: 0
+  })
+
+  const markComposerDraftMutated = useCallback(() => {
+    if (isApplyingDraftRef.current) return
+    composerDraftSessionIdRef.current = currentSessionIdRef.current
+    composerDraftMutationRef.current = {
+      sessionId: currentSessionIdRef.current,
+      updatedAt: Date.now()
+    }
+  }, [])
 
   const mergeHiddenContext = useCallback(
     (currentValue: string, ...nextValues: Array<string | undefined>) => {
@@ -1194,32 +1211,44 @@ const ChatPage: React.FC<ChatPageProps> = ({
     []
   )
 
-  const setInputValue = useCallback<React.Dispatch<React.SetStateAction<string>>>((value) => {
-    setInputValueState((prev) => {
-      const next = typeof value === 'function' ? value(prev) : value
-      inputValueRef.current = next
-      return next
-    })
-  }, [])
+  const setInputValue = useCallback<React.Dispatch<React.SetStateAction<string>>>(
+    (value) => {
+      setInputValueState((prev) => {
+        const next = typeof value === 'function' ? value(prev) : value
+        inputValueRef.current = next
+        if (next !== prev) {
+          markComposerDraftMutated()
+        }
+        return next
+      })
+    },
+    [markComposerDraftMutated]
+  )
   const setPendingAttachments = useCallback<React.Dispatch<React.SetStateAction<ChatAttachment[]>>>(
     (value) => {
       setPendingAttachmentsState((prev) => {
         const next = typeof value === 'function' ? value(prev) : value
         pendingAttachmentsRef.current = next
+        if (next !== prev) {
+          markComposerDraftMutated()
+        }
         return next
       })
     },
-    []
+    [markComposerDraftMutated]
   )
   const setPendingHiddenContext = useCallback<React.Dispatch<React.SetStateAction<string>>>(
     (value) => {
       setPendingHiddenContextState((prev) => {
         const next = typeof value === 'function' ? value(prev) : value
         pendingHiddenContextRef.current = next
+        if (next !== prev) {
+          markComposerDraftMutated()
+        }
         return next
       })
     },
-    []
+    [markComposerDraftMutated]
   )
 
   const applyExternalSendToAgentInput = useCallback(
@@ -1290,28 +1319,49 @@ const ChatPage: React.FC<ChatPageProps> = ({
   const applyDraftToComposerState = useCallback(
     (draft?: ChatSessionDraft | null) => {
       const normalizedDraft = cloneChatSessionDraft(normalizeChatSessionDraft(draft))
+      const targetSessionId = currentSessionIdRef.current
+      const localMutation = composerDraftMutationRef.current
+      if (
+        composerDraftSessionIdRef.current === targetSessionId &&
+        localMutation.sessionId === targetSessionId &&
+        localMutation.updatedAt > (normalizedDraft?.updatedAt ?? 0)
+      ) {
+        return
+      }
+
       const nextInputValue = normalizedDraft?.inputValue ?? ''
       const nextPendingAttachments = normalizedDraft?.pendingAttachments ?? []
       const nextPendingHiddenContext = normalizedDraft?.pendingHiddenContext ?? ''
 
-      if (inputValueRef.current !== nextInputValue) {
-        inputValueRef.current = nextInputValue
-        setInputValue(nextInputValue)
+      isApplyingDraftRef.current = true
+      try {
+        if (inputValueRef.current !== nextInputValue) {
+          inputValueRef.current = nextInputValue
+          setInputValue(nextInputValue)
+        }
+
+        const currentDraft = normalizeChatSessionDraft({
+          inputValue: inputValueRef.current,
+          pendingAttachments: pendingAttachmentsRef.current,
+          pendingHiddenContext: pendingHiddenContextRef.current,
+          updatedAt: normalizedDraft?.updatedAt ?? 0
+        })
+
+        if (!areChatSessionDraftsEqual(currentDraft, normalizedDraft)) {
+          pendingAttachmentsRef.current = nextPendingAttachments
+          pendingHiddenContextRef.current = nextPendingHiddenContext
+          setPendingAttachments(nextPendingAttachments)
+          setPendingHiddenContext(nextPendingHiddenContext)
+        }
+      } finally {
+        isApplyingDraftRef.current = false
       }
 
-      const currentDraft = normalizeChatSessionDraft({
-        inputValue: inputValueRef.current,
-        pendingAttachments: pendingAttachmentsRef.current,
-        pendingHiddenContext: pendingHiddenContextRef.current,
+      composerDraftMutationRef.current = {
+        sessionId: targetSessionId,
         updatedAt: normalizedDraft?.updatedAt ?? 0
-      })
-
-      if (!areChatSessionDraftsEqual(currentDraft, normalizedDraft)) {
-        pendingAttachmentsRef.current = nextPendingAttachments
-        pendingHiddenContextRef.current = nextPendingHiddenContext
-        setPendingAttachments(nextPendingAttachments)
-        setPendingHiddenContext(nextPendingHiddenContext)
       }
+      composerDraftSessionIdRef.current = targetSessionId
     },
     [setInputValue, setPendingAttachments, setPendingHiddenContext]
   )
@@ -1323,6 +1373,19 @@ const ChatPage: React.FC<ChatPageProps> = ({
       }
 
       const normalizedSnapshot = normalizeChatSessionDraft(snapshot)
+      const isStaleCurrentComposerSnapshot = (updatedAt = 0): boolean => {
+        const localMutation = composerDraftMutationRef.current
+        return (
+          sessionId === currentSessionIdRef.current &&
+          localMutation.sessionId === sessionId &&
+          localMutation.updatedAt > updatedAt
+        )
+      }
+
+      if (isStaleCurrentComposerSnapshot(normalizedSnapshot?.updatedAt ?? 0)) {
+        return
+      }
+
       const initialSessions = sessionsRef.current
       const initialSessionIndex = initialSessions.findIndex((session) => session.id === sessionId)
       if (initialSessionIndex < 0) {
@@ -1352,6 +1415,14 @@ const ChatPage: React.FC<ChatPageProps> = ({
             )
           })
         : undefined
+      if (
+        isStaleCurrentComposerSnapshot(
+          persistedDraft?.updatedAt ?? normalizedSnapshot?.updatedAt ?? 0
+        )
+      ) {
+        return
+      }
+
       writeSessionDraftBackup(
         sessionId,
         persistedDraft?.updatedAt ?? normalizedSnapshot?.updatedAt ?? Date.now(),
@@ -1795,7 +1866,11 @@ const ChatPage: React.FC<ChatPageProps> = ({
         }>
       ).detail
 
-      if (detail?.scope && detail.scope !== storageScope) return
+      if (detail?.scope) {
+        if (detail.scope !== storageScope) return
+      } else if (!active) {
+        return
+      }
       const sessionId = detail?.sessionId
       if (!sessionId) return
 
@@ -1824,7 +1899,7 @@ const ChatPage: React.FC<ChatPageProps> = ({
 
     window.addEventListener('chat:session-terminated', handleSessionTerminated)
     return () => window.removeEventListener('chat:session-terminated', handleSessionTerminated)
-  }, [emitPreviewRefresh, pendingExternalConfirmations, storageScope])
+  }, [active, emitPreviewRefresh, pendingExternalConfirmations, storageScope])
   useEffect(() => {
     if (!sessionsLoaded) {
       return
@@ -2165,84 +2240,28 @@ const ChatPage: React.FC<ChatPageProps> = ({
         hiddenText?: string
         attachment?: ChatAttachment
         attachments?: ChatAttachment[]
+        scope?: string
         targetScope?: string
         autoSend?: boolean
       }>
       const detail = customEvent.detail
-      if (detail.targetScope !== storageScope) return
+      const targetScope = detail.targetScope ?? detail.scope
+      if (targetScope) {
+        if (targetScope !== storageScope) return
+      } else if (!active) {
+        return
+      }
       if (!sessionsLoaded) {
-        pendingExternalSendToAgentRef.current.push({
-          image: detail.image,
-          text: detail.text,
-          hiddenText: detail.hiddenText,
-          attachment: detail.attachment,
-          attachments: detail.attachments,
-          autoSend: detail.autoSend
-        })
+        pendingExternalSendToAgentRef.current.push(detail)
         return
       }
 
-      // autoSend 模式：立即发送到 agent 线程
-      if (detail.autoSend && sendMessageRef.current) {
-        const sendAttachments =
-          detail.attachments && detail.attachments.length > 0 ? detail.attachments : undefined
-        void sendMessageRef.current({
-          content: detail.text || '',
-          attachments: sendAttachments,
-          hiddenContext: detail.hiddenText
-        })
-        return
-      }
-
-      if (detail.attachment?.url) {
-        setPendingAttachments((prev) => {
-          if (prev.some((item) => item.url === detail.attachment?.url)) return prev
-          return [...prev, detail.attachment as ChatAttachment]
-        })
-      }
-
-      if (detail.image) {
-        fetch(detail.image)
-          .then((res) => res.blob())
-          .then(async (blob) => {
-            const attachment = await buildImageChatAttachmentFromFile(
-              new File([blob], getDownloadFileNameFromUrl(detail.image as string, 'image.png'), {
-                type: blob.type || 'image/png'
-              }),
-              detail.image as string
-            )
-            setPendingAttachments((prev) => {
-              if (prev.some((a) => a.url === detail.image)) return prev
-              return [...prev, attachment]
-            })
-          })
-          .catch((err) => console.error('[ChatPage] Failed to parse canvas image:', err))
-      }
-
-      const txt = detail.text
-      if (txt) {
-        setInputValue((prev) => {
-          const base = prev.trim()
-          return base ? `${base}\n\n${txt}` : txt
-        })
-      }
-
-      if (detail.hiddenText) {
-        setPendingHiddenContext((prev) => mergeHiddenContext(prev, detail.hiddenText))
-      }
+      applyExternalSendToAgentInput(detail)
     }
 
     window.addEventListener('send-to-agent', handleSendToAgent)
     return () => window.removeEventListener('send-to-agent', handleSendToAgent)
-  }, [
-    acceptExternalInput,
-    mergeHiddenContext,
-    sessionsLoaded,
-    setInputValue,
-    setPendingAttachments,
-    setPendingHiddenContext,
-    storageScope
-  ])
+  }, [acceptExternalInput, active, applyExternalSendToAgentInput, sessionsLoaded, storageScope])
 
   useEffect(() => {
     const handleFocusComposer = (event: Event) => {
@@ -3117,7 +3136,11 @@ const ChatPage: React.FC<ChatPageProps> = ({
   useEffect(() => {
     const handleTerminateScope = (event: Event): void => {
       const customEvent = event as CustomEvent<{ scope?: string }>
-      if (customEvent.detail?.scope && customEvent.detail.scope !== storageScope) return
+      if (customEvent.detail?.scope) {
+        if (customEvent.detail.scope !== storageScope) return
+      } else if (!active) {
+        return
+      }
 
       const sessionIds = new Set<string>([
         ...loadingSessionIdsRef.current,
@@ -3129,7 +3152,11 @@ const ChatPage: React.FC<ChatPageProps> = ({
     }
     const handleTerminateSession = (event: Event): void => {
       const customEvent = event as CustomEvent<{ scope?: string; sessionId?: string }>
-      if (customEvent.detail?.scope && customEvent.detail.scope !== storageScope) return
+      if (customEvent.detail?.scope) {
+        if (customEvent.detail.scope !== storageScope) return
+      } else if (!active) {
+        return
+      }
       const sessionId = customEvent.detail?.sessionId
       if (!sessionId) return
 
@@ -3142,7 +3169,7 @@ const ChatPage: React.FC<ChatPageProps> = ({
       window.removeEventListener('chat:terminate-scope', handleTerminateScope)
       window.removeEventListener('chat:terminate-session', handleTerminateSession)
     }
-  }, [storageScope, terminateSession])
+  }, [active, storageScope, terminateSession])
 
   useEffect(() => {
     const handleAppendMessage = (event: Event) => {
@@ -3284,7 +3311,11 @@ const ChatPage: React.FC<ChatPageProps> = ({
 
     const handleScopeReadyPing = (event: Event) => {
       const customEvent = event as CustomEvent<{ scope?: string; requestId?: string }>
-      if (customEvent.detail?.scope && customEvent.detail.scope !== storageScope) return
+      if (customEvent.detail?.scope) {
+        if (customEvent.detail.scope !== storageScope) return
+      } else if (!active) {
+        return
+      }
       emitScopeReady(customEvent.detail?.requestId)
     }
 
@@ -3297,7 +3328,7 @@ const ChatPage: React.FC<ChatPageProps> = ({
       window.clearTimeout(timerId)
       window.removeEventListener('chat:ping-scope-ready', handleScopeReadyPing)
     }
-  }, [acceptExternalInput, storageScope])
+  }, [acceptExternalInput, active, storageScope])
 
   const deleteSession = (sessionId: string) => {
     terminateSession(sessionId)

--- a/packages/app/src/renderer/src/pages/ChatPage/components/ChatComposer.test.tsx
+++ b/packages/app/src/renderer/src/pages/ChatPage/components/ChatComposer.test.tsx
@@ -14,10 +14,16 @@ vi.mock('react-i18next', () => ({
 
 function ControlledChatComposer({
   initialValue,
-  renderNonce
+  renderNonce,
+  isLoading = false,
+  disabled = false,
+  onSend = vi.fn()
 }: {
   initialValue: string
   renderNonce?: number
+  isLoading?: boolean
+  disabled?: boolean
+  onSend?: () => void
 }) {
   const [value, setValue] = useState(initialValue)
   const inputRef = useRef<HTMLTextAreaElement | HTMLInputElement | null>(null)
@@ -27,14 +33,14 @@ function ControlledChatComposer({
       <ChatComposer
         inputValue={value}
         onInputChange={setValue}
-        onSend={vi.fn()}
+        onSend={onSend}
         onUploadFile={vi.fn()}
         pendingAttachments={[]}
         uploadProgress={{}}
         onRemoveAttachment={vi.fn()}
-        isLoading={false}
+        isLoading={isLoading}
         onStopGenerating={vi.fn()}
-        disabled={false}
+        disabled={disabled}
         composerInputRef={inputRef}
         onPreviewImage={vi.fn()}
       />
@@ -311,6 +317,64 @@ describe('ChatComposer', () => {
       overflowX: 'hidden',
       resize: 'none'
     })
+  })
+
+  it('renders a single native textarea for composer input', () => {
+    const { container } = render(<ControlledChatComposer initialValue="hello" />)
+
+    const textarea = screen.getByTestId('chat-composer-input')
+
+    expect(textarea.tagName).toBe('TEXTAREA')
+    expect(container.querySelectorAll('textarea')).toHaveLength(1)
+  })
+
+  it('does not send on Enter while IME composition is active', () => {
+    const onSend = vi.fn()
+    render(<ControlledChatComposer initialValue="draft" onSend={onSend} />)
+
+    const textarea = screen.getByTestId('chat-composer-input') as HTMLTextAreaElement
+
+    fireEvent.compositionStart(textarea)
+    fireEvent.keyDown(textarea, { key: 'Enter', code: 'Enter', charCode: 13 })
+
+    expect(onSend).not.toHaveBeenCalled()
+  })
+
+  it('keeps the input editable while generation is loading', () => {
+    const onInputChange = vi.fn()
+    render(
+      <ThemeProvider theme={theme}>
+        <ChatComposer
+          inputValue="draft"
+          onInputChange={onInputChange}
+          onSend={vi.fn()}
+          onUploadFile={vi.fn()}
+          pendingAttachments={[]}
+          uploadProgress={{}}
+          onRemoveAttachment={vi.fn()}
+          isLoading
+          onStopGenerating={vi.fn()}
+          disabled={false}
+          composerInputRef={{ current: null }}
+          onPreviewImage={vi.fn()}
+        />
+      </ThemeProvider>
+    )
+
+    const textarea = screen.getByTestId('chat-composer-input') as HTMLTextAreaElement
+
+    expect(textarea).not.toBeDisabled()
+
+    fireEvent.change(textarea, {
+      target: {
+        value: 'draft update',
+        selectionStart: 12,
+        selectionEnd: 12,
+        selectionDirection: 'none'
+      }
+    })
+
+    expect(onInputChange).toHaveBeenCalledWith('draft update')
   })
 
   it('keeps the caret at the edit position when typing in the middle', () => {

--- a/packages/app/src/renderer/src/pages/ChatPage/components/ChatComposer.tsx
+++ b/packages/app/src/renderer/src/pages/ChatPage/components/ChatComposer.tsx
@@ -1,4 +1,11 @@
-import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import React, {
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useLayoutEffect,
+  useRef,
+  useState
+} from 'react'
 import {
   Box,
   TextField,
@@ -13,6 +20,7 @@ import {
   Menu,
   MenuItem
 } from '@mui/material'
+import type { InputBaseComponentProps } from '@mui/material/InputBase'
 import {
   Send as SendIcon,
   Add as AddIcon,
@@ -97,6 +105,60 @@ const COMPOSER_VERTICAL_OVERHEAD = 140
 const MIN_ATTACHMENT_PREVIEW_HEIGHT = 88
 const MAX_ATTACHMENT_PREVIEW_HEIGHT = 240
 const ATTACHMENT_PREVIEW_HEIGHT_RATIO = 0.32
+
+const parseCssPixelValue = (value: unknown): number | null => {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null
+  if (typeof value !== 'string') return null
+
+  const parsed = Number.parseFloat(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+const StableNativeTextarea = React.forwardRef<HTMLTextAreaElement, InputBaseComponentProps>(
+  function StableNativeTextarea(props, forwardedRef) {
+    const { ownerState: _ownerState, style, value, defaultValue, onInput, rows, ...rest } = props
+    const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+
+    useImperativeHandle(forwardedRef, () => textareaRef.current as HTMLTextAreaElement)
+
+    const resizeTextarea = useCallback(() => {
+      const textarea = textareaRef.current
+      if (!textarea) return
+
+      const resolvedStyle = style as React.CSSProperties | undefined
+      const minHeight = parseCssPixelValue(resolvedStyle?.minHeight) ?? MIN_TEXTAREA_HEIGHT
+      const maxHeight = parseCssPixelValue(resolvedStyle?.maxHeight)
+
+      textarea.style.height = 'auto'
+      const nextHeight =
+        maxHeight == null
+          ? Math.max(minHeight, textarea.scrollHeight)
+          : Math.max(minHeight, Math.min(textarea.scrollHeight, maxHeight))
+      textarea.style.height = `${nextHeight}px`
+    }, [style])
+
+    useLayoutEffect(() => {
+      resizeTextarea()
+    }, [resizeTextarea, value, defaultValue])
+
+    const handleInput = (event: React.FormEvent<HTMLTextAreaElement>) => {
+      resizeTextarea()
+      ;(onInput as React.FormEventHandler<HTMLTextAreaElement> | undefined)?.(event)
+    }
+
+    return (
+      <textarea
+        {...(rest as React.TextareaHTMLAttributes<HTMLTextAreaElement>)}
+        ref={textareaRef}
+        rows={typeof rows === 'number' ? rows : 1}
+        value={value as string | number | readonly string[] | undefined}
+        defaultValue={defaultValue as string | number | readonly string[] | undefined}
+        onInput={handleInput}
+        style={style as React.CSSProperties | undefined}
+      />
+    )
+  }
+)
 
 type InputSelectionSnapshot = {
   value: string
@@ -404,6 +466,12 @@ const ChatComposer: React.FC<ChatComposerProps> = ({
   }
 
   const handleKeyDown = (event: React.KeyboardEvent) => {
+    const nativeEvent = event.nativeEvent as KeyboardEvent & { isComposing?: boolean }
+    const isImeComposing =
+      isComposingInputRef.current || nativeEvent.isComposing || nativeEvent.keyCode === 229
+
+    if (isImeComposing) return
+
     if (event.key === 'Enter' && !event.shiftKey) {
       event.preventDefault()
       onSend()
@@ -741,8 +809,6 @@ const ChatComposer: React.FC<ChatComposerProps> = ({
           <Box sx={{ width: '100%', minHeight: 0, mb: 1 }}>
             <TextField
               fullWidth
-              multiline
-              minRows={1}
               inputRef={composerInputRef}
               value={inputValue}
               onChange={handleInputChange}
@@ -752,6 +818,7 @@ const ChatComposer: React.FC<ChatComposerProps> = ({
               variant="standard"
               InputProps={{
                 disableUnderline: true,
+                inputComponent: StableNativeTextarea as React.ElementType<InputBaseComponentProps>,
                 startAdornment: selectedSkillName ? (
                   <Box
                     contentEditable={false}
@@ -805,6 +872,7 @@ const ChatComposer: React.FC<ChatComposerProps> = ({
               }}
               inputProps={{
                 'data-testid': 'chat-composer-input',
+                rows: 1,
                 onFocus: handleInputSelectionChange,
                 onBeforeInput: handleBeforeInput,
                 onKeyUp: handleInputSelectionChange,
@@ -826,12 +894,20 @@ const ChatComposer: React.FC<ChatComposerProps> = ({
                 }
               }}
               sx={{
-                '& .MuiInputBase-root.MuiInputBase-multiline': {
+                '& .MuiInputBase-root': {
                   alignItems: 'flex-start',
                   maxHeight: resolvedTextareaMaxHeight,
                   overflow: 'hidden',
                   display: 'flex',
-                  flexWrap: 'wrap'
+                  flexWrap: 'wrap',
+                  '&:focus': {
+                    outline: 'none',
+                    boxShadow: 'none'
+                  },
+                  '&:focus-within': {
+                    outline: 'none',
+                    boxShadow: 'none'
+                  }
                 },
                 '& .MuiInputBase-input': {
                   py: 0.5,
@@ -846,16 +922,6 @@ const ChatComposer: React.FC<ChatComposerProps> = ({
                   flex: '1 1 auto',
                   minWidth: 100,
                   '&:focus': {
-                    outline: 'none',
-                    boxShadow: 'none'
-                  }
-                },
-                '& .MuiInputBase-root': {
-                  '&:focus': {
-                    outline: 'none',
-                    boxShadow: 'none'
-                  },
-                  '&:focus-within': {
                     outline: 'none',
                     boxShadow: 'none'
                   }


### PR DESCRIPTION
## Summary
- Keep ChatPage composer input from being overwritten by older async draft/session restores.
- Tighten ChatComposer controlled state handling for text and attachment flows.
- Add regression coverage for composer input stability and runtime flow cases.

## Validation
- npx vitest run --config config/vitest/vitest.web.config.mjs packages/app/src/renderer/src/pages/ChatPage/components/ChatComposer.test.tsx packages/app/src/renderer/src/pages/ChatPage/ChatPage.runtimeFlow.test.tsx --pool=forks --maxWorkers=1