### PR TITLE
[codex] Fix CodeQL security alerts

### DIFF
--- a/.github/workflows/call-build.yml
+++ b/.github/workflows/call-build.yml
@@ -12,6 +12,9 @@ on:
         type: string
         default: ''
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/call-ci.yml
+++ b/.github/workflows/call-ci.yml
@@ -12,6 +12,9 @@ on:
         type: string
         default: ''
 
+permissions:
+  contents: read
+
 jobs:
   test-lint-typecheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-on-master.yml
+++ b/.github/workflows/ci-on-master.yml
@@ -6,12 +6,18 @@ on:
     branches:
       - master
 
+permissions: {}
+
 jobs:
   ci:
+    permissions:
+      contents: read
     uses: ./.github/workflows/call-ci.yml
     with:
       ref: ${{ github.ref }}
   build:
+    permissions:
+      contents: read
     uses: ./.github/workflows/call-build.yml
     with:
       ref: ${{ github.ref }}

--- a/.github/workflows/ci-on-pull-request.yml
+++ b/.github/workflows/ci-on-pull-request.yml
@@ -6,14 +6,20 @@ on:
     branches:
       - '**'
 
+permissions: {}
+
 jobs:
   ci:
+    permissions:
+      contents: read
     uses: ./.github/workflows/call-ci.yml
     with:
       ref: ${{ github.ref }}
       fallback_ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
   build:
+    permissions:
+      contents: read
     uses: ./.github/workflows/call-build.yml
     with:
       ref: ${{ github.ref }}

--- a/.github/workflows/nightly-bump-version.yml
+++ b/.github/workflows/nightly-bump-version.yml
@@ -5,6 +5,8 @@ on:
     - cron: '0 19 * * 0' # Every Monday at 03:00 Beijing time.
   workflow_dispatch:
 
+permissions: {}
+
 env:
   RELEASE_BRANCH: release/nightly
 
@@ -87,6 +89,8 @@ jobs:
   ci:
     needs: check-commits
     if: needs.check-commits.outputs.release_mode == 'bump' || needs.check-commits.outputs.release_mode == 'initial'
+    permissions:
+      contents: read
     uses: ./.github/workflows/call-ci.yml
     with:
       ref: refs/heads/master
@@ -94,6 +98,8 @@ jobs:
   build:
     needs: check-commits
     if: needs.check-commits.outputs.release_mode == 'bump' || needs.check-commits.outputs.release_mode == 'initial'
+    permissions:
+      contents: read
     uses: ./.github/workflows/call-build.yml
     with:
       ref: refs/heads/master

--- a/packages/app/src/main/api/svcFigmaImpl.test.ts
+++ b/packages/app/src/main/api/svcFigmaImpl.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeFigmaFileKey } from './svcFigmaImpl'
+
+describe('svcFigmaImpl', () => {
+  it('extracts Figma file keys from figma.com URLs only', () => {
+    expect(normalizeFigmaFileKey('www.figma.com/design/ABC123Demo/file-name?node-id=1-2')).toBe(
+      'ABC123Demo'
+    )
+    expect(() =>
+      normalizeFigmaFileKey('https://gateway.example/figma.com/design/ABC123Demo/file-name')
+    ).toThrow('figma.com')
+  })
+})

--- a/packages/app/src/main/api/svcFigmaImpl.ts
+++ b/packages/app/src/main/api/svcFigmaImpl.ts
@@ -40,6 +40,7 @@ type FigmaApiImagesResponse = {
 
 const FIGMA_API_ORIGIN = 'https://api.figma.com/v1'
 const FIGMA_IMAGE_BATCH_SIZE = 20
+const FIGMA_HOSTNAME = 'figma.com'
 
 function ensureAccessToken(accessToken: string): string {
   const normalized = accessToken.trim()
@@ -49,7 +50,10 @@ function ensureAccessToken(accessToken: string): string {
   return normalized
 }
 
-function normalizeFigmaFileKey(input: string): string {
+const isFigmaHostname = (hostname: string): boolean =>
+  hostname === FIGMA_HOSTNAME || hostname.endsWith(`.${FIGMA_HOSTNAME}`)
+
+export function normalizeFigmaFileKey(input: string): string {
   const trimmed = input.trim()
   if (!trimmed) {
     throw new Error('Figma file link or file key is required.')
@@ -58,6 +62,9 @@ function normalizeFigmaFileKey(input: string): string {
   const tryParseUrl = (value: string): string | null => {
     try {
       const url = new URL(value)
+      if (!isFigmaHostname(url.hostname.toLowerCase())) {
+        return null
+      }
       const match = url.pathname.match(/\/(?:file|design|proto|board)\/([A-Za-z0-9]+)(?:[/?#]|$)/i)
       return match?.[1] ?? null
     } catch {
@@ -67,12 +74,14 @@ function normalizeFigmaFileKey(input: string): string {
 
   const parsedFromUrl =
     tryParseUrl(trimmed) ||
-    (trimmed.includes('figma.com/')
-      ? tryParseUrl(`https://${trimmed.replace(/^https?:\/\//i, '')}`)
-      : null)
+    (/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed) ? null : tryParseUrl(`https://${trimmed}`))
 
   if (parsedFromUrl) {
     return parsedFromUrl
+  }
+
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) {
+    throw new Error('Figma file URL must use figma.com.')
   }
 
   return trimmed

--- a/packages/app/src/main/api/svcPhotoshopImpl.ts
+++ b/packages/app/src/main/api/svcPhotoshopImpl.ts
@@ -15,7 +15,7 @@ import { app, clipboard, nativeImage } from 'electron'
 import * as fs from 'fs/promises'
 import * as path from 'path'
 import { shell } from 'electron'
-import { exec } from 'child_process'
+import { exec, execFile } from 'child_process'
 import { promisify } from 'util'
 import * as os from 'os'
 import { getQueue } from '../queue/taskQueue'
@@ -31,7 +31,22 @@ import { normalizeLocalFilePath } from '../utils/localFileUrl'
 
 const inflateAsync = promisify(zlib.inflate)
 const execAsync = promisify(exec)
+const execFileAsync = promisify(execFile)
 const testUiPolicy = resolveTestUiPolicy(readTestUiEnv())
+
+const escapeAppleScriptString = (value: string): string =>
+  value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+
+const buildPhotoshopJavaScriptAppleScript = (jsxScript: string): string =>
+  [
+    'tell application "Adobe Photoshop"',
+    '  activate',
+    `  do javascript "${escapeAppleScriptString(jsxScript)}"`,
+    'end tell'
+  ].join('\n')
+
+const runAppleScript = (appleScript: string, timeout = 10000) =>
+  execFileAsync('osascript', ['-e', appleScript], { timeout })
 
 const getPhotoshopTempDir = async (): Promise<string> => {
   const tempDir = resolveTestArtifactPath({
@@ -102,12 +117,7 @@ export class PhotoshopSvcImpl implements PhotoshopSvc {
 
   private async isPhotoshopRunningMac(): Promise<boolean> {
     try {
-      const { stdout } = await execAsync(
-        `osascript -e 'application "Adobe Photoshop" is running'`,
-        {
-          timeout: 5000
-        }
-      )
+      const { stdout } = await runAppleScript('application "Adobe Photoshop" is running', 5000)
       return stdout.trim().toLowerCase() === 'true'
     } catch {
       return false
@@ -307,15 +317,7 @@ export class PhotoshopSvcImpl implements PhotoshopSvc {
       '}'
     ].join('\n')
 
-    const appleScript = [
-      'tell application "Adobe Photoshop"',
-      '  activate',
-      '  do javascript "' + jsxScript.replace(/"/g, '\\"') + '"',
-      'end tell'
-    ].join('\n')
-
-    const command = `osascript -e '${appleScript.replace(/'/g, "'\\''")}'`
-    const { stderr } = await execAsync(command, { timeout: 10000 })
+    const { stderr } = await runAppleScript(buildPhotoshopJavaScriptAppleScript(jsxScript))
 
     if (stderr) {
       throw new Error(stderr)
@@ -943,15 +945,7 @@ export class PhotoshopSvcImpl implements PhotoshopSvc {
     ].join('\n')
 
     // Use osascript to invoke Photoshop.
-    const appleScript = [
-      'tell application "Adobe Photoshop"',
-      '  activate',
-      '  do javascript "' + jsxScript.replace(/"/g, '\\"') + '"',
-      'end tell'
-    ].join('\n')
-
-    const command = `osascript -e '${appleScript.replace(/'/g, "'\\''")}'`
-    const { stdout, stderr } = await execAsync(command, { timeout: 10000 })
+    const { stderr } = await runAppleScript(buildPhotoshopJavaScriptAppleScript(jsxScript))
 
     if (stderr) {
       throw new Error(stderr)

--- a/packages/app/src/main/mainWindow.ts
+++ b/packages/app/src/main/mainWindow.ts
@@ -136,7 +136,6 @@ export function createMainWindow(): BrowserWindow {
     webPreferences: {
       preload: join(__dirname, '../preload/index.js'),
       sandbox: false,
-      webSecurity: false,
       webviewTag: true,
       devTools: !app.isPackaged
     }

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasTargetQuickAppRuntime.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasTargetQuickAppRuntime.ts
@@ -18,6 +18,7 @@ import { transformResults } from '../QuickAppPage/ResultList/resultTransformers'
 import { dispatchQAppResultsToCanvas } from '../QuickAppPage/utils/qAppCanvasDispatch'
 import { buildQAppSubmitWorkflowRequest } from '../QuickAppPage/utils/qAppSubmitWorkflow'
 import { waitForQAppPromptResult } from '../QuickAppPage/utils/qAppPromptResult'
+import { createSecureIdSegment, createSecureRandomUint32 } from './secureId'
 import type {
   CanvasTargetOutputTarget,
   CanvasTargetQuickAppAction,
@@ -66,7 +67,7 @@ const toWorkflowJson = (workflow: Workflow): JsonDict => workflow as unknown as 
 
 const normalizeLabelKey = (value: string | undefined): string => value?.trim().toLowerCase() || ''
 
-const randomSeed = () => Math.floor(Math.random() * 0xffffffff)
+const randomSeed = () => createSecureRandomUint32()
 
 const looksLikeTransferableUrl = (value: string): boolean =>
   /^(data|blob|https?|file|local-media):/i.test(value.trim())
@@ -742,9 +743,7 @@ export async function runCanvasTargetQuickAppAction(
       qAppKey: options.action.qAppKey,
       sessionKey:
         options.generationSessionId ||
-        `canvas-target-${options.projectId || 'canvas'}-${Date.now()}-${Math.random()
-          .toString(36)
-          .slice(2, 8)}`
+        `canvas-target-${options.projectId || 'canvas'}-${Date.now()}-${createSecureIdSegment()}`
     })
   )
 

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasTargetWorkflow.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasTargetWorkflow.ts
@@ -48,6 +48,7 @@ import {
   normalizeCanvasTargetEvidenceMode,
   resolveCanvasTargetEvidencePolicy
 } from './canvasTargetEvidence'
+import { createTimestampedSecureId } from './secureId'
 
 type BoundsResolver = (item: CanvasItem) => {
   x: number
@@ -261,7 +262,7 @@ const DEFAULT_CANVAS_TARGET_TASK =
   'Work on the selected MagicPot canvas region against the provided local target scheme and user intent. Coordinate the candidate models as needed, keep outputs grounded in the canvas context, and avoid destructive or auto-fix actions unless the user explicitly requests them.'
 
 function createCanvasTargetId(prefix: string): string {
-  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  return createTimestampedSecureId(prefix)
 }
 
 function stripCodeFences(value: string): string {

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/generationTraceRuntime.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/generationTraceRuntime.ts
@@ -8,9 +8,10 @@ import {
   type GenerationTraceCandidateEntry,
   type GenerationTraceRecord
 } from './generationTraceStorage'
+import { createTimestampedSecureId } from './secureId'
 
 export function createGenerationTraceSessionId(): string {
-  return `generation-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  return createTimestampedSecureId('generation')
 }
 
 type BeginGenerationTraceSessionOptions = {
@@ -69,7 +70,7 @@ export function appendGenerationTraceCandidate(
     id:
       options.candidate.id?.trim() ||
       options.candidate.canvasItemId?.trim() ||
-      `candidate-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      createTimestampedSecureId('candidate'),
     canvasItemId: options.candidate.canvasItemId,
     fileName: options.candidate.fileName,
     src: options.candidate.src,

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/searchUtils.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/searchUtils.ts
@@ -1,4 +1,5 @@
 import type { CanvasAnnotationItem, CanvasItem, CanvasItemType } from './types'
+import { stripHtmlToText } from '@renderer/utils/htmlText'
 
 export type CanvasSearchFilter = 'all' | 'text' | 'image' | 'video' | 'model3d'
 
@@ -32,15 +33,6 @@ function truncateText(value: string, maxLength: number): string {
   const trimmed = value.trim()
   if (trimmed.length <= maxLength) return trimmed
   return `${trimmed.slice(0, Math.max(0, maxLength - 1)).trimEnd()}…`
-}
-
-function stripHtml(html: string): string {
-  return html
-    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
-    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
-    .replace(/<[^>]+>/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim()
 }
 
 function getSourceName(src: string): string {
@@ -180,7 +172,7 @@ function getSearchDescriptor(item: CanvasItem): SearchDescriptor {
     }
   }
 
-  const htmlText = item.type === 'html' ? stripHtml(item.htmlData) : ''
+  const htmlText = item.type === 'html' ? stripHtmlToText(item.htmlData) : ''
   return {
     filterType,
     title: truncateText(htmlText, 48),

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/secureId.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/secureId.ts
@@ -1,0 +1,36 @@
+const getCryptoSource = (): Crypto => {
+  const cryptoSource = globalThis.crypto
+  if (!cryptoSource || typeof cryptoSource.getRandomValues !== 'function') {
+    throw new Error('Secure random generator is unavailable')
+  }
+  return cryptoSource
+}
+
+const bytesToHex = (bytes: Uint8Array): string =>
+  Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('')
+
+export function createSecureIdSegment(byteLength = 6): string {
+  const cryptoSource = getCryptoSource()
+  const randomUUID = (cryptoSource as Crypto & { randomUUID?: () => string }).randomUUID
+
+  if (typeof randomUUID === 'function') {
+    return randomUUID
+      .call(cryptoSource)
+      .replace(/-/g, '')
+      .slice(0, byteLength * 2)
+  }
+
+  const bytes = new Uint8Array(byteLength)
+  cryptoSource.getRandomValues(bytes)
+  return bytesToHex(bytes)
+}
+
+export function createTimestampedSecureId(prefix: string): string {
+  return `${prefix}-${Date.now()}-${createSecureIdSegment()}`
+}
+
+export function createSecureRandomUint32(): number {
+  const values = new Uint32Array(1)
+  getCryptoSource().getRandomValues(values)
+  return values[0]
+}

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/types.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/types.ts
@@ -322,7 +322,7 @@ export function isModelArchiveFile(filename: string): boolean {
 export const ALL_ACCEPT = [
   'image/*',
   ...PSD_IMPORT_EXTENSIONS,
-  ...MODEL_IMPORT_EXTENSIONS.map((e) => e.replace('.', '.')),
-  ...FILE_IMPORT_EXTENSIONS.map((e) => e.replace('.', '.')),
+  ...MODEL_IMPORT_EXTENSIONS,
+  ...FILE_IMPORT_EXTENSIONS,
   'video/*'
 ].join(',')

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/useCanvasFileIntake.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/useCanvasFileIntake.ts
@@ -12,6 +12,7 @@ import {
   getDroppedAttachmentFile,
   parseInternalImageDragPayload
 } from '@renderer/utils/droppedImageUtils'
+import { stripHtmlToText } from '@renderer/utils/htmlText'
 import type { ChatAttachment, OCRResult } from '@shared/api/svcLLMProxy'
 import type { FileItem } from '@shared/comfy/types'
 import { getProjectCanvasLocation, isCanvasFile } from './canvasStorage'
@@ -951,7 +952,7 @@ export function useCanvasFileIntake({
             dropDataTransfer.getData('Text') ||
             dropDataTransfer.getData('text/html')
           if (text) {
-            text = text.replace(/<[^>]*>?/gm, '')
+            text = stripHtmlToText(text)
           }
         }
 

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/useCanvasTargetWorkflow.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/useCanvasTargetWorkflow.ts
@@ -77,6 +77,7 @@ import {
   type CanvasTargetQuickAppDraft,
   type CanvasTargetStageDraft
 } from './canvasTargetTypes'
+import { createTimestampedSecureId } from './secureId'
 import {
   buildCanvasTargetHistoryTargetRecord,
   materializeCanvasTargetQuickAppsForOptions,
@@ -1046,7 +1047,7 @@ async function presentCanvasTargetFinalResult(options: {
 }
 
 function createCanvasTargetRunId(): string {
-  return `canvas-target-run-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  return createTimestampedSecureId('canvas-target-run')
 }
 
 function createCanvasTargetArtifactId(stageId: string, suffix: string): string {

--- a/packages/app/src/renderer/src/utils/droppedImageUtils.ts
+++ b/packages/app/src/renderer/src/utils/droppedImageUtils.ts
@@ -12,6 +12,7 @@ import {
   normalizeLocalMediaUrl
 } from '@renderer/pages/ChatPage/chatPageShared'
 import { loadImageFromSrc } from '@renderer/pages/ProjectCanvasPage/canvasAssetIntakeHelpers'
+import { stripHtmlToText } from './htmlText'
 
 export const QAPP_IMAGE_DRAG_MIME = 'application/x-qapp-image'
 export const AGENT_IMAGE_DRAG_MIME = 'application/x-ai-image'
@@ -827,7 +828,7 @@ export const getDroppedTextContent = (dataTransfer: DragDataReader): string | nu
 
   const htmlText = dataTransfer.getData('text/html')
   if (htmlText.trim()) {
-    const strippedText = htmlText.replace(/<[^>]*>?/gm, '').trim()
+    const strippedText = stripHtmlToText(htmlText)
     return strippedText || null
   }
 

--- a/packages/app/src/renderer/src/utils/htmlText.test.ts
+++ b/packages/app/src/renderer/src/utils/htmlText.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+
+import { stripHtmlToText } from './htmlText'
+
+describe('htmlText', () => {
+  it('extracts readable text from html and removes script/style content', () => {
+    expect(
+      stripHtmlToText(
+        '<style>.hidden{display:none}</style><p>Hello&nbsp;<strong>world</strong></p><script>alert(1)</script >'
+      )
+    ).toBe('Hello world')
+  })
+})

--- a/packages/app/src/renderer/src/utils/htmlText.ts
+++ b/packages/app/src/renderer/src/utils/htmlText.ts
@@ -1,0 +1,60 @@
+const collapseWhitespace = (value: string): string => value.replace(/\s+/g, ' ').trim()
+
+const decodeBasicHtmlEntities = (value: string): string =>
+  value.replace(/&(nbsp|amp|lt|gt|quot|apos|#39);/gi, (match, entity: string) => {
+    switch (entity.toLowerCase()) {
+      case 'nbsp':
+        return ' '
+      case 'amp':
+        return '&'
+      case 'lt':
+        return '<'
+      case 'gt':
+        return '>'
+      case 'quot':
+        return '"'
+      case 'apos':
+      case '#39':
+        return "'"
+      default:
+        return match
+    }
+  })
+
+const stripHtmlWithoutDom = (html: string): string => {
+  let text = ''
+  let inTag = false
+
+  for (const char of html) {
+    if (char === '<') {
+      inTag = true
+      text += ' '
+      continue
+    }
+
+    if (char === '>' && inTag) {
+      inTag = false
+      text += ' '
+      continue
+    }
+
+    if (!inTag) {
+      text += char
+    }
+  }
+
+  return collapseWhitespace(decodeBasicHtmlEntities(text))
+}
+
+export function stripHtmlToText(html: string): string {
+  const trimmed = html.trim()
+  if (!trimmed) return ''
+
+  if (typeof DOMParser !== 'undefined') {
+    const document = new DOMParser().parseFromString(trimmed, 'text/html')
+    document.querySelectorAll('script, style').forEach((element) => element.remove())
+    return collapseWhitespace(document.body.textContent || '')
+  }
+
+  return stripHtmlWithoutDom(trimmed)
+}

--- a/packages/app/src/shared/config/apiProfileSelectors.test.ts
+++ b/packages/app/src/shared/config/apiProfileSelectors.test.ts
@@ -4,6 +4,7 @@ import {
   findHunyuan3DQAppProfile,
   getQAppApiProfiles,
   isConfiguredHunyuan3DProfile,
+  isHunyuan3DCompatibleProfile,
   isVisionCapableApiProfile
 } from './apiProfileSelectors'
 
@@ -205,6 +206,25 @@ describe('apiProfileSelectors', () => {
 
     expect(isConfiguredHunyuan3DProfile(profile)).toBe(true)
     expect(findHunyuan3DQAppProfile(config)?.id).toBe('plugin-hunyuan-sdk')
+  })
+
+  it('matches Hunyuan3D Tencent endpoints by hostname only', () => {
+    expect(
+      isHunyuan3DCompatibleProfile({
+        id: 'hunyuan',
+        model_name: 'hunyuan',
+        base_url: 'https://ai3d.cloud.tencent.com/v1',
+        api_key: 'secret'
+      })
+    ).toBe(true)
+    expect(
+      isHunyuan3DCompatibleProfile({
+        id: 'spoofed',
+        model_name: 'hunyuan',
+        base_url: 'https://gateway.example/ai3d.cloud.tencent.com/v1',
+        api_key: 'secret'
+      })
+    ).toBe(false)
   })
 
   it('treats explicit vision profiles as vision-capable for quick app prompt helpers', () => {

--- a/packages/app/src/shared/config/apiProfileSelectors.ts
+++ b/packages/app/src/shared/config/apiProfileSelectors.ts
@@ -15,6 +15,31 @@ export const isConfiguredApiProfile = (profile: LLMAPIProfile): boolean =>
 const hasConfiguredHunyuan3DSecretCredentials = (profile: LLMAPIProfile): boolean =>
   Boolean(profile.tencent_secret_id?.trim() && profile.tencent_secret_key?.trim())
 
+const getProfileBaseHostname = (value: string): string | null => {
+  const normalized = value.trim().toLowerCase()
+  if (!normalized) return null
+
+  const parseHostname = (candidate: string): string | null => {
+    try {
+      return new URL(candidate).hostname.toLowerCase()
+    } catch {
+      return null
+    }
+  }
+
+  return (
+    parseHostname(normalized) ||
+    (/^[a-z][a-z0-9+.-]*:\/\//i.test(normalized) ? null : parseHostname(`https://${normalized}`))
+  )
+}
+
+const hostnameMatchesDomain = (hostname: string, domain: string): boolean =>
+  hostname === domain || hostname.endsWith(`.${domain}`)
+
+const isTencentHunyuan3DHostname = (hostname: string): boolean =>
+  hostnameMatchesDomain(hostname, 'ai3d.cloud.tencent.com') ||
+  hostnameMatchesDomain(hostname, 'hunyuan.cloud.tencent.com')
+
 export const isVisionCapableApiProfile = (profile: LLMAPIProfile): boolean => {
   const modelUse = resolveProfileModelUse(profile)
   return (
@@ -29,12 +54,14 @@ export const isVisionCapableApiProfile = (profile: LLMAPIProfile): boolean => {
 export const isHunyuan3DCompatibleProfile = (profile: LLMAPIProfile): boolean => {
   if (!profile.model_name || !profile.base_url) return false
   const modelName = profile.model_name.toLowerCase()
-  const baseUrl = profile.base_url.toLowerCase()
+  const baseHostname = getProfileBaseHostname(profile.base_url)
+  const isTencentHunyuan3DBaseUrl = Boolean(
+    baseHostname && isTencentHunyuan3DHostname(baseHostname)
+  )
   return (
     modelName.includes('hunyuan3d') ||
-    (modelName.includes('hunyuan') && baseUrl.includes('ai3d.cloud.tencent.com')) ||
-    baseUrl.includes('ai3d.cloud.tencent.com') ||
-    baseUrl.includes('hunyuan.cloud.tencent.com')
+    (modelName.includes('hunyuan') && isTencentHunyuan3DBaseUrl) ||
+    isTencentHunyuan3DBaseUrl
   )
 }
 

--- a/packages/app/src/shared/llm/utils.test.ts
+++ b/packages/app/src/shared/llm/utils.test.ts
@@ -2,6 +2,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { ClaudeAPICli, GeminiAPICli, OllamaAPICli, OpenAIAPICli } from './clients'
 import {
   cliFromProfile,
+  isClaudeUrl,
+  isGeminiUrl,
   isOllamaProfile,
   isOllamaUrl,
   isRunnableProfile,
@@ -156,6 +158,13 @@ describe('shared llm ollama compatibility', () => {
     }
 
     expect(cliFromProfile(profile)).toBeInstanceOf(GeminiAPICli)
+  })
+
+  it('matches Gemini and Claude providers by hostname only', () => {
+    expect(isGeminiUrl('generativelanguage.googleapis.com/v1beta')).toBe(true)
+    expect(isGeminiUrl('https://evil.example/generativelanguage.googleapis.com/v1beta')).toBe(false)
+    expect(isClaudeUrl('https://api.anthropic.com/v1/messages')).toBe(true)
+    expect(isClaudeUrl('https://gateway.example/claude/v1/messages')).toBe(false)
   })
 
   it('allows local OpenAI-compatible gateways without API keys', () => {

--- a/packages/app/src/shared/llm/utils.ts
+++ b/packages/app/src/shared/llm/utils.ts
@@ -105,12 +105,43 @@ const normalizeModelUse = (modelUse?: string): LLMModelUse | undefined => {
   }
 }
 
+const getBaseUrlHostname = (value: string): string | null => {
+  const normalized = value.trim().toLowerCase()
+  if (!normalized) return null
+
+  const parseHostname = (candidate: string): string | null => {
+    try {
+      return new URL(candidate).hostname.toLowerCase()
+    } catch {
+      return null
+    }
+  }
+
+  return (
+    parseHostname(normalized) ||
+    (/^[a-z][a-z0-9+.-]*:\/\//i.test(normalized) ? null : parseHostname(`https://${normalized}`))
+  )
+}
+
+const hostnameMatchesDomain = (hostname: string, domain: string): boolean =>
+  hostname === domain || hostname.endsWith(`.${domain}`)
+
 export const isGeminiUrl = (url: string): boolean => {
-  return url.includes('generativelanguage.googleapis.com') || url.includes('googleapis.com')
+  const hostname = getBaseUrlHostname(url)
+  return Boolean(
+    hostname &&
+    (hostnameMatchesDomain(hostname, 'generativelanguage.googleapis.com') ||
+      hostnameMatchesDomain(hostname, 'googleapis.com'))
+  )
 }
 
 export const isClaudeUrl = (url: string): boolean => {
-  return url.includes('anthropic.com') || url.includes('claude')
+  const hostname = getBaseUrlHostname(url)
+  return Boolean(
+    hostname &&
+    (hostnameMatchesDomain(hostname, 'anthropic.com') ||
+      hostnameMatchesDomain(hostname, 'claude.ai'))
+  )
 }
 
 export const isOllamaUrl = (url: string): boolean => {


### PR DESCRIPTION
## Summary
- add explicit GitHub Actions token permissions for CI, build, and nightly reusable workflow paths
- replace substring-based provider/Figma URL checks with hostname validation
- remove disabled Electron web security and harden Photoshop AppleScript execution
- centralize HTML text extraction and replace CodeQL-flagged Math.random IDs with Web Crypto IDs

## Validation
- npx vitest run --config config/vitest/vitest.node.config.mjs packages/app/src/shared/llm/utils.test.ts packages/app/src/shared/config/apiProfileSelectors.test.ts packages/app/src/main/api/svcFigmaImpl.test.ts
- npx vitest run --config config/vitest/vitest.web.config.mjs packages/app/src/renderer/src/utils/htmlText.test.ts packages/app/src/renderer/src/pages/ProjectCanvasPage/generationTraceRuntime.test.ts packages/app/src/renderer/src/utils/droppedImageUtils.test.ts
- npm run typecheck
- npm run lint
- npm run test
- npm run build:pure