### PR TITLE
[codex] Add host extension API for private integrations

### DIFF
--- a/.vscode/QAppCfg.schema.json
+++ b/.vscode/QAppCfg.schema.json
@@ -631,6 +631,11 @@
     "QAppRequiredModel": {
       "additionalProperties": false,
       "properties": {
+        "baseDir": {
+          "description": "Base directory for dir. Defaults to ComfyUI.",
+          "enum": ["comfyui", "portableHome"],
+          "type": "string"
+        },
         "dir": {
           "description": "模型放置目录（相对于 ComfyUI 目录），如 models/unet",
           "type": "string"

--- a/packages/app/src/main/api/extensionServices.ts
+++ b/packages/app/src/main/api/extensionServices.ts
@@ -1,0 +1,1 @@
+export { createApiExtensionServices } from '../extensions/generatedRegistry'

--- a/packages/app/src/main/api/serverIpc.ts
+++ b/packages/app/src/main/api/serverIpc.ts
@@ -1,4 +1,4 @@
-import { Api, apiDef } from '@shared/api'
+import { Api, BaseApi, apiDef } from '@shared/api'
 import { AdobeBridgeSvcImpl } from './svcAdobeBridgeImpl'
 import { StateSvcImpl } from './svcStateImpl'
 import { ComfySvcImpl } from './svcComfyImpl'
@@ -19,9 +19,10 @@ import { FsSvcImpl } from './svcFsImpl'
 import { DccBridgeSvcImpl } from './svcDccBridgeImpl'
 import { DuplicateCheckSvcImpl } from './svcDuplicateCheckImpl'
 import { registerIpcServer } from '@shared/api/createServer/registerIpcServer'
+import { createApiExtensionServices } from './extensionServices'
 
 export const createServer = (): Api => {
-  return {
+  const baseApi: BaseApi = {
     svcAdobeBridge: new AdobeBridgeSvcImpl(),
     svcState: new StateSvcImpl(),
     svcHyper: new HyperSvcImpl(),
@@ -41,6 +42,11 @@ export const createServer = (): Api => {
     svcFs: new FsSvcImpl(),
     svcDccBridge: new DccBridgeSvcImpl(),
     svcDuplicateCheck: new DuplicateCheckSvcImpl()
+  }
+
+  return {
+    ...baseApi,
+    ...createApiExtensionServices({ baseApi })
   }
 }
 

--- a/packages/app/src/main/api/svcLLMProxyImpl.ts
+++ b/packages/app/src/main/api/svcLLMProxyImpl.ts
@@ -68,6 +68,7 @@ import { validateStructuredSkillOutput } from './skillRuntimeStructuredOutput'
 import { syncMcpClientManager } from '../mcp/runtime'
 import fs from 'node:fs/promises'
 import { isLocalFileSource } from '../utils/localFileUrl'
+import { mainHostExtensionApiV1 } from '../extensions/generatedRegistry'
 // Browser automation snapshots may arrive through file URLs; normalize them before downstream handling.
 
 const decodeHy3dProfileSegment = (value?: string): string => {
@@ -910,6 +911,17 @@ export class LLMProxySvcImpl implements LLMProxySvc {
   // Keep per-endpoint round-robin counters stable across requests so load-balanced profile selection stays deterministic.
   private static loadBalancingCounters: Map<string, number> = new Map()
 
+  private normalizeRequestedProfileId(profileId: string | undefined): string | undefined {
+    let nextProfileId = profileId
+    for (const extension of mainHostExtensionApiV1.llmProxy) {
+      const resolvedProfileId = extension.normalizeRequestedProfileId?.(nextProfileId)
+      if (resolvedProfileId !== undefined) {
+        nextProfileId = resolvedProfileId
+      }
+    }
+    return nextProfileId
+  }
+
   private findHunyuan3DProfile(config: Config, profileId?: string): LLMAPIProfile | undefined {
     const requestedProfileId = profileId?.trim()
     if (requestedProfileId) {
@@ -1300,7 +1312,21 @@ export class LLMProxySvcImpl implements LLMProxySvc {
     throwIfAborted(options?.signal)
     req = applySkillRuntimeContextMessageLimit(req)
     const config = getConfig()
-    const requestedProfileId = req.profileId
+    const requestedProfileId = this.normalizeRequestedProfileId(req.profileId)
+
+    for (const extension of mainHostExtensionApiV1.llmProxy) {
+      const extensionResponse = await extension.handleChatRequest?.(req, {
+        config,
+        fetchImpl: this.getFetchImpl(),
+        rawProfileId: req.profileId,
+        requestedProfileId,
+        signal: options?.signal
+      })
+      if (extensionResponse) {
+        throwIfAborted(options?.signal)
+        return extensionResponse
+      }
+    }
 
     const [
       baseProfileId,
@@ -1484,9 +1510,20 @@ export class LLMProxySvcImpl implements LLMProxySvc {
       return await this.chatViaBigModelOcr(req, profileWithSelectedKey, options)
     }
 
-    const cli = cliFromProfile(profileWithSelectedKey, {
-      fetchImpl: this.getFetchImpl()
-    })
+    const extensionContext = {
+      config,
+      fetchImpl: this.getFetchImpl(),
+      rawProfileId: req.profileId,
+      requestedProfileId,
+      signal: options?.signal
+    }
+    const cli =
+      mainHostExtensionApiV1.llmProxy
+        .map((extension) => extension.createCli?.(profileWithSelectedKey, extensionContext))
+        .find((client) => Boolean(client)) ??
+      cliFromProfile(profileWithSelectedKey, {
+        fetchImpl: this.getFetchImpl()
+      })
     if (!cli) {
       throw new Error('Unable to create an LLM client.')
     }

--- a/packages/app/src/main/extensions/generatedRegistry.ts
+++ b/packages/app/src/main/extensions/generatedRegistry.ts
@@ -1,0 +1,42 @@
+import type { BaseApi } from '@shared/api'
+import type { LLMChatReq, LLMChatResp } from '@shared/api/svcLLMProxy'
+import type { Config, LLMAPIProfile } from '@shared/config/config'
+import type { ApiExtensionServices } from '@shared/api/extensionServices'
+import type { FetchImpl } from '@shared/llm/clients'
+
+export type MainApiExtensionContextV1 = {
+  baseApi: BaseApi
+}
+
+export type MainLlmProxyExtensionContextV1 = {
+  config: Config
+  fetchImpl?: FetchImpl
+  rawProfileId?: string
+  requestedProfileId?: string
+  signal?: AbortSignal
+}
+
+export type MainLlmProxyExtensionV1 = {
+  id: string
+  createCli?: (
+    profile: LLMAPIProfile,
+    options: MainLlmProxyExtensionContextV1
+  ) => import('@shared/llm').LLMCli | undefined
+  handleChatRequest?: (
+    req: LLMChatReq,
+    options: MainLlmProxyExtensionContextV1
+  ) => Promise<LLMChatResp | undefined>
+  normalizeRequestedProfileId?: (profileId: string | undefined) => string | undefined
+}
+
+export type MainHostExtensionApiV1 = {
+  llmProxy: MainLlmProxyExtensionV1[]
+}
+
+export const mainHostExtensionApiV1: MainHostExtensionApiV1 = {
+  llmProxy: []
+}
+
+export const createApiExtensionServices = (
+  _context: MainApiExtensionContextV1
+): ApiExtensionServices => ({})

--- a/packages/app/src/main/qApp/bundledQApps.test.ts
+++ b/packages/app/src/main/qApp/bundledQApps.test.ts
@@ -68,7 +68,7 @@ const runtimeModelExpectations = {
   },
   'ckpt_base.pth': {
     dir: '.transparent-background',
-    baseDir: 'userHome'
+    baseDir: 'portableHome'
   }
 } as const
 

--- a/packages/app/src/renderer/src/extensions/generatedRegistry.tsx
+++ b/packages/app/src/renderer/src/extensions/generatedRegistry.tsx
@@ -1,0 +1,45 @@
+import type React from 'react'
+import type { Config, LLMAPIProfile } from '@shared/config/config'
+import type { ChatCapabilityProfile } from '@shared/llm'
+
+export type QuickAppApiProfileLists = {
+  pluginProfileCards: LLMAPIProfile[]
+  qAppProfiles: LLMAPIProfile[]
+}
+
+export type QuickAppApiProfilesSectionActionOptions = {
+  effectivePluginProfiles: LLMAPIProfile[]
+  isChineseUi: boolean
+  savePluginProfiles: (nextProfiles: LLMAPIProfile[]) => void
+}
+
+export type RendererHostExtensionApiV1 = {
+  chat?: {
+    resolveAssistantImageAutoSaveDir?: (options: {
+      config: Pick<Config, 'download_dir'>
+      storageScope?: string
+    }) => string | undefined
+    resolveReasoningPreferenceKey?: (
+      profileId: string | null | undefined,
+      profile?: ChatCapabilityProfile | null
+    ) => string | null | undefined
+  }
+  settings?: {
+    buildQuickAppLegacyHunyuanProfile?: (settingsValue: Config) => LLMAPIProfile | null
+    buildClearedQuickAppLegacyHunyuanConfig?: () => NonNullable<Config['aigc3d_config']>
+    getQuickAppApiProfilesSectionAction?: (
+      options: QuickAppApiProfilesSectionActionOptions
+    ) => React.ReactNode
+    isQuickAppLegacyHunyuanProfile?: (profile: LLMAPIProfile) => boolean
+    prepareClonedQuickAppProfile?: (
+      sourceProfile: LLMAPIProfile,
+      clonedProfile: LLMAPIProfile
+    ) => LLMAPIProfile
+    resolveQuickAppApiProfileLists?: (options: {
+      effectivePluginProfiles: LLMAPIProfile[]
+      settingsValue: Config
+    }) => QuickAppApiProfileLists
+  }
+}
+
+export const rendererHostExtensionApiV1: RendererHostExtensionApiV1 = {}

--- a/packages/app/src/renderer/src/pages/ChatPage/ChatPage.runtimeFlow.test.tsx
+++ b/packages/app/src/renderer/src/pages/ChatPage/ChatPage.runtimeFlow.test.tsx
@@ -767,6 +767,93 @@ describe('ChatPage runtime workflow integration', () => {
     })
   })
 
+  it('routes unscoped send-to-agent input only into the active mounted ChatPage', async () => {
+    render(
+      <ThemeProvider theme={theme}>
+        <div data-testid="agent-a">
+          <ChatPage compact storageScope="runtime-flow-a" active={false} />
+        </div>
+        <div data-testid="agent-b">
+          <ChatPage compact storageScope="runtime-flow-b" active />
+        </div>
+      </ThemeProvider>
+    )
+
+    const agentA = screen.getByTestId('agent-a')
+    const agentB = screen.getByTestId('agent-b')
+
+    await waitFor(() =>
+      expect(within(agentA).getByTestId('chat-composer-mock')).toBeInTheDocument()
+    )
+    await waitFor(() =>
+      expect(within(agentB).getByTestId('chat-composer-mock')).toBeInTheDocument()
+    )
+
+    await act(async () => {
+      window.dispatchEvent(
+        new CustomEvent('send-to-agent', {
+          detail: {
+            text: 'active agent only',
+            attachment: createImageAttachment('active-only.png')
+          }
+        })
+      )
+    })
+
+    await waitFor(() => {
+      expect(within(agentA).getByTestId('chat-composer-input-mock')).toHaveValue('')
+      expect(within(agentA).getByTestId('chat-composer-attachment-count').textContent).toBe('0')
+      expect(within(agentB).getByTestId('chat-composer-input-mock')).toHaveValue(
+        'active agent only'
+      )
+      expect(within(agentB).getByTestId('chat-composer-attachment-count').textContent).toBe('1')
+      expect(within(agentB).getByTestId('chat-composer-attachment-names').textContent).toContain(
+        'active-only.png'
+      )
+    })
+  })
+
+  it('allows scoped send-to-agent input to mutate an explicit inactive target scope', async () => {
+    render(
+      <ThemeProvider theme={theme}>
+        <div data-testid="agent-a">
+          <ChatPage compact storageScope="runtime-flow-a" active />
+        </div>
+        <div data-testid="agent-b">
+          <ChatPage compact storageScope="runtime-flow-b" active={false} />
+        </div>
+      </ThemeProvider>
+    )
+
+    const agentA = screen.getByTestId('agent-a')
+    const agentB = screen.getByTestId('agent-b')
+
+    await waitFor(() =>
+      expect(within(agentA).getByTestId('chat-composer-mock')).toBeInTheDocument()
+    )
+    await waitFor(() =>
+      expect(within(agentB).getByTestId('chat-composer-mock')).toBeInTheDocument()
+    )
+
+    await act(async () => {
+      window.dispatchEvent(
+        new CustomEvent('send-to-agent', {
+          detail: {
+            text: 'explicit inactive target',
+            targetScope: 'runtime-flow-b'
+          }
+        })
+      )
+    })
+
+    await waitFor(() => {
+      expect(within(agentA).getByTestId('chat-composer-input-mock')).toHaveValue('')
+      expect(within(agentB).getByTestId('chat-composer-input-mock')).toHaveValue(
+        'explicit inactive target'
+      )
+    })
+  })
+
   it('handles unscoped compact chat events only in the active mounted ChatPage', async () => {
     render(
       <ThemeProvider theme={theme}>
@@ -1141,6 +1228,90 @@ describe('ChatPage runtime workflow integration', () => {
     await act(async () => {
       releaseSaveSessionToDB?.()
       hoisted.saveSessionToDBGate.value = null
+    })
+  })
+
+  it('does not let an older async draft persistence restore over newer composer input', async () => {
+    const user = userEvent.setup()
+    const originalFetch = globalThis.fetch
+    let releaseFetch: (() => void) | null = null
+    const fetchMock = vi.fn(
+      () =>
+        new Promise<Response>((resolve) => {
+          releaseFetch = () =>
+            resolve(new Response(new Blob(['old'], { type: 'model/gltf-binary' })))
+        })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    try {
+      renderChatPage('runtime-flow-stale-draft')
+
+      await waitFor(() => expect(screen.getByTestId('chat-composer-mock')).toBeInTheDocument())
+      await waitFor(() => expect(readCurrentSessionState()?.id).toBeTruthy())
+
+      await user.type(screen.getByTestId('chat-composer-input-mock'), 'stale draft')
+
+      hoisted.selectFileMock.mockResolvedValueOnce(
+        new File(['stale'], 'stale.glb', { type: 'model/gltf-binary' })
+      )
+      await user.click(screen.getByTestId('chat-composer-upload-mock'))
+
+      await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+
+      await user.type(screen.getByTestId('chat-composer-input-mock'), ' plus fresh edit')
+
+      await act(async () => {
+        releaseFetch?.()
+        await Promise.resolve()
+      })
+
+      expect(screen.getByTestId('chat-composer-input-mock')).toHaveValue(
+        'stale draft plus fresh edit'
+      )
+
+      await act(async () => {
+        await new Promise((resolve) => window.setTimeout(resolve, 250))
+      })
+      if (fetchMock.mock.calls.length > 1) {
+        await act(async () => {
+          releaseFetch?.()
+          await Promise.resolve()
+        })
+      }
+    } finally {
+      vi.stubGlobal('fetch', originalFetch)
+    }
+  })
+
+  it('does not keep another session draft when returning to a session with an empty draft', async () => {
+    const user = userEvent.setup()
+    renderChatPage('runtime-flow-empty-draft')
+
+    await waitFor(() => expect(screen.getByTestId('chat-composer-mock')).toBeInTheDocument())
+
+    let firstSessionId: string | undefined
+    await waitFor(() => {
+      firstSessionId = readCurrentSessionState()?.id
+      expect(firstSessionId).toBeTruthy()
+    })
+
+    const input = screen.getByTestId('chat-composer-input-mock')
+    await user.type(input, 'temporary draft')
+    await user.clear(input)
+
+    await dispatchNewSession({}, 'runtime-flow-empty-draft')
+    await waitFor(() => {
+      expect(readCurrentSessionState()?.id).not.toBe(firstSessionId)
+    })
+
+    await user.type(screen.getByTestId('chat-composer-input-mock'), 'second session draft')
+
+    await dispatchSwitchSession(firstSessionId as string, 'runtime-flow-empty-draft')
+
+    await waitFor(() => {
+      expect(readCurrentSessionState()?.id).toBe(firstSessionId)
+      expect(screen.getByTestId('chat-composer-input-mock')).toHaveValue('')
     })
   })
 

--- a/packages/app/src/renderer/src/pages/ChatPage/ChatPage.tsx
+++ b/packages/app/src/renderer/src/pages/ChatPage/ChatPage.tsx
@@ -191,6 +191,8 @@ type ExternalSendToAgentDetail = {
   hiddenText?: string
   attachment?: ChatAttachment
   attachments?: ChatAttachment[]
+  scope?: string
+  targetScope?: string
   autoSend?: boolean
 }
 
@@ -1173,6 +1175,21 @@ const ChatPage: React.FC<ChatPageProps> = ({
   const pendingAttachmentsRef = useRef<ChatAttachment[]>(pendingAttachments)
   const pendingHiddenContextRef = useRef(pendingHiddenContext)
   const pendingExternalSendToAgentRef = useRef<ExternalSendToAgentDetail[]>([])
+  const isApplyingDraftRef = useRef(false)
+  const composerDraftSessionIdRef = useRef<string | null>(currentSessionIdRef.current)
+  const composerDraftMutationRef = useRef<{ sessionId: string | null; updatedAt: number }>({
+    sessionId: currentSessionIdRef.current,
+    updatedAt: 0
+  })
+
+  const markComposerDraftMutated = useCallback(() => {
+    if (isApplyingDraftRef.current) return
+    composerDraftSessionIdRef.current = currentSessionIdRef.current
+    composerDraftMutationRef.current = {
+      sessionId: currentSessionIdRef.current,
+      updatedAt: Date.now()
+    }
+  }, [])
 
   const mergeHiddenContext = useCallback(
     (currentValue: string, ...nextValues: Array<string | undefined>) => {
@@ -1194,32 +1211,44 @@ const ChatPage: React.FC<ChatPageProps> = ({
     []
   )
 
-  const setInputValue = useCallback<React.Dispatch<React.SetStateAction<string>>>((value) => {
-    setInputValueState((prev) => {
-      const next = typeof value === 'function' ? value(prev) : value
-      inputValueRef.current = next
-      return next
-    })
-  }, [])
+  const setInputValue = useCallback<React.Dispatch<React.SetStateAction<string>>>(
+    (value) => {
+      setInputValueState((prev) => {
+        const next = typeof value === 'function' ? value(prev) : value
+        inputValueRef.current = next
+        if (next !== prev) {
+          markComposerDraftMutated()
+        }
+        return next
+      })
+    },
+    [markComposerDraftMutated]
+  )
   const setPendingAttachments = useCallback<React.Dispatch<React.SetStateAction<ChatAttachment[]>>>(
     (value) => {
       setPendingAttachmentsState((prev) => {
         const next = typeof value === 'function' ? value(prev) : value
         pendingAttachmentsRef.current = next
+        if (next !== prev) {
+          markComposerDraftMutated()
+        }
         return next
       })
     },
-    []
+    [markComposerDraftMutated]
   )
   const setPendingHiddenContext = useCallback<React.Dispatch<React.SetStateAction<string>>>(
     (value) => {
       setPendingHiddenContextState((prev) => {
         const next = typeof value === 'function' ? value(prev) : value
         pendingHiddenContextRef.current = next
+        if (next !== prev) {
+          markComposerDraftMutated()
+        }
         return next
       })
     },
-    []
+    [markComposerDraftMutated]
   )
 
   const applyExternalSendToAgentInput = useCallback(
@@ -1290,28 +1319,49 @@ const ChatPage: React.FC<ChatPageProps> = ({
   const applyDraftToComposerState = useCallback(
     (draft?: ChatSessionDraft | null) => {
       const normalizedDraft = cloneChatSessionDraft(normalizeChatSessionDraft(draft))
+      const targetSessionId = currentSessionIdRef.current
+      const localMutation = composerDraftMutationRef.current
+      if (
+        composerDraftSessionIdRef.current === targetSessionId &&
+        localMutation.sessionId === targetSessionId &&
+        localMutation.updatedAt > (normalizedDraft?.updatedAt ?? 0)
+      ) {
+        return
+      }
+
       const nextInputValue = normalizedDraft?.inputValue ?? ''
       const nextPendingAttachments = normalizedDraft?.pendingAttachments ?? []
       const nextPendingHiddenContext = normalizedDraft?.pendingHiddenContext ?? ''
 
-      if (inputValueRef.current !== nextInputValue) {
-        inputValueRef.current = nextInputValue
-        setInputValue(nextInputValue)
+      isApplyingDraftRef.current = true
+      try {
+        if (inputValueRef.current !== nextInputValue) {
+          inputValueRef.current = nextInputValue
+          setInputValue(nextInputValue)
+        }
+
+        const currentDraft = normalizeChatSessionDraft({
+          inputValue: inputValueRef.current,
+          pendingAttachments: pendingAttachmentsRef.current,
+          pendingHiddenContext: pendingHiddenContextRef.current,
+          updatedAt: normalizedDraft?.updatedAt ?? 0
+        })
+
+        if (!areChatSessionDraftsEqual(currentDraft, normalizedDraft)) {
+          pendingAttachmentsRef.current = nextPendingAttachments
+          pendingHiddenContextRef.current = nextPendingHiddenContext
+          setPendingAttachments(nextPendingAttachments)
+          setPendingHiddenContext(nextPendingHiddenContext)
+        }
+      } finally {
+        isApplyingDraftRef.current = false
       }
 
-      const currentDraft = normalizeChatSessionDraft({
-        inputValue: inputValueRef.current,
-        pendingAttachments: pendingAttachmentsRef.current,
-        pendingHiddenContext: pendingHiddenContextRef.current,
+      composerDraftMutationRef.current = {
+        sessionId: targetSessionId,
         updatedAt: normalizedDraft?.updatedAt ?? 0
-      })
-
-      if (!areChatSessionDraftsEqual(currentDraft, normalizedDraft)) {
-        pendingAttachmentsRef.current = nextPendingAttachments
-        pendingHiddenContextRef.current = nextPendingHiddenContext
-        setPendingAttachments(nextPendingAttachments)
-        setPendingHiddenContext(nextPendingHiddenContext)
       }
+      composerDraftSessionIdRef.current = targetSessionId
     },
     [setInputValue, setPendingAttachments, setPendingHiddenContext]
   )
@@ -1323,6 +1373,19 @@ const ChatPage: React.FC<ChatPageProps> = ({
       }
 
       const normalizedSnapshot = normalizeChatSessionDraft(snapshot)
+      const isStaleCurrentComposerSnapshot = (updatedAt = 0): boolean => {
+        const localMutation = composerDraftMutationRef.current
+        return (
+          sessionId === currentSessionIdRef.current &&
+          localMutation.sessionId === sessionId &&
+          localMutation.updatedAt > updatedAt
+        )
+      }
+
+      if (isStaleCurrentComposerSnapshot(normalizedSnapshot?.updatedAt ?? 0)) {
+        return
+      }
+
       const initialSessions = sessionsRef.current
       const initialSessionIndex = initialSessions.findIndex((session) => session.id === sessionId)
       if (initialSessionIndex < 0) {
@@ -1352,6 +1415,14 @@ const ChatPage: React.FC<ChatPageProps> = ({
             )
           })
         : undefined
+      if (
+        isStaleCurrentComposerSnapshot(
+          persistedDraft?.updatedAt ?? normalizedSnapshot?.updatedAt ?? 0
+        )
+      ) {
+        return
+      }
+
       writeSessionDraftBackup(
         sessionId,
         persistedDraft?.updatedAt ?? normalizedSnapshot?.updatedAt ?? Date.now(),
@@ -1795,7 +1866,11 @@ const ChatPage: React.FC<ChatPageProps> = ({
         }>
       ).detail
 
-      if (detail?.scope && detail.scope !== storageScope) return
+      if (detail?.scope) {
+        if (detail.scope !== storageScope) return
+      } else if (!active) {
+        return
+      }
       const sessionId = detail?.sessionId
       if (!sessionId) return
 
@@ -1824,7 +1899,7 @@ const ChatPage: React.FC<ChatPageProps> = ({
 
     window.addEventListener('chat:session-terminated', handleSessionTerminated)
     return () => window.removeEventListener('chat:session-terminated', handleSessionTerminated)
-  }, [emitPreviewRefresh, pendingExternalConfirmations, storageScope])
+  }, [active, emitPreviewRefresh, pendingExternalConfirmations, storageScope])
   useEffect(() => {
     if (!sessionsLoaded) {
       return
@@ -2165,84 +2240,28 @@ const ChatPage: React.FC<ChatPageProps> = ({
         hiddenText?: string
         attachment?: ChatAttachment
         attachments?: ChatAttachment[]
+        scope?: string
         targetScope?: string
         autoSend?: boolean
       }>
       const detail = customEvent.detail
-      if (detail.targetScope !== storageScope) return
+      const targetScope = detail.targetScope ?? detail.scope
+      if (targetScope) {
+        if (targetScope !== storageScope) return
+      } else if (!active) {
+        return
+      }
       if (!sessionsLoaded) {
-        pendingExternalSendToAgentRef.current.push({
-          image: detail.image,
-          text: detail.text,
-          hiddenText: detail.hiddenText,
-          attachment: detail.attachment,
-          attachments: detail.attachments,
-          autoSend: detail.autoSend
-        })
+        pendingExternalSendToAgentRef.current.push(detail)
         return
       }
 
-      // autoSend 模式：立即发送到 agent 线程
-      if (detail.autoSend && sendMessageRef.current) {
-        const sendAttachments =
-          detail.attachments && detail.attachments.length > 0 ? detail.attachments : undefined
-        void sendMessageRef.current({
-          content: detail.text || '',
-          attachments: sendAttachments,
-          hiddenContext: detail.hiddenText
-        })
-        return
-      }
-
-      if (detail.attachment?.url) {
-        setPendingAttachments((prev) => {
-          if (prev.some((item) => item.url === detail.attachment?.url)) return prev
-          return [...prev, detail.attachment as ChatAttachment]
-        })
-      }
-
-      if (detail.image) {
-        fetch(detail.image)
-          .then((res) => res.blob())
-          .then(async (blob) => {
-            const attachment = await buildImageChatAttachmentFromFile(
-              new File([blob], getDownloadFileNameFromUrl(detail.image as string, 'image.png'), {
-                type: blob.type || 'image/png'
-              }),
-              detail.image as string
-            )
-            setPendingAttachments((prev) => {
-              if (prev.some((a) => a.url === detail.image)) return prev
-              return [...prev, attachment]
-            })
-          })
-          .catch((err) => console.error('[ChatPage] Failed to parse canvas image:', err))
-      }
-
-      const txt = detail.text
-      if (txt) {
-        setInputValue((prev) => {
-          const base = prev.trim()
-          return base ? `${base}\n\n${txt}` : txt
-        })
-      }
-
-      if (detail.hiddenText) {
-        setPendingHiddenContext((prev) => mergeHiddenContext(prev, detail.hiddenText))
-      }
+      applyExternalSendToAgentInput(detail)
     }
 
     window.addEventListener('send-to-agent', handleSendToAgent)
     return () => window.removeEventListener('send-to-agent', handleSendToAgent)
-  }, [
-    acceptExternalInput,
-    mergeHiddenContext,
-    sessionsLoaded,
-    setInputValue,
-    setPendingAttachments,
-    setPendingHiddenContext,
-    storageScope
-  ])
+  }, [acceptExternalInput, active, applyExternalSendToAgentInput, sessionsLoaded, storageScope])
 
   useEffect(() => {
     const handleFocusComposer = (event: Event) => {
@@ -3117,7 +3136,11 @@ const ChatPage: React.FC<ChatPageProps> = ({
   useEffect(() => {
     const handleTerminateScope = (event: Event): void => {
       const customEvent = event as CustomEvent<{ scope?: string }>
-      if (customEvent.detail?.scope && customEvent.detail.scope !== storageScope) return
+      if (customEvent.detail?.scope) {
+        if (customEvent.detail.scope !== storageScope) return
+      } else if (!active) {
+        return
+      }
 
       const sessionIds = new Set<string>([
         ...loadingSessionIdsRef.current,
@@ -3129,7 +3152,11 @@ const ChatPage: React.FC<ChatPageProps> = ({
     }
     const handleTerminateSession = (event: Event): void => {
       const customEvent = event as CustomEvent<{ scope?: string; sessionId?: string }>
-      if (customEvent.detail?.scope && customEvent.detail.scope !== storageScope) return
+      if (customEvent.detail?.scope) {
+        if (customEvent.detail.scope !== storageScope) return
+      } else if (!active) {
+        return
+      }
       const sessionId = customEvent.detail?.sessionId
       if (!sessionId) return
 
@@ -3142,7 +3169,7 @@ const ChatPage: React.FC<ChatPageProps> = ({
       window.removeEventListener('chat:terminate-scope', handleTerminateScope)
       window.removeEventListener('chat:terminate-session', handleTerminateSession)
     }
-  }, [storageScope, terminateSession])
+  }, [active, storageScope, terminateSession])
 
   useEffect(() => {
     const handleAppendMessage = (event: Event) => {
@@ -3284,7 +3311,11 @@ const ChatPage: React.FC<ChatPageProps> = ({
 
     const handleScopeReadyPing = (event: Event) => {
       const customEvent = event as CustomEvent<{ scope?: string; requestId?: string }>
-      if (customEvent.detail?.scope && customEvent.detail.scope !== storageScope) return
+      if (customEvent.detail?.scope) {
+        if (customEvent.detail.scope !== storageScope) return
+      } else if (!active) {
+        return
+      }
       emitScopeReady(customEvent.detail?.requestId)
     }
 
@@ -3297,7 +3328,7 @@ const ChatPage: React.FC<ChatPageProps> = ({
       window.clearTimeout(timerId)
       window.removeEventListener('chat:ping-scope-ready', handleScopeReadyPing)
     }
-  }, [acceptExternalInput, storageScope])
+  }, [acceptExternalInput, active, storageScope])
 
   const deleteSession = (sessionId: string) => {
     terminateSession(sessionId)

--- a/packages/app/src/renderer/src/pages/ChatPage/ChatPage.tsx
+++ b/packages/app/src/renderer/src/pages/ChatPage/ChatPage.tsx
@@ -156,9 +156,9 @@ import {
 import { getQAppPromptSettings } from '../QuickAppPage/QAppExecutePanel/qAppExecuteInputs/qAppPromptSettings'
 import { emitProjectTraceRuntimeEvent } from '@renderer/features/projectTrace/projectTraceRuntime'
 import {
-  resolveProjectIdFromStorageScope,
-  resolveProjectResourceDir
-} from '@renderer/utils/projectResourcePaths'
+  resolveAssistantImageAutoSaveDir,
+  resolveChatReasoningPreferenceKey
+} from './chatPageExtensions'
 
 // Hooks
 import { useImagePreview } from './hooks/useImagePreview'
@@ -462,21 +462,6 @@ const normalizeReasoningPreferenceMap = (
           Boolean(entry[0]?.trim()) && Boolean(entry[1])
       )
   )
-
-const resolveReasoningPreferenceKey = (
-  profileId: string | null | undefined,
-  profile?: ChatCapabilityProfile | null
-): string | null => {
-  const baseProfileId = getBaseProfileId(profileId)
-  if (baseProfileId) {
-    return baseProfileId
-  }
-
-  const modelName = String(profile?.model_name || '')
-    .trim()
-    .toLowerCase()
-  return modelName || null
-}
 
 const dispatchReasoningEffortSync = (map: Record<string, LLMReasoningEffort>) => {
   window.dispatchEvent(
@@ -1945,7 +1930,7 @@ const ChatPage: React.FC<ChatPageProps> = ({
     [selectedCapabilityProfile]
   )
   const selectedReasoningProfileKey = useMemo(
-    () => resolveReasoningPreferenceKey(selectedProfileId, selectedCapabilityProfile),
+    () => resolveChatReasoningPreferenceKey(selectedProfileId, selectedCapabilityProfile),
     [selectedCapabilityProfile, selectedProfileId]
   )
   const selectedReasoningEffort = useMemo(() => {
@@ -2319,10 +2304,9 @@ const ChatPage: React.FC<ChatPageProps> = ({
                 recordAutoSavedChatImageKey(trackerKey)
 
                 try {
-                  const targetDir = resolveProjectResourceDir({
+                  const targetDir = resolveAssistantImageAutoSaveDir({
                     config: { download_dir: config.download_dir },
-                    projectId: resolveProjectIdFromStorageScope(storageScope),
-                    segments: ['AutoSave', 'Agent']
+                    storageScope
                   })
                   const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)
                   const fileName = `agent_auto_${timestamp}.png`

--- a/packages/app/src/renderer/src/pages/ChatPage/chatPageExtensions.ts
+++ b/packages/app/src/renderer/src/pages/ChatPage/chatPageExtensions.ts
@@ -1,0 +1,48 @@
+import type { Config } from '@shared/config/config'
+import type { ChatCapabilityProfile } from '@shared/llm'
+import {
+  resolveProjectIdFromStorageScope,
+  resolveProjectResourceDir
+} from '@renderer/utils/projectResourcePaths'
+import { rendererHostExtensionApiV1 } from '@renderer/extensions/generatedRegistry'
+import { getBaseProfileId } from './chatPageShared'
+
+export const resolveChatReasoningPreferenceKey = (
+  profileId: string | null | undefined,
+  profile?: ChatCapabilityProfile | null
+): string | null => {
+  const extensionValue = rendererHostExtensionApiV1.chat?.resolveReasoningPreferenceKey?.(
+    profileId,
+    profile
+  )
+  if (extensionValue !== undefined) {
+    return extensionValue
+  }
+
+  const baseProfileId = getBaseProfileId(profileId)
+  if (baseProfileId) {
+    return baseProfileId
+  }
+
+  const modelName = String(profile?.model_name || '')
+    .trim()
+    .toLowerCase()
+  return modelName || null
+}
+
+export const resolveAssistantImageAutoSaveDir = (options: {
+  config: Pick<Config, 'download_dir'>
+  storageScope?: string
+}): string | undefined => {
+  const extensionValue =
+    rendererHostExtensionApiV1.chat?.resolveAssistantImageAutoSaveDir?.(options)
+  if (extensionValue !== undefined) {
+    return extensionValue
+  }
+
+  return resolveProjectResourceDir({
+    config: { download_dir: options.config.download_dir },
+    projectId: resolveProjectIdFromStorageScope(options.storageScope),
+    segments: ['AutoSave', 'Agent']
+  })
+}

--- a/packages/app/src/renderer/src/pages/ChatPage/components/ChatComposer.test.tsx
+++ b/packages/app/src/renderer/src/pages/ChatPage/components/ChatComposer.test.tsx
@@ -14,10 +14,16 @@ vi.mock('react-i18next', () => ({
 
 function ControlledChatComposer({
   initialValue,
-  renderNonce
+  renderNonce,
+  isLoading = false,
+  disabled = false,
+  onSend = vi.fn()
 }: {
   initialValue: string
   renderNonce?: number
+  isLoading?: boolean
+  disabled?: boolean
+  onSend?: () => void
 }) {
   const [value, setValue] = useState(initialValue)
   const inputRef = useRef<HTMLTextAreaElement | HTMLInputElement | null>(null)
@@ -27,14 +33,14 @@ function ControlledChatComposer({
       <ChatComposer
         inputValue={value}
         onInputChange={setValue}
-        onSend={vi.fn()}
+        onSend={onSend}
         onUploadFile={vi.fn()}
         pendingAttachments={[]}
         uploadProgress={{}}
         onRemoveAttachment={vi.fn()}
-        isLoading={false}
+        isLoading={isLoading}
         onStopGenerating={vi.fn()}
-        disabled={false}
+        disabled={disabled}
         composerInputRef={inputRef}
         onPreviewImage={vi.fn()}
       />
@@ -311,6 +317,64 @@ describe('ChatComposer', () => {
       overflowX: 'hidden',
       resize: 'none'
     })
+  })
+
+  it('renders a single native textarea for composer input', () => {
+    const { container } = render(<ControlledChatComposer initialValue="hello" />)
+
+    const textarea = screen.getByTestId('chat-composer-input')
+
+    expect(textarea.tagName).toBe('TEXTAREA')
+    expect(container.querySelectorAll('textarea')).toHaveLength(1)
+  })
+
+  it('does not send on Enter while IME composition is active', () => {
+    const onSend = vi.fn()
+    render(<ControlledChatComposer initialValue="draft" onSend={onSend} />)
+
+    const textarea = screen.getByTestId('chat-composer-input') as HTMLTextAreaElement
+
+    fireEvent.compositionStart(textarea)
+    fireEvent.keyDown(textarea, { key: 'Enter', code: 'Enter', charCode: 13 })
+
+    expect(onSend).not.toHaveBeenCalled()
+  })
+
+  it('keeps the input editable while generation is loading', () => {
+    const onInputChange = vi.fn()
+    render(
+      <ThemeProvider theme={theme}>
+        <ChatComposer
+          inputValue="draft"
+          onInputChange={onInputChange}
+          onSend={vi.fn()}
+          onUploadFile={vi.fn()}
+          pendingAttachments={[]}
+          uploadProgress={{}}
+          onRemoveAttachment={vi.fn()}
+          isLoading
+          onStopGenerating={vi.fn()}
+          disabled={false}
+          composerInputRef={{ current: null }}
+          onPreviewImage={vi.fn()}
+        />
+      </ThemeProvider>
+    )
+
+    const textarea = screen.getByTestId('chat-composer-input') as HTMLTextAreaElement
+
+    expect(textarea).not.toBeDisabled()
+
+    fireEvent.change(textarea, {
+      target: {
+        value: 'draft update',
+        selectionStart: 12,
+        selectionEnd: 12,
+        selectionDirection: 'none'
+      }
+    })
+
+    expect(onInputChange).toHaveBeenCalledWith('draft update')
   })
 
   it('keeps the caret at the edit position when typing in the middle', () => {

--- a/packages/app/src/renderer/src/pages/ChatPage/components/ChatComposer.tsx
+++ b/packages/app/src/renderer/src/pages/ChatPage/components/ChatComposer.tsx
@@ -1,4 +1,11 @@
-import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import React, {
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useLayoutEffect,
+  useRef,
+  useState
+} from 'react'
 import {
   Box,
   TextField,
@@ -13,6 +20,7 @@ import {
   Menu,
   MenuItem
 } from '@mui/material'
+import type { InputBaseComponentProps } from '@mui/material/InputBase'
 import {
   Send as SendIcon,
   Add as AddIcon,
@@ -97,6 +105,60 @@ const COMPOSER_VERTICAL_OVERHEAD = 140
 const MIN_ATTACHMENT_PREVIEW_HEIGHT = 88
 const MAX_ATTACHMENT_PREVIEW_HEIGHT = 240
 const ATTACHMENT_PREVIEW_HEIGHT_RATIO = 0.32
+
+const parseCssPixelValue = (value: unknown): number | null => {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null
+  if (typeof value !== 'string') return null
+
+  const parsed = Number.parseFloat(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+const StableNativeTextarea = React.forwardRef<HTMLTextAreaElement, InputBaseComponentProps>(
+  function StableNativeTextarea(props, forwardedRef) {
+    const { ownerState: _ownerState, style, value, defaultValue, onInput, rows, ...rest } = props
+    const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+
+    useImperativeHandle(forwardedRef, () => textareaRef.current as HTMLTextAreaElement)
+
+    const resizeTextarea = useCallback(() => {
+      const textarea = textareaRef.current
+      if (!textarea) return
+
+      const resolvedStyle = style as React.CSSProperties | undefined
+      const minHeight = parseCssPixelValue(resolvedStyle?.minHeight) ?? MIN_TEXTAREA_HEIGHT
+      const maxHeight = parseCssPixelValue(resolvedStyle?.maxHeight)
+
+      textarea.style.height = 'auto'
+      const nextHeight =
+        maxHeight == null
+          ? Math.max(minHeight, textarea.scrollHeight)
+          : Math.max(minHeight, Math.min(textarea.scrollHeight, maxHeight))
+      textarea.style.height = `${nextHeight}px`
+    }, [style])
+
+    useLayoutEffect(() => {
+      resizeTextarea()
+    }, [resizeTextarea, value, defaultValue])
+
+    const handleInput = (event: React.FormEvent<HTMLTextAreaElement>) => {
+      resizeTextarea()
+      ;(onInput as React.FormEventHandler<HTMLTextAreaElement> | undefined)?.(event)
+    }
+
+    return (
+      <textarea
+        {...(rest as React.TextareaHTMLAttributes<HTMLTextAreaElement>)}
+        ref={textareaRef}
+        rows={typeof rows === 'number' ? rows : 1}
+        value={value as string | number | readonly string[] | undefined}
+        defaultValue={defaultValue as string | number | readonly string[] | undefined}
+        onInput={handleInput}
+        style={style as React.CSSProperties | undefined}
+      />
+    )
+  }
+)
 
 type InputSelectionSnapshot = {
   value: string
@@ -404,6 +466,12 @@ const ChatComposer: React.FC<ChatComposerProps> = ({
   }
 
   const handleKeyDown = (event: React.KeyboardEvent) => {
+    const nativeEvent = event.nativeEvent as KeyboardEvent & { isComposing?: boolean }
+    const isImeComposing =
+      isComposingInputRef.current || nativeEvent.isComposing || nativeEvent.keyCode === 229
+
+    if (isImeComposing) return
+
     if (event.key === 'Enter' && !event.shiftKey) {
       event.preventDefault()
       onSend()
@@ -741,8 +809,6 @@ const ChatComposer: React.FC<ChatComposerProps> = ({
           <Box sx={{ width: '100%', minHeight: 0, mb: 1 }}>
             <TextField
               fullWidth
-              multiline
-              minRows={1}
               inputRef={composerInputRef}
               value={inputValue}
               onChange={handleInputChange}
@@ -752,6 +818,7 @@ const ChatComposer: React.FC<ChatComposerProps> = ({
               variant="standard"
               InputProps={{
                 disableUnderline: true,
+                inputComponent: StableNativeTextarea as React.ElementType<InputBaseComponentProps>,
                 startAdornment: selectedSkillName ? (
                   <Box
                     contentEditable={false}
@@ -805,6 +872,7 @@ const ChatComposer: React.FC<ChatComposerProps> = ({
               }}
               inputProps={{
                 'data-testid': 'chat-composer-input',
+                rows: 1,
                 onFocus: handleInputSelectionChange,
                 onBeforeInput: handleBeforeInput,
                 onKeyUp: handleInputSelectionChange,
@@ -826,12 +894,20 @@ const ChatComposer: React.FC<ChatComposerProps> = ({
                 }
               }}
               sx={{
-                '& .MuiInputBase-root.MuiInputBase-multiline': {
+                '& .MuiInputBase-root': {
                   alignItems: 'flex-start',
                   maxHeight: resolvedTextareaMaxHeight,
                   overflow: 'hidden',
                   display: 'flex',
-                  flexWrap: 'wrap'
+                  flexWrap: 'wrap',
+                  '&:focus': {
+                    outline: 'none',
+                    boxShadow: 'none'
+                  },
+                  '&:focus-within': {
+                    outline: 'none',
+                    boxShadow: 'none'
+                  }
                 },
                 '& .MuiInputBase-input': {
                   py: 0.5,
@@ -846,16 +922,6 @@ const ChatComposer: React.FC<ChatComposerProps> = ({
                   flex: '1 1 auto',
                   minWidth: 100,
                   '&:focus': {
-                    outline: 'none',
-                    boxShadow: 'none'
-                  }
-                },
-                '& .MuiInputBase-root': {
-                  '&:focus': {
-                    outline: 'none',
-                    boxShadow: 'none'
-                  },
-                  '&:focus-within': {
                     outline: 'none',
                     boxShadow: 'none'
                   }

--- a/packages/app/src/renderer/src/pages/QuickAppPage/QAppDesignPanel/qAppDesignInputs/DsnRequiredModels.tsx
+++ b/packages/app/src/renderer/src/pages/QuickAppPage/QAppDesignPanel/qAppDesignInputs/DsnRequiredModels.tsx
@@ -72,7 +72,7 @@ const ModelItem: React.FC<{
           sx={{ minWidth: 132 }}
         >
           <MenuItem value="comfyui">ComfyUI</MenuItem>
-          <MenuItem value="userHome">User home</MenuItem>
+          <MenuItem value="portableHome">Portable home</MenuItem>
         </Select>
         <TextField
           size="small"

--- a/packages/app/src/renderer/src/pages/QuickAppPage/utils/qAppDependencyCheck.test.ts
+++ b/packages/app/src/renderer/src/pages/QuickAppPage/utils/qAppDependencyCheck.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ConfigUtils } from '@shared/config/configUtils'
+import type { BuiltInPath } from '@shared/utils/utilWindow'
+import { checkRequiredModels, resolveRequiredModelPaths } from './qAppDependencyCheck'
+
+const pathApi = {
+  join: (first: string, ...args: string[]) => [first, ...args].filter(Boolean).join('\\'),
+  isAbsolute: (value: string) => /^[A-Z]:\\/i.test(value) || value.startsWith('/'),
+  normalize: (value: string) => value,
+  relative: (from: string, to: string) => to.replace(`${from}\\`, ''),
+  dirname: (value: string) => value.split('\\').slice(0, -1).join('\\'),
+  basename: (value: string) => value.split('\\').pop() || '',
+  extname: (value: string) => {
+    const base = value.split('\\').pop() || ''
+    const index = base.lastIndexOf('.')
+    return index >= 0 ? base.slice(index) : ''
+  },
+  format: () => '',
+  parse: () => ({})
+} satisfies BuiltInPath
+
+describe('qAppDependencyCheck', () => {
+  const originalPath = window.path
+  const originalApi = window.api
+
+  beforeEach(() => {
+    window.path = pathApi
+  })
+
+  afterEach(() => {
+    window.path = originalPath
+    window.api = originalApi
+  })
+
+  it('resolves portableHome models under the embedded Python home', () => {
+    const resolved = resolveRequiredModelPaths(
+      {
+        name: 'ckpt_base.pth',
+        size: '368 MB',
+        baseDir: 'portableHome',
+        dir: '.transparent-background',
+        url: 'https://example.test/ckpt_base.pth'
+      },
+      'C:\\ComfyUI',
+      'C:\\MagicPot\\data\\runtime\\home'
+    )
+
+    expect(resolved).toEqual({
+      dirPath: 'C:\\MagicPot\\data\\runtime\\home\\.transparent-background',
+      displayDir: 'C:\\MagicPot\\data\\runtime\\home\\.transparent-background',
+      filePath: 'C:\\MagicPot\\data\\runtime\\home\\.transparent-background\\ckpt_base.pth'
+    })
+  })
+
+  it('checks portableHome under the embedded Python home', async () => {
+    const fileExistsBatch = vi.fn(async () => [false])
+    window.api = {
+      svcShell: {
+        fileExistsBatch
+      }
+    } as unknown as typeof window.api
+
+    const configUtils = {
+      getComfyUIDir: () => ['C:\\ComfyUI', true],
+      getPortablePythonHomeDir: () => 'C:\\MagicPot\\data\\runtime\\home'
+    } as ConfigUtils
+
+    const missing = await checkRequiredModels(
+      [
+        {
+          name: 'ckpt_base.pth',
+          size: '368 MB',
+          baseDir: 'portableHome',
+          dir: '.transparent-background',
+          url: 'https://example.test/ckpt_base.pth'
+        }
+      ],
+      configUtils
+    )
+
+    expect(fileExistsBatch).toHaveBeenCalledWith([
+      'C:\\MagicPot\\data\\runtime\\home\\.transparent-background\\ckpt_base.pth'
+    ])
+    expect(missing).toHaveLength(1)
+  })
+})

--- a/packages/app/src/renderer/src/pages/QuickAppPage/utils/qAppDependencyCheck.ts
+++ b/packages/app/src/renderer/src/pages/QuickAppPage/utils/qAppDependencyCheck.ts
@@ -35,15 +35,13 @@ export function getRequiredModelBaseDir(
 export function resolveRequiredModelPaths(
   model: QAppRequiredModel,
   comfyDir: string,
-  homeDir: string
+  portableHomeDir: string
 ): { filePath: string; dirPath: string; displayDir: string } {
-  const rootDir = getRequiredModelBaseDir(model) === 'userHome' ? homeDir : comfyDir
+  const baseDir = getRequiredModelBaseDir(model)
+  const rootDir = baseDir === 'portableHome' ? portableHomeDir : comfyDir
   const dirPath = window.path.join(rootDir, model.dir)
   const filePath = window.path.join(dirPath, model.name)
-  const displayDir =
-    getRequiredModelBaseDir(model) === 'userHome'
-      ? dirPath
-      : `ComfyUI\\${model.dir.replace(/\//g, '\\')}`
+  const displayDir = baseDir === 'comfyui' ? `ComfyUI\\${model.dir.replace(/\//g, '\\')}` : dirPath
 
   return { filePath, dirPath, displayDir }
 }
@@ -103,11 +101,10 @@ export async function checkRequiredModels(
     return []
   }
 
-  const needsHomeDir = requiredModels.some((model) => getRequiredModelBaseDir(model) === 'userHome')
-  const homeDir = needsHomeDir ? await api().svcShell.getHomeDir() : ''
+  const portableHomeDir = configUtils.getPortablePythonHomeDir()
   const resolvedModels = requiredModels.map((model) => ({
     model,
-    ...resolveRequiredModelPaths(model, comfyDir, homeDir)
+    ...resolveRequiredModelPaths(model, comfyDir, portableHomeDir)
   }))
   const exists = await api().svcShell.fileExistsBatch(resolvedModels.map((model) => model.filePath))
 

--- a/packages/app/src/renderer/src/pages/SettingsPage/PanelLLM.tsx
+++ b/packages/app/src/renderer/src/pages/SettingsPage/PanelLLM.tsx
@@ -893,6 +893,7 @@ const ApiProfileCard: React.FC<ApiProfileCardProps> = ({
 }
 
 type ApiProfilesSectionProps = {
+  action?: React.ReactNode
   onAdd: () => void
   onClone: (profile: LLMAPIProfile) => void
   onDelete: (profileId: string) => void
@@ -904,6 +905,7 @@ type ApiProfilesSectionProps = {
 }
 
 export const ApiProfilesSection: React.FC<ApiProfilesSectionProps> = ({
+  action,
   onAdd,
   onClone,
   onDelete,
@@ -914,7 +916,10 @@ export const ApiProfilesSection: React.FC<ApiProfilesSectionProps> = ({
   title
 }) => {
   return (
-    <SettingSection title={title || (isChineseUi ? 'Agent线程配置' : t('llm.profile_title'))}>
+    <SettingSection
+      action={action}
+      title={title || (isChineseUi ? 'Agent线程配置' : t('llm.profile_title'))}
+    >
       <Box
         sx={{
           display: 'grid',

--- a/packages/app/src/renderer/src/pages/SettingsPage/PanelPlugin.tsx
+++ b/packages/app/src/renderer/src/pages/SettingsPage/PanelPlugin.tsx
@@ -10,11 +10,7 @@ import InputPath from '@renderer/components/inputs/InputPath'
 import { PanelProps } from './PanelProps'
 import { useTranslation } from 'react-i18next'
 import { LLMAPIProfile } from '@shared/config/config'
-import {
-  getQAppApiProfiles,
-  isHunyuan3DCompatibleProfile,
-  isVisionCapableApiProfile
-} from '@shared/config/apiProfileSelectors'
+import { isVisionCapableApiProfile } from '@shared/config/apiProfileSelectors'
 import { ApiProfilesSection, createEmptyProfile } from './PanelLLM'
 import { getQAppPromptSettings } from '../QuickAppPage/QAppExecutePanel/qAppExecuteInputs/qAppPromptSettings'
 import {
@@ -24,6 +20,14 @@ import {
   type DuplicateCheckSettings,
   type DuplicateCheckVisualModelConfig
 } from '@shared/duplicateCheck/types'
+import {
+  buildClearedQuickAppLegacyHunyuanConfig,
+  buildQuickAppLegacyHunyuanProfile,
+  getQuickAppApiProfilesSectionAction,
+  isQuickAppLegacyHunyuanProfile,
+  prepareClonedQuickAppProfile,
+  resolveQuickAppApiProfileLists
+} from './settingsPageExtensions'
 
 type SaveSettings = PanelProps['saveSettings']
 
@@ -42,51 +46,6 @@ const stripExternalAuthProfile = (profile: LLMAPIProfile): LLMAPIProfile => {
   } = profile
 
   return nextProfile
-}
-
-const HUNYUAN_AI3D_BASE_URL = 'https://api.ai3d.cloud.tencent.com'
-const DEFAULT_HY3D_COS_PREFIX = 'magicpot/hunyuan3d'
-const DEFAULT_HY3D_API_REGION = 'ap-guangzhou'
-const LEGACY_HUNYUAN_PROFILE_ID = 'legacy-hunyuan3d-profile'
-
-const buildLegacyHunyuanProfile = (
-  settingsValue: PanelProps['settingsValue']
-): LLMAPIProfile | null => {
-  const legacy = settingsValue.aigc3d_config
-  const legacyKeyPrefix = legacy?.cos_key_prefix?.trim() || ''
-  const hasCustomKeyPrefix = Boolean(legacyKeyPrefix && legacyKeyPrefix !== DEFAULT_HY3D_COS_PREFIX)
-
-  if (
-    !legacy ||
-    !(
-      legacy.tencent_secret_id?.trim() ||
-      legacy.tencent_secret_key?.trim() ||
-      legacy.api_region?.trim() ||
-      legacy.cos_bucket?.trim() ||
-      legacy.cos_region?.trim() ||
-      hasCustomKeyPrefix
-    )
-  ) {
-    return null
-  }
-
-  return {
-    id: LEGACY_HUNYUAN_PROFILE_ID,
-    model_name: 'Hunyuan3D Pro',
-    base_url: HUNYUAN_AI3D_BASE_URL,
-    api_key: '',
-    provider: 'default',
-    model_use: 'default',
-    is_ollama: false,
-    is_vision_model: false,
-    is_ocr_model: false,
-    tencent_secret_id: legacy.tencent_secret_id || '',
-    tencent_secret_key: legacy.tencent_secret_key || '',
-    api_region: legacy.api_region || DEFAULT_HY3D_API_REGION,
-    cos_bucket: legacy.cos_bucket || '',
-    cos_region: legacy.cos_region || DEFAULT_HY3D_API_REGION,
-    cos_key_prefix: legacyKeyPrefix || DEFAULT_HY3D_COS_PREFIX
-  }
 }
 
 const quickAppSectionSurfaceSx = {
@@ -606,14 +565,14 @@ const PanelPlugin: React.FC<PanelProps> = ({ settingsValue, saveSettings }: Pane
   )
 
   const legacyHunyuanProfile = React.useMemo(
-    () => buildLegacyHunyuanProfile(settingsValue),
+    () => buildQuickAppLegacyHunyuanProfile(settingsValue),
     [settingsValue]
   )
   const shouldUseLegacyHunyuanProfile = React.useMemo(
     () =>
       Boolean(
         legacyHunyuanProfile &&
-        !pluginProfiles.some((profile) => isHunyuan3DCompatibleProfile(profile))
+        !pluginProfiles.some((profile) => isQuickAppLegacyHunyuanProfile(profile))
       ),
     [legacyHunyuanProfile, pluginProfiles]
   )
@@ -624,13 +583,22 @@ const PanelPlugin: React.FC<PanelProps> = ({ settingsValue, saveSettings }: Pane
         : pluginProfiles,
     [legacyHunyuanProfile, pluginProfiles, shouldUseLegacyHunyuanProfile]
   )
-  const pluginProfileCards = effectivePluginProfiles
-  const qAppProfiles = React.useMemo(
+  const { pluginProfileCards, qAppProfiles } = React.useMemo(
     () =>
-      effectivePluginProfiles.length > 0
-        ? effectivePluginProfiles
-        : getQAppApiProfiles(settingsValue),
+      resolveQuickAppApiProfileLists({
+        effectivePluginProfiles,
+        settingsValue
+      }),
     [effectivePluginProfiles, settingsValue]
+  )
+  const apiProfilesSectionAction = React.useMemo(
+    () =>
+      getQuickAppApiProfilesSectionAction({
+        effectivePluginProfiles,
+        isChineseUi,
+        savePluginProfiles
+      }),
+    [effectivePluginProfiles, isChineseUi, savePluginProfiles]
   )
 
   React.useEffect(() => {
@@ -657,19 +625,16 @@ const PanelPlugin: React.FC<PanelProps> = ({ settingsValue, saveSettings }: Pane
       const deletedProfile = effectivePluginProfiles.find((profile) => profile.id === profileId)
       const nextProfiles = effectivePluginProfiles.filter((profile) => profile.id !== profileId)
 
-      if (deletedProfile && legacyHunyuanProfile && isHunyuan3DCompatibleProfile(deletedProfile)) {
+      if (
+        deletedProfile &&
+        legacyHunyuanProfile &&
+        isQuickAppLegacyHunyuanProfile(deletedProfile)
+      ) {
         saveSettings({
           plugin_config: {
             api_profiles: nextProfiles
           },
-          aigc3d_config: {
-            tencent_secret_id: '',
-            tencent_secret_key: '',
-            api_region: '',
-            cos_bucket: '',
-            cos_region: '',
-            cos_key_prefix: ''
-          }
+          aigc3d_config: buildClearedQuickAppLegacyHunyuanConfig()
         })
         return
       }
@@ -687,11 +652,11 @@ const PanelPlugin: React.FC<PanelProps> = ({ settingsValue, saveSettings }: Pane
     (profile: LLMAPIProfile) => {
       savePluginProfiles([
         ...effectivePluginProfiles,
-        {
+        prepareClonedQuickAppProfile(profile, {
           ...stripExternalAuthProfile(profile),
           id: crypto.randomUUID(),
           api_key: ''
-        }
+        })
       ])
     },
     [effectivePluginProfiles, savePluginProfiles]
@@ -742,6 +707,7 @@ const PanelPlugin: React.FC<PanelProps> = ({ settingsValue, saveSettings }: Pane
 
       {!settingsValue.use_remote_llm && (
         <ApiProfilesSection
+          action={apiProfilesSectionAction}
           title={qt('quickapp_api.api_profiles_section', '快应用 API 设置')}
           onAdd={handleAddPluginApiProfile}
           onClone={handleClonePluginApiProfile}

--- a/packages/app/src/renderer/src/pages/SettingsPage/settingsPageExtensions.tsx
+++ b/packages/app/src/renderer/src/pages/SettingsPage/settingsPageExtensions.tsx
@@ -1,0 +1,110 @@
+import type React from 'react'
+import type { Config, LLMAPIProfile } from '@shared/config/config'
+import {
+  getQAppApiProfiles,
+  isHunyuan3DCompatibleProfile
+} from '@shared/config/apiProfileSelectors'
+import { rendererHostExtensionApiV1 } from '@renderer/extensions/generatedRegistry'
+
+const HUNYUAN_AI3D_BASE_URL = 'https://api.ai3d.cloud.tencent.com'
+const DEFAULT_HY3D_COS_PREFIX = 'magicpot/hunyuan3d'
+const DEFAULT_HY3D_API_REGION = 'ap-guangzhou'
+const LEGACY_HUNYUAN_PROFILE_ID = 'legacy-hunyuan3d-profile'
+
+export const buildQuickAppLegacyHunyuanProfile = (settingsValue: Config): LLMAPIProfile | null => {
+  const extensionValue =
+    rendererHostExtensionApiV1.settings?.buildQuickAppLegacyHunyuanProfile?.(settingsValue)
+  if (extensionValue !== undefined) {
+    return extensionValue
+  }
+
+  const legacy = settingsValue.aigc3d_config
+  const legacyKeyPrefix = legacy?.cos_key_prefix?.trim() || ''
+  const hasCustomKeyPrefix = Boolean(legacyKeyPrefix && legacyKeyPrefix !== DEFAULT_HY3D_COS_PREFIX)
+
+  if (
+    !legacy ||
+    !(
+      legacy.tencent_secret_id?.trim() ||
+      legacy.tencent_secret_key?.trim() ||
+      legacy.api_region?.trim() ||
+      legacy.cos_bucket?.trim() ||
+      legacy.cos_region?.trim() ||
+      hasCustomKeyPrefix
+    )
+  ) {
+    return null
+  }
+
+  return {
+    id: LEGACY_HUNYUAN_PROFILE_ID,
+    model_name: 'Hunyuan3D Pro',
+    base_url: HUNYUAN_AI3D_BASE_URL,
+    api_key: '',
+    provider: 'default',
+    model_use: 'default',
+    is_ollama: false,
+    is_vision_model: false,
+    is_ocr_model: false,
+    tencent_secret_id: legacy.tencent_secret_id || '',
+    tencent_secret_key: legacy.tencent_secret_key || '',
+    api_region: legacy.api_region || DEFAULT_HY3D_API_REGION,
+    cos_bucket: legacy.cos_bucket || '',
+    cos_region: legacy.cos_region || DEFAULT_HY3D_API_REGION,
+    cos_key_prefix: legacyKeyPrefix || DEFAULT_HY3D_COS_PREFIX
+  }
+}
+
+export const buildClearedQuickAppLegacyHunyuanConfig = (): NonNullable<Config['aigc3d_config']> =>
+  rendererHostExtensionApiV1.settings?.buildClearedQuickAppLegacyHunyuanConfig?.() ?? {
+    tencent_secret_id: '',
+    tencent_secret_key: '',
+    api_region: '',
+    cos_bucket: '',
+    cos_region: '',
+    cos_key_prefix: ''
+  }
+
+export const resolveQuickAppApiProfileLists = (options: {
+  effectivePluginProfiles: LLMAPIProfile[]
+  settingsValue: Config
+}): {
+  pluginProfileCards: LLMAPIProfile[]
+  qAppProfiles: LLMAPIProfile[]
+} => {
+  const extensionValue =
+    rendererHostExtensionApiV1.settings?.resolveQuickAppApiProfileLists?.(options)
+  if (extensionValue) {
+    return extensionValue
+  }
+
+  const { effectivePluginProfiles, settingsValue } = options
+
+  return {
+    pluginProfileCards: effectivePluginProfiles,
+    qAppProfiles:
+      effectivePluginProfiles.length > 0
+        ? effectivePluginProfiles
+        : getQAppApiProfiles(settingsValue)
+  }
+}
+
+export const prepareClonedQuickAppProfile = (
+  sourceProfile: LLMAPIProfile,
+  clonedProfile: LLMAPIProfile
+): LLMAPIProfile =>
+  rendererHostExtensionApiV1.settings?.prepareClonedQuickAppProfile?.(
+    sourceProfile,
+    clonedProfile
+  ) ?? clonedProfile
+
+export const getQuickAppApiProfilesSectionAction = (options: {
+  effectivePluginProfiles: LLMAPIProfile[]
+  isChineseUi: boolean
+  savePluginProfiles: (nextProfiles: LLMAPIProfile[]) => void
+}): React.ReactNode =>
+  rendererHostExtensionApiV1.settings?.getQuickAppApiProfilesSectionAction?.(options) ?? null
+
+export const isQuickAppLegacyHunyuanProfile = (profile: LLMAPIProfile): boolean =>
+  rendererHostExtensionApiV1.settings?.isQuickAppLegacyHunyuanProfile?.(profile) ??
+  isHunyuan3DCompatibleProfile(profile)

--- a/packages/app/src/shared/api/extensionServices.ts
+++ b/packages/app/src/shared/api/extensionServices.ts
@@ -1,0 +1,2 @@
+export type { ApiExtensionServices } from '@shared/extensions/generatedRegistry'
+export { apiExtensionDef } from '@shared/extensions/generatedRegistry'

--- a/packages/app/src/shared/api/index.ts
+++ b/packages/app/src/shared/api/index.ts
@@ -18,8 +18,9 @@ import { PysssssSvc, pysssssSvcDef } from './svcPysssss'
 import { QAppSvc, qAppSvcDef } from './svcQApp'
 import { ShellSvc, shellSvcDef } from './svcShell'
 import { StateSvc, stateSvcDef } from './svcState'
+import { apiExtensionDef, type ApiExtensionServices } from './extensionServices'
 
-export type Api = {
+export type BaseApi = {
   svcAdobeBridge: AdobeBridgeSvc
   svcState: StateSvc
   svcHyper: HyperSvc
@@ -41,6 +42,8 @@ export type Api = {
   svcDuplicateCheck: DuplicateCheckSvc
 }
 
+export type Api = BaseApi & ApiExtensionServices
+
 export const apiDef: ApiDefSheet<Api> = {
   svcAdobeBridge: adobeBridgeSvcDef,
   svcState: stateSvcDef,
@@ -60,5 +63,6 @@ export const apiDef: ApiDefSheet<Api> = {
   svcLog: logSvcDef,
   svcFs: fsSvcDef,
   svcDccBridge: dccBridgeSvcDef,
-  svcDuplicateCheck: duplicateCheckSvcDef
+  svcDuplicateCheck: duplicateCheckSvcDef,
+  ...apiExtensionDef
 }

--- a/packages/app/src/shared/config/config.ts
+++ b/packages/app/src/shared/config/config.ts
@@ -12,7 +12,7 @@ export type LLMModelUse = 'chat' | 'agent' | 'multimodal' | 'vision' | 'ocr' | '
 export type LLMProviderOption = LLMProvider | 'default'
 export type LLMModelUseOption = LLMModelUse | 'default'
 export type LLMProfileAuthMode = string
-export type LLMProfileCallType = 'api' | 'local'
+export type LLMProfileCallType = 'api' | 'local' | (string & {})
 export type TaggerProviderId = 'wdtagger' | 'cl_tagger' | 'paddle_ocr'
 export type TaggerProviderOption = TaggerProviderId | 'default'
 export type TaggerRuntimeCacheScope = 'profile' | 'provider' | 'endpoint'
@@ -35,6 +35,7 @@ export type LLMAPIProfile = {
   auth_mode?: LLMProfileAuthMode
   auth_account_email?: string
   auth_connected_at?: string
+  codex_fast_mode?: boolean
   provider?: LLMProviderOption
   deployment?: LLMDeployment
   model_use?: LLMModelUseOption

--- a/packages/app/src/shared/config/configUtils.ts
+++ b/packages/app/src/shared/config/configUtils.ts
@@ -122,6 +122,10 @@ export class ConfigUtils {
     return `http://localhost:${port}`
   }
 
+  getPortablePythonHomeDir(): string {
+    return this.path.join(this.buildEnv.pathMap.data, 'runtime', 'home')
+  }
+
   // 所有 ComfyUI 子目录统一逻辑：
   // 如果为绝对路径，则直接返回
   // 否则，返回相对于 ComfyUI 目录的相对路径

--- a/packages/app/src/shared/extensions/generatedRegistry.ts
+++ b/packages/app/src/shared/extensions/generatedRegistry.ts
@@ -1,0 +1,56 @@
+import type {
+  Config,
+  LLMAPIProfile,
+  LLMDeployment,
+  LLMModelUse,
+  LLMProfileCallType,
+  LLMProvider
+} from '@shared/config/config'
+import type { ApiDefSheet } from '@shared/api/apiUtils/serviceDefSheet'
+import type { FetchImpl } from '@shared/llm/clients'
+import type {
+  ChatCapabilityProfile,
+  ChatProfileCapabilities,
+  LLMCli,
+  ModelCatalogOption
+} from '@shared/llm'
+
+export type ApiExtensionServices = {}
+
+export const apiExtensionDef: ApiDefSheet<ApiExtensionServices> = {}
+
+export type LlmProfileLikeV1 = Partial<LLMAPIProfile>
+
+export type SharedLlmProfileExtensionV1 = {
+  id: string
+  buildModelCatalog?: (options: {
+    authMode?: string
+    deployment: LLMDeployment
+    modelUse: LLMModelUse
+    provider: LLMProvider
+    currentModelName?: string | null
+    discoveredModelNames?: readonly (string | ModelCatalogOption | null | undefined)[]
+    observedModelNames?: readonly (string | ModelCatalogOption | null | undefined)[]
+  }) => ModelCatalogOption[] | undefined
+  createCli?: (profile: LlmProfileLikeV1, options?: { fetchImpl?: FetchImpl }) => LLMCli | undefined
+  isRunnableProfile?: (profile: LlmProfileLikeV1) => boolean | undefined
+  resolveCapabilities?: (
+    profile: ChatCapabilityProfile | null | undefined,
+    baseCapabilities: ChatProfileCapabilities
+  ) => Partial<ChatProfileCapabilities> | undefined
+  resolveProfileCallType?: (
+    profile: Pick<LLMAPIProfile, 'auth_mode' | 'call_type'>
+  ) => LLMProfileCallType | undefined
+  resolveProfileDeployment?: (profile: LlmProfileLikeV1) => LLMDeployment | undefined
+  resolveProfileModelUse?: (profile: LlmProfileLikeV1) => LLMModelUse | undefined
+  resolveProfileProvider?: (profile: LlmProfileLikeV1) => LLMProvider | undefined
+  transformQAppApiProfiles?: (profiles: LLMAPIProfile[], config: Config) => LLMAPIProfile[]
+}
+
+export type SharedHostExtensionApiV1 = {
+  llmProfiles: SharedLlmProfileExtensionV1[]
+}
+
+export const sharedHostExtensionApiV1: SharedHostExtensionApiV1 = {
+  llmProfiles: []
+}

--- a/packages/app/src/shared/llm/modelCatalog.ts
+++ b/packages/app/src/shared/llm/modelCatalog.ts
@@ -1,4 +1,5 @@
 import type { LLMDeployment, LLMModelUse, LLMProvider } from '@shared/config/config'
+import { sharedHostExtensionApiV1 } from '@shared/extensions/generatedRegistry'
 
 export type ModelCatalogOption = {
   label: string
@@ -90,10 +91,29 @@ const dedupeOptions = (options: ModelCatalogOption[]): ModelCatalogOption[] => {
 }
 
 export function getSuggestedModelCatalog(options: {
+  authMode?: string
   deployment: LLMDeployment
   modelUse: LLMModelUse
   provider: LLMProvider
+  codexCurrentModelName?: string | null
+  codexDiscoveredModelNames?: readonly (string | ModelCatalogOption | null | undefined)[]
+  codexObservedModelNames?: readonly (string | ModelCatalogOption | null | undefined)[]
 }): ModelCatalogOption[] {
+  for (const extension of sharedHostExtensionApiV1.llmProfiles) {
+    const catalog = extension.buildModelCatalog?.({
+      authMode: options.authMode,
+      deployment: options.deployment,
+      modelUse: options.modelUse,
+      provider: options.provider,
+      currentModelName: options.codexCurrentModelName,
+      discoveredModelNames: options.codexDiscoveredModelNames,
+      observedModelNames: options.codexObservedModelNames
+    })
+    if (catalog) {
+      return catalog
+    }
+  }
+
   if (options.provider === 'openai') {
     return toOptions(OPENAI_MODEL_NAMES)
   }

--- a/packages/app/src/shared/llm/profileCapabilities.ts
+++ b/packages/app/src/shared/llm/profileCapabilities.ts
@@ -1,4 +1,5 @@
 import type { LLMDeployment, LLMProviderOption } from '@shared/config/config'
+import { sharedHostExtensionApiV1 } from '@shared/extensions/generatedRegistry'
 
 export type LLMReasoningEffort = 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'
 
@@ -85,11 +86,25 @@ export const getReasoningEffortLabel = (effort: LLMReasoningEffort): string => {
 export const resolveChatProfileCapabilities = (
   profile?: ChatCapabilityProfile | null
 ): ChatProfileCapabilities => {
+  const applyExtensions = (baseCapabilities: ChatProfileCapabilities): ChatProfileCapabilities => {
+    let nextCapabilities = baseCapabilities
+    for (const extension of sharedHostExtensionApiV1.llmProfiles) {
+      const resolved = extension.resolveCapabilities?.(profile, nextCapabilities)
+      if (resolved) {
+        nextCapabilities = {
+          ...nextCapabilities,
+          ...resolved
+        }
+      }
+    }
+    return nextCapabilities
+  }
+
   if (!isOpenAICompatibleProfile(profile)) {
-    return {
+    return applyExtensions({
       reasoningEfforts: [],
       supportsAutoContextCompression: false
-    }
+    })
   }
 
   const modelName = normalizeModelName(profile?.model_name)
@@ -148,7 +163,7 @@ export const resolveChatProfileCapabilities = (
       )
     : undefined
 
-  return {
+  return applyExtensions({
     reasoningEfforts: normalizedEfforts,
     ...(normalizedDefaultReasoningEffort
       ? { defaultReasoningEffort: normalizedDefaultReasoningEffort }
@@ -156,7 +171,7 @@ export const resolveChatProfileCapabilities = (
     ...(contextWindowTokens ? { contextWindowTokens } : {}),
     ...(contextBudgetTokens ? { contextBudgetTokens } : {}),
     supportsAutoContextCompression: Boolean(contextBudgetTokens)
-  }
+  })
 }
 
 export const normalizeReasoningEffort = (

--- a/packages/app/src/shared/llm/utils.ts
+++ b/packages/app/src/shared/llm/utils.ts
@@ -14,6 +14,7 @@ import type {
   LLMProvider,
   LLMProviderOption
 } from '@shared/config/config'
+import { sharedHostExtensionApiV1 } from '@shared/extensions/generatedRegistry'
 import { LLMCli } from './types'
 import { OpenAIAPICli, GeminiAPICli, ClaudeAPICli, OllamaAPICli, type FetchImpl } from './clients'
 
@@ -43,6 +44,13 @@ const normalizeCallType = (callType?: string): LLMProfileCallType | undefined =>
 }
 
 export const resolveProfileCallType = (profile: ProfileLike): LLMProfileCallType => {
+  for (const extension of sharedHostExtensionApiV1.llmProfiles) {
+    const resolved = extension.resolveProfileCallType?.(profile)
+    if (resolved) {
+      return resolved
+    }
+  }
+
   const explicitCallType = normalizeCallType(profile.call_type)
   if (explicitCallType) {
     return explicitCallType
@@ -160,6 +168,13 @@ export const resolveProfileProvider = (profile: ProfileLike): LLMProvider | unde
     return undefined
   }
 
+  for (const extension of sharedHostExtensionApiV1.llmProfiles) {
+    const resolved = extension.resolveProfileProvider?.(profile)
+    if (resolved) {
+      return resolved
+    }
+  }
+
   const explicitProvider = normalizeProvider(profile.provider)
   if (explicitProvider) {
     return explicitProvider
@@ -189,6 +204,13 @@ export const resolveProfileDeployment = (profile: ProfileLike): LLMDeployment =>
     return 'local'
   }
 
+  for (const extension of sharedHostExtensionApiV1.llmProfiles) {
+    const resolved = extension.resolveProfileDeployment?.(profile)
+    if (resolved) {
+      return resolved
+    }
+  }
+
   const explicitDeployment = normalizeDeployment(profile.deployment)
   if (explicitDeployment) {
     return explicitDeployment
@@ -206,6 +228,13 @@ export const resolveProfileDeployment = (profile: ProfileLike): LLMDeployment =>
 }
 
 export const resolveProfileModelUse = (profile: ProfileLike): LLMModelUse => {
+  for (const extension of sharedHostExtensionApiV1.llmProfiles) {
+    const resolved = extension.resolveProfileModelUse?.(profile)
+    if (resolved) {
+      return resolved
+    }
+  }
+
   const explicitModelUse = normalizeModelUse(profile.model_use)
   if (explicitModelUse) {
     return explicitModelUse
@@ -226,6 +255,13 @@ export const isOllamaProfile = (profile: ProfileLike): boolean =>
   resolveProfileProvider(profile) === 'ollama'
 
 export const isRunnableProfile = (profile: ProfileLike): boolean => {
+  for (const extension of sharedHostExtensionApiV1.llmProfiles) {
+    const resolved = extension.isRunnableProfile?.(profile)
+    if (typeof resolved === 'boolean') {
+      return resolved
+    }
+  }
+
   if (resolveProfileCallType(profile) === 'local') {
     return false
   }
@@ -261,6 +297,7 @@ export const cliFromProfile = (
     api_key: string
     auth_mode?: string
     base_url: string
+    codex_fast_mode?: boolean
     model_name: string
     provider?: LLMProviderOption
     deployment?: LLMDeployment
@@ -270,6 +307,13 @@ export const cliFromProfile = (
 ): LLMCli | undefined => {
   if (!isRunnableProfile(profile)) {
     return undefined
+  }
+
+  for (const extension of sharedHostExtensionApiV1.llmProfiles) {
+    const cli = extension.createCli?.(profile, options)
+    if (cli) {
+      return cli
+    }
   }
 
   switch (resolveProfileProvider(profile)) {

--- a/packages/app/src/shared/qApp/cfgTypes.ts
+++ b/packages/app/src/shared/qApp/cfgTypes.ts
@@ -161,7 +161,7 @@ export type QAppRequiredModel = {
   /** 文件大小描述 */
   size: string
   /** Base directory for dir. Defaults to ComfyUI. */
-  baseDir?: 'comfyui' | 'userHome'
+  baseDir?: 'comfyui' | 'portableHome'
   /** 模型放置目录（相对于 baseDir 对应目录），如 models/unet */
   dir: string
   /** 下载链接 */

--- a/packages/qapps/一键抠图/Rembg.qacfg.json
+++ b/packages/qapps/一键抠图/Rembg.qacfg.json
@@ -15,7 +15,7 @@
     {
       "name": "ckpt_base.pth",
       "size": "368 MB",
-      "baseDir": "userHome",
+      "baseDir": "portableHome",
       "dir": ".transparent-background",
       "url": "https://hf-mirror.com/datasets/chaodu001/ComfyUI_LayerStyle_All_models_download/resolve/main/transparent-background/ckpt_base.pth"
     }


### PR DESCRIPTION
﻿## Summary

- Add a host extension API surface and generated registries for main, renderer, and shared extension hooks.
- Route LLM/model/profile/settings and chat page extension points through the host extension layer.
- Fix the rembg bundled QApp model cache path and add dependency-check coverage.

## Impact

This lets private integrations be layered on top of magicpot-open through generated host extension registries, reducing private patch pressure while keeping the open app buildable on its own.

## Validation

- From the wrapper repo: `npm run check`
- From the wrapper repo: `npm run check:codex-overlay:typecheck`
