### PR TITLE
[codex] Fix quick app repeat run button

### DIFF
--- a/packages/app/src/renderer/src/pages/QuickAppPage/components/CascadingMenuItem.tsx
+++ b/packages/app/src/renderer/src/pages/QuickAppPage/components/CascadingMenuItem.tsx
@@ -3,6 +3,7 @@ import { Box, Collapse, IconButton, List, ListItemButton, styled } from '@mui/ma
 import { ExpandMore, ChevronRight, PlayArrow as PlayArrowIcon } from '@mui/icons-material'
 import { useComfyEventCallback } from '@renderer/hooks/useComfyEvent'
 import { QAppMenuItem } from '@shared/api/svcQApp'
+import { isBuiltinDuplicateCheckQApp } from '../duplicateCheck/builtin'
 
 const overflowWidth = 14
 const leftOverflow = overflowWidth + 4
@@ -128,6 +129,7 @@ export const CascadingMenuItem = memo(
     const isDirectory = !!qAppItem.isDirectory
     const isExpanded = isDirectory && expandedKeys.has(qAppItem.key)
     const displayName = getDisplayName(qAppItem.name) || getDisplayName(qAppItem.key)
+    const canCancelRun = isBuiltinDuplicateCheckQApp(qAppItem.key) && Boolean(isRunning)
 
     // 进度条状态
     const [progress, setProgress] = useState(0)
@@ -258,14 +260,14 @@ export const CascadingMenuItem = memo(
                   p: 0.5,
                   flexShrink: 0,
                   ml: 0.5,
-                  color: isRunning ? '#fff' : '#7E73FD',
-                  bgcolor: isRunning ? '#d32f2f' : '#ffffff',
+                  color: canCancelRun ? '#fff' : '#7E73FD',
+                  bgcolor: canCancelRun ? '#d32f2f' : '#ffffff',
                   borderRadius: 1,
                   boxShadow: '0 2px 4px rgba(0,0,0,0.15)',
                   transition:
                     'background-color 0.15s ease, transform 0.1s ease, box-shadow 0.15s ease',
                   '&:hover': {
-                    bgcolor: isRunning ? '#b71c1c' : '#f8f8f8',
+                    bgcolor: canCancelRun ? '#b71c1c' : '#f8f8f8',
                     transform: 'scale(1.12)',
                     boxShadow: '0 4px 8px rgba(0,0,0,0.2)'
                   },
@@ -274,7 +276,7 @@ export const CascadingMenuItem = memo(
                   }
                 }}
               >
-                {isRunning ? (
+                {canCancelRun ? (
                   <Box sx={{ width: 10, height: 10, bgcolor: '#fff', borderRadius: 0.5 }} />
                 ) : (
                   <PlayArrowIcon sx={{ fontSize: 20 }} />

--- a/packages/app/src/renderer/src/pages/QuickAppPage/components/QAppMenu.test.tsx
+++ b/packages/app/src/renderer/src/pages/QuickAppPage/components/QAppMenu.test.tsx
@@ -189,6 +189,21 @@ const renderInlineDropMenu = () =>
     </ThemeProvider>
   )
 
+const renderRunnableMenu = (isRunning: boolean, onRunClick = vi.fn()) => ({
+  onRunClick,
+  ...render(
+    <ThemeProvider theme={theme}>
+      <QAppMenu
+        currentQAppKey="alpha"
+        setCurrentQAppKey={setCurrentQAppKeyMock}
+        activeCategory="image"
+        onRunClick={onRunClick}
+        isRunning={isRunning}
+      />
+    </ThemeProvider>
+  )
+})
+
 beforeEach(() => {
   setCurrentQAppKeyMock.mockClear()
   navigateMock.mockClear()
@@ -343,6 +358,19 @@ describe('QAppMenu', () => {
     })
 
     expect(menuRoot).toHaveAttribute('data-dragging-over', 'false')
+  })
+
+  it('keeps the normal quick app run button as a run action while running', async () => {
+    const { onRunClick } = renderRunnableMenu(true)
+
+    const playIcon = await screen.findByTestId('PlayArrowIcon')
+    const runButton = playIcon.closest('button')
+
+    expect(runButton).toBeTruthy()
+
+    fireEvent.click(runButton!)
+
+    expect(onRunClick).toHaveBeenCalledWith('alpha')
   })
 
   it('restores the matching Hunyuan3D quick app and parameters from an internal 3d drag', async () => {

--- a/packages/app/src/renderer/src/pages/QuickAppPage/components/QAppMenu.tsx
+++ b/packages/app/src/renderer/src/pages/QuickAppPage/components/QAppMenu.tsx
@@ -301,6 +301,7 @@ const CascadingMenuItem = memo(
     const displayName = getDisplayName(qAppItem.name) || getDisplayName(qAppItem.key)
     const itemRef = useRef<HTMLDivElement | null>(null)
     const [isPinned, setIsPinned] = useState(false)
+    const canCancelRun = isBuiltinDuplicateCheckQApp(qAppItem.key) && Boolean(isRunning)
 
     // 进度条状态
     const [progress, setProgress] = useState(0)
@@ -470,14 +471,14 @@ const CascadingMenuItem = memo(
                   p: 0.5,
                   flexShrink: 0,
                   ml: 0.5,
-                  color: isRunning ? '#fff' : '#7E73FD',
-                  bgcolor: isRunning ? '#d32f2f' : '#ffffff',
+                  color: canCancelRun ? '#fff' : '#7E73FD',
+                  bgcolor: canCancelRun ? '#d32f2f' : '#ffffff',
                   borderRadius: 1,
                   boxShadow: '0 2px 4px rgba(0,0,0,0.15)',
                   transition:
                     'background-color 0.15s ease, transform 0.1s ease, box-shadow 0.15s ease',
                   '&:hover': {
-                    bgcolor: isRunning ? '#b71c1c' : '#f8f8f8',
+                    bgcolor: canCancelRun ? '#b71c1c' : '#f8f8f8',
                     transform: 'scale(1.12)',
                     boxShadow: '0 4px 8px rgba(0,0,0,0.2)'
                   },
@@ -486,7 +487,7 @@ const CascadingMenuItem = memo(
                   }
                 }}
               >
-                {isRunning ? (
+                {canCancelRun ? (
                   <Box sx={{ width: 10, height: 10, bgcolor: '#fff', borderRadius: 0.5 }} />
                 ) : (
                   <PlayArrowIcon sx={{ fontSize: 20 }} />


### PR DESCRIPTION
## Summary
- Keep normal Quick App menu run buttons as repeat-run actions while a workflow is running.
- Preserve the red stop-state affordance for built-in duplicate check, which supports cancellation.
- Add a menu test covering the running repeat-run state.

## Root Cause
The shared menu button rendered every running Quick App as a stop button, even though normal Quick Apps still invoke the run callback and do not cancel a running workflow.

## Validation
- npm exec vitest -- run --config config/vitest/vitest.web.config.mjs packages/app/src/renderer/src/pages/QuickAppPage/components/QAppMenu.test.tsx
- npm run typecheck:web