### PR TITLE
fix(quickapp): stop refresh loops and preserve media previews

### DIFF
--- a/packages/app/src/renderer/src/components/SidePanel.tsx
+++ b/packages/app/src/renderer/src/components/SidePanel.tsx
@@ -1,5 +1,6 @@
 // packages/app/src/renderer/src/components/SidePanel.tsx
 import React, { Suspense, lazy, useCallback, useEffect, useRef, useState } from 'react'
+import { isEqual } from 'es-toolkit'
 import {
   Box,
   CircularProgress,
@@ -1102,7 +1103,7 @@ const SidePanel: React.FC<SidePanelProps> = ({ width = SIDE_PANEL_DEFAULT_WIDTH,
       : 'ComfyUI is offline, click to reconnect'
   }
   const {
-    state: { isConnected },
+    state: { isConnected, objectInfos },
     setIsConnected,
     setObjectInfos
   } = useComfyStatus()
@@ -1124,6 +1125,7 @@ const SidePanel: React.FC<SidePanelProps> = ({ width = SIDE_PANEL_DEFAULT_WIDTH,
   const reconnectAttemptsRef = useRef(0)
   const nextReconnectAllowedAtRef = useRef(0)
   const isConnectedRef = useRef(isConnected)
+  const objectInfosRef = useRef(objectInfos)
   const quickAppTitleRef = useRef<HTMLElement | null>(null)
   const quickAppQueueBadgeRef = useRef<HTMLDivElement | null>(null)
   const quickAppActionsRef = useRef<HTMLDivElement | null>(null)
@@ -1210,10 +1212,16 @@ const SidePanel: React.FC<SidePanelProps> = ({ width = SIDE_PANEL_DEFAULT_WIDTH,
 
     try {
       const objectInfo = await api().svcComfy.getObjectInfo({})
-      const wasDisconnected = !isConnected
+      const wasDisconnected = !isConnectedRef.current
 
-      setIsConnected(true)
-      setObjectInfos(objectInfo)
+      if (!isConnectedRef.current) {
+        setIsConnected(true)
+      }
+      isConnectedRef.current = true
+      if (!isEqual(objectInfosRef.current, objectInfo)) {
+        objectInfosRef.current = objectInfo
+        setObjectInfos(objectInfo)
+      }
       reconnectAttemptsRef.current = 0
       nextReconnectAllowedAtRef.current = 0
 
@@ -1223,12 +1231,15 @@ const SidePanel: React.FC<SidePanelProps> = ({ width = SIDE_PANEL_DEFAULT_WIDTH,
 
       return true
     } catch {
-      setIsConnected(false)
+      if (isConnectedRef.current) {
+        setIsConnected(false)
+      }
+      isConnectedRef.current = false
       const nextAttempt = reconnectAttemptsRef.current + 1
       nextReconnectAllowedAtRef.current = Date.now() + Math.min(30000, 5000 * nextAttempt)
       return false
     }
-  }, [isConnected, setIsConnected, setObjectInfos])
+  }, [setIsConnected, setObjectInfos])
 
   const _refreshStatusLegacy = useCallback(async () => {
     const ok = await silentRefresh()
@@ -1251,16 +1262,20 @@ const SidePanel: React.FC<SidePanelProps> = ({ width = SIDE_PANEL_DEFAULT_WIDTH,
   }, [isConnected])
 
   useEffect(() => {
+    objectInfosRef.current = objectInfos
+  }, [objectInfos])
+
+  useEffect(() => {
     if (activeSidePanel !== 'quickapp') {
       reconnectAttemptsRef.current = 0
       return
     }
 
-    if (isConnected) {
+    if (isConnectedRef.current) {
       reconnectAttemptsRef.current = 0
     }
 
-    if (!isConnected && reconnectAttemptsRef.current < 3) {
+    if (!isConnectedRef.current && reconnectAttemptsRef.current < 3) {
       silentRefresh().then((ok) => {
         if (!ok) reconnectAttemptsRef.current += 1
       })
@@ -1271,7 +1286,7 @@ const SidePanel: React.FC<SidePanelProps> = ({ width = SIDE_PANEL_DEFAULT_WIDTH,
     }, 5000)
 
     return () => clearInterval(timer)
-  }, [activeSidePanel, silentRefresh, isConnected])
+  }, [activeSidePanel, silentRefresh])
 
   useEffect(() => {
     if (activeSidePanel !== 'quickapp') return
@@ -1284,8 +1299,6 @@ const SidePanel: React.FC<SidePanelProps> = ({ width = SIDE_PANEL_DEFAULT_WIDTH,
         const { newAbortHandler } = await import('@shared/api/apiUtils/abortHandler')
         const [abortSender, abortReceiver] = newAbortHandler()
         abortFn = () => abortSender.abort()
-        const { isEqual } = await import('es-toolkit')
-
         await api().svcComfy.watchQueue(
           {},
           {

--- a/packages/app/src/renderer/src/components/inputs/InputComfyImage.test.tsx
+++ b/packages/app/src/renderer/src/components/inputs/InputComfyImage.test.tsx
@@ -118,6 +118,28 @@ describe('InputComfyImage', () => {
     expect(notifyErrorMock.mock.calls[0][0]).toBe(UNSUPPORTED_INTERNAL_FILE_DROP_MESSAGE)
   })
 
+
+  it('preserves the selected value when preview loading fails', async () => {
+    apiMocks.getView.mockRejectedValue(new Error('preview offline'))
+    const onChange = vi.fn()
+
+    render(
+      <InputComfyImage
+        label="Quick App Image"
+        value="demo.png"
+        onChange={onChange}
+        placeholder="Drop an image"
+      />
+    )
+
+    await waitFor(() => {
+      expect(apiMocks.getView).toHaveBeenCalledTimes(1)
+    })
+
+    expect(onChange).not.toHaveBeenCalled()
+    expect(screen.getByText('Drop an image')).toBeInTheDocument()
+  })
+
   it('clears a selected image from the preview delete button', async () => {
     const createObjectURLMock = vi.fn(() => 'blob:preview')
     const revokeObjectURLMock = vi.fn()

--- a/packages/app/src/renderer/src/components/inputs/InputComfyImage.test.tsx
+++ b/packages/app/src/renderer/src/components/inputs/InputComfyImage.test.tsx
@@ -118,7 +118,6 @@ describe('InputComfyImage', () => {
     expect(notifyErrorMock.mock.calls[0][0]).toBe(UNSUPPORTED_INTERNAL_FILE_DROP_MESSAGE)
   })
 
-
   it('preserves the selected value when preview loading fails', async () => {
     apiMocks.getView.mockRejectedValue(new Error('preview offline'))
     const onChange = vi.fn()

--- a/packages/app/src/renderer/src/components/inputs/InputComfyImage.tsx
+++ b/packages/app/src/renderer/src/components/inputs/InputComfyImage.tsx
@@ -28,10 +28,8 @@ const InputComfyImage: React.FC<InputComfyImageProps> = ({
 
   // 同步外部 value 变化到 internalValue
   useEffect(() => {
-    if (value !== internalValue) {
-      setInternalValue(value)
-    }
-  }, [value, internalValue])
+    setInternalValue((prev) => (prev === value ? prev : value))
+  }, [value])
 
   const doUpload = async (file: File) => {
     setIsLoading(true)
@@ -59,12 +57,6 @@ const InputComfyImage: React.FC<InputComfyImageProps> = ({
       setIsLoading(false)
     }
   }
-
-  const viewImage = useCallback(async () => {
-    const res = await api().svcComfy.getView(valueToFileItem(internalValue))
-    const image: Uint8Array = res.result
-    return image
-  }, [internalValue])
 
   const handleLoadFromPhotoshop = async () => {
     try {
@@ -117,20 +109,20 @@ const InputComfyImage: React.FC<InputComfyImageProps> = ({
         return
       }
       try {
-        const bytes = await viewImage()
+        const res = await api().svcComfy.getView(valueToFileItem(internalValue))
         if (!active) return
-        const blob = new Blob([bytes as BlobPart], { type: 'image/*' })
+        const image: Uint8Array = res.result
+        const blob = new Blob([image as BlobPart], { type: 'image/*' })
         const url = URL.createObjectURL(blob)
         setPreviewUrl((prev) => {
           if (prev) URL.revokeObjectURL(prev)
           return url
         })
-      } catch {
-        // Image file doesn't exist anymore, clear the value
-        console.warn('[InputComfyImage] Failed to load image, clearing value:', internalValue)
+      } catch (error) {
+        // Preview failures should not erase the selected input value; the
+        // uploaded image may still be available once ComfyUI refreshes.
+        console.warn('[InputComfyImage] Failed to load image preview:', internalValue, error)
         if (active) {
-          setInternalValue('')
-          onChange('')
           setPreviewUrl((prev) => {
             if (prev) URL.revokeObjectURL(prev)
             return null
@@ -141,7 +133,7 @@ const InputComfyImage: React.FC<InputComfyImageProps> = ({
     return () => {
       active = false
     }
-  }, [internalValue, viewImage, onChange])
+  }, [internalValue])
 
   return (
     <BaseInputComfyImage

--- a/packages/app/src/renderer/src/components/inputs/InputComfyImage.tsx
+++ b/packages/app/src/renderer/src/components/inputs/InputComfyImage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { InputProps } from './InputProps'
 import { Box, IconButton, Typography, Button } from '@mui/material'
 import { UploadOutlined, PhotoLibraryOutlined } from '@mui/icons-material'
@@ -23,8 +23,29 @@ const InputComfyImage: React.FC<InputComfyImageProps> = ({
   const [internalValue, setInternalValue] = useState(value)
   const [isLoading, setIsLoading] = useState(false)
   const [previewUrl, setPreviewUrl] = useState<string | null>(null)
+  const previewUrlRef = useRef<string | null>(null)
   const { notifySuccess, notifyError } = useMessage()
   const { t } = useTranslation()
+
+  const updatePreviewUrl = useCallback((nextUrl: string | null) => {
+    setPreviewUrl((prev) => {
+      if (prev && prev !== nextUrl) {
+        URL.revokeObjectURL(prev)
+      }
+      previewUrlRef.current = nextUrl
+      return nextUrl
+    })
+  }, [])
+
+  useEffect(
+    () => () => {
+      if (previewUrlRef.current) {
+        URL.revokeObjectURL(previewUrlRef.current)
+        previewUrlRef.current = null
+      }
+    },
+    []
+  )
 
   // 同步外部 value 变化到 internalValue
   useEffect(() => {
@@ -92,20 +113,14 @@ const InputComfyImage: React.FC<InputComfyImageProps> = ({
   const handleClear = useCallback(() => {
     setInternalValue('')
     onChange('')
-    setPreviewUrl((prev) => {
-      if (prev) URL.revokeObjectURL(prev)
-      return null
-    })
-  }, [onChange])
+    updatePreviewUrl(null)
+  }, [onChange, updatePreviewUrl])
 
   useEffect(() => {
     let active = true
     ;(async () => {
       if (!internalValue) {
-        setPreviewUrl((prev) => {
-          if (prev) URL.revokeObjectURL(prev)
-          return null
-        })
+        updatePreviewUrl(null)
         return
       }
       try {
@@ -114,26 +129,20 @@ const InputComfyImage: React.FC<InputComfyImageProps> = ({
         const image: Uint8Array = res.result
         const blob = new Blob([image as BlobPart], { type: 'image/*' })
         const url = URL.createObjectURL(blob)
-        setPreviewUrl((prev) => {
-          if (prev) URL.revokeObjectURL(prev)
-          return url
-        })
+        updatePreviewUrl(url)
       } catch (error) {
         // Preview failures should not erase the selected input value; the
         // uploaded image may still be available once ComfyUI refreshes.
         console.warn('[InputComfyImage] Failed to load image preview:', internalValue, error)
         if (active) {
-          setPreviewUrl((prev) => {
-            if (prev) URL.revokeObjectURL(prev)
-            return null
-          })
+          updatePreviewUrl(null)
         }
       }
     })()
     return () => {
       active = false
     }
-  }, [internalValue])
+  }, [internalValue, updatePreviewUrl])
 
   return (
     <BaseInputComfyImage

--- a/packages/app/src/renderer/src/components/inputs/InputComfyImageMask.tsx
+++ b/packages/app/src/renderer/src/components/inputs/InputComfyImageMask.tsx
@@ -56,10 +56,8 @@ const InputComfyImageMask: React.FC<InputComfyImageMaskProps> = ({
 
   // 同步外部 value 变化到 internalValue
   useEffect(() => {
-    if (value !== internalValue) {
-      setInternalValue(value)
-    }
-  }, [value, internalValue])
+    setInternalValue((prev) => (prev === value ? prev : value))
+  }, [value])
 
   const { notifyError } = useMessage()
   const { t } = useTranslation()
@@ -88,12 +86,6 @@ const InputComfyImageMask: React.FC<InputComfyImageMaskProps> = ({
     }
   }
 
-  const viewImage = useCallback(async () => {
-    const res = await api().svcComfy.getView(valueToFileItem(internalValue))
-    const image: Uint8Array = res.result
-    return image
-  }, [internalValue])
-
   const handleClear = useCallback(() => {
     setModalOpen(false)
     setInternalValue('')
@@ -115,22 +107,29 @@ const InputComfyImageMask: React.FC<InputComfyImageMaskProps> = ({
         return
       }
       try {
-        const bytes = await viewImage()
+        const res = await api().svcComfy.getView(valueToFileItem(internalValue))
         if (!active) return
-        const blob = new Blob([bytes as BlobPart], { type: 'image/*' })
+        const image: Uint8Array = res.result
+        const blob = new Blob([image as BlobPart], { type: 'image/*' })
         const url = URL.createObjectURL(blob)
         setPreviewUrl((prev) => {
           if (prev) URL.revokeObjectURL(prev)
           return url
         })
-      } catch {
-        // ignore preview errors
+      } catch (error) {
+        console.warn('[InputComfyImageMask] Failed to load image preview:', internalValue, error)
+        if (active) {
+          setPreviewUrl((prev) => {
+            if (prev) URL.revokeObjectURL(prev)
+            return null
+          })
+        }
       }
     })()
     return () => {
       active = false
     }
-  }, [internalValue, viewImage])
+  }, [internalValue])
 
   const doUploadMask = async (maskCanvas: HTMLCanvasElement) => {
     console.log('doUploadMask', maskCanvas)

--- a/packages/app/src/renderer/src/components/inputs/InputLoRAChain.test.tsx
+++ b/packages/app/src/renderer/src/components/inputs/InputLoRAChain.test.tsx
@@ -1,0 +1,260 @@
+import React from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import InputLoRAChain, { type LoRAConfig } from './InputLoRAChain'
+
+const comfyMocks = vi.hoisted(() => ({
+  listImages: vi.fn(),
+  viewImage: vi.fn()
+}))
+const objectUrlMocks = vi.hoisted(() => ({
+  bytesToObjectUrl: vi.fn()
+}))
+
+vi.mock('@renderer/utils/windowUtils', () => ({
+  api: () => ({
+    svcComfy: {},
+    svcPysssss: {}
+  })
+}))
+
+vi.mock('@renderer/utils/comfyUtils', () => ({
+  ComfyUtils: vi.fn().mockImplementation(() => ({
+    listImages: comfyMocks.listImages,
+    viewImage: comfyMocks.viewImage
+  }))
+}))
+
+vi.mock('@renderer/utils/fileUtils', () => ({
+  bytesToObjectUrl: objectUrlMocks.bytesToObjectUrl
+}))
+
+vi.mock('./InputSlider', () => ({
+  default: ({
+    value,
+    label,
+    onChange
+  }: {
+    value: number
+    label: string
+    onChange: (value: number) => void
+  }) => (
+    <input
+      aria-label={label}
+      value={value}
+      onChange={(event) => onChange(Number(event.currentTarget.value))}
+    />
+  )
+}))
+
+const createLora = (name = ''): LoRAConfig => ({
+  lora_name: name,
+  strength_model: 1,
+  strength_clip: 1,
+  trigger_words: ''
+})
+
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((innerResolve, innerReject) => {
+    resolve = innerResolve
+    reject = innerReject
+  })
+  return { promise, resolve, reject }
+}
+
+const renderControlled = ({
+  initialValue,
+  onLoraSelected
+}: {
+  initialValue: LoRAConfig[]
+  onLoraSelected?: (loraName: string, triggerWords?: string) => string | void | Promise<string | void>
+}) => {
+  const latest = { value: initialValue }
+  const onChange = vi.fn((nextValue: LoRAConfig[]) => {
+    latest.value = nextValue
+  })
+
+  const Harness = () => {
+    const [value, setValue] = React.useState(initialValue)
+    return (
+      <InputLoRAChain
+        label="LoRA"
+        value={value}
+        onChange={(nextValue) => {
+          onChange(nextValue)
+          setValue(nextValue)
+        }}
+        lora_options={['alpha.safetensors', 'beta.safetensors']}
+        onLoraSelected={onLoraSelected}
+      />
+    )
+  }
+
+  const view = render(<Harness />)
+  return { ...view, latest, onChange }
+}
+
+describe('InputLoRAChain', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    comfyMocks.listImages.mockReset()
+    comfyMocks.viewImage.mockReset()
+    objectUrlMocks.bytesToObjectUrl.mockReset()
+    Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({
+        width: 240,
+        height: 120,
+        top: 0,
+        left: 0,
+        right: 240,
+        bottom: 120,
+        x: 0,
+        y: 0,
+        toJSON: () => undefined
+      })
+    })
+  })
+
+  it('ignores stale LoRA preview responses and revokes stale object URLs', async () => {
+    const revokeObjectURL = vi.fn()
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: revokeObjectURL
+    })
+    comfyMocks.listImages.mockResolvedValue({
+      'alpha.safetensors': 'alpha.png',
+      'beta.safetensors': 'beta.png'
+    })
+    const alphaPreview = deferred<{ image: Uint8Array }>()
+    const betaPreview = deferred<{ image: Uint8Array }>()
+    comfyMocks.viewImage.mockImplementation(({ name }: { name: string }) => {
+      if (name === 'alpha.png') return alphaPreview.promise
+      if (name === 'beta.png') return betaPreview.promise
+      return Promise.reject(new Error(`unexpected image ${name}`))
+    })
+    objectUrlMocks.bytesToObjectUrl.mockImplementation((bytes: Uint8Array) => `blob:${bytes[0]}`)
+
+    const { rerender, unmount } = render(
+      <InputLoRAChain
+        label="LoRA"
+        value={[createLora('alpha.safetensors')]}
+        onChange={vi.fn()}
+        lora_options={['alpha.safetensors', 'beta.safetensors']}
+      />
+    )
+
+    await waitFor(() => {
+      expect(comfyMocks.viewImage).toHaveBeenCalledWith({ name: 'alpha.png' })
+    })
+
+    rerender(
+      <InputLoRAChain
+        label="LoRA"
+        value={[createLora('beta.safetensors')]}
+        onChange={vi.fn()}
+        lora_options={['alpha.safetensors', 'beta.safetensors']}
+      />
+    )
+
+    await waitFor(() => {
+      expect(comfyMocks.viewImage).toHaveBeenCalledWith({ name: 'beta.png' })
+    })
+
+    betaPreview.resolve({ image: new Uint8Array([2]) })
+    expect(await screen.findByRole('img', { name: 'beta.safetensors' })).toHaveAttribute(
+      'src',
+      'blob:2'
+    )
+
+    alphaPreview.resolve({ image: new Uint8Array([1]) })
+
+    await waitFor(() => {
+      expect(revokeObjectURL).toHaveBeenCalledWith('blob:1')
+    })
+    expect(screen.queryByRole('img', { name: 'alpha.safetensors' })).toBeNull()
+    expect(screen.getByRole('img', { name: 'beta.safetensors' })).toHaveAttribute('src', 'blob:2')
+
+    unmount()
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:2')
+  })
+
+  it('does not apply delayed trigger words after deleting the selected row', async () => {
+    comfyMocks.listImages.mockResolvedValue({})
+    const triggerWords = deferred<string>()
+    const onLoraSelected = vi.fn(() => triggerWords.promise)
+    const { latest } = renderControlled({
+      initialValue: [createLora('alpha.safetensors'), createLora('')],
+      onLoraSelected
+    })
+
+    const secondCombo = await screen.findByLabelText('Lora 1')
+    fireEvent.mouseDown(secondCombo)
+    fireEvent.change(secondCombo, { target: { value: 'beta.safetensors' } })
+    fireEvent.click(await screen.findByRole('option', { name: 'beta.safetensors' }))
+
+    await waitFor(() => {
+      expect(onLoraSelected).toHaveBeenCalledWith('beta.safetensors', '')
+      expect(latest.value[1].lora_name).toBe('beta.safetensors')
+    })
+
+    const secondDeleteButton = screen.getAllByTestId('DeleteIcon')[1].closest('button')
+    expect(secondDeleteButton).toBeTruthy()
+    fireEvent.click(secondDeleteButton as HTMLButtonElement)
+
+    await waitFor(() => {
+      expect(latest.value).toHaveLength(1)
+      expect(latest.value[0].lora_name).toBe('alpha.safetensors')
+    })
+
+    triggerWords.resolve('late trigger words')
+
+    await waitFor(() => {
+      expect(latest.value).toHaveLength(1)
+      expect(latest.value[0]).toMatchObject({
+        lora_name: 'alpha.safetensors',
+        trigger_words: ''
+      })
+    })
+  })
+
+  it('applies delayed trigger words to the same row after deleting a row before it', async () => {
+    comfyMocks.listImages.mockResolvedValue({})
+    const triggerWords = deferred<string>()
+    const onLoraSelected = vi.fn(() => triggerWords.promise)
+    const { latest } = renderControlled({
+      initialValue: [createLora('alpha.safetensors'), createLora('')],
+      onLoraSelected
+    })
+
+    const secondCombo = await screen.findByLabelText('Lora 1')
+    fireEvent.mouseDown(secondCombo)
+    fireEvent.change(secondCombo, { target: { value: 'beta.safetensors' } })
+    fireEvent.click(await screen.findByRole('option', { name: 'beta.safetensors' }))
+
+    await waitFor(() => {
+      expect(onLoraSelected).toHaveBeenCalledWith('beta.safetensors', '')
+      expect(latest.value[1].lora_name).toBe('beta.safetensors')
+    })
+
+    const firstDeleteButton = screen.getAllByTestId('DeleteIcon')[0].closest('button')
+    expect(firstDeleteButton).toBeTruthy()
+    fireEvent.click(firstDeleteButton as HTMLButtonElement)
+
+    await waitFor(() => {
+      expect(latest.value).toHaveLength(1)
+      expect(latest.value[0].lora_name).toBe('beta.safetensors')
+    })
+
+    triggerWords.resolve('late trigger words')
+
+    await waitFor(() => {
+      expect(latest.value[0]).toMatchObject({
+        lora_name: 'beta.safetensors',
+        trigger_words: 'late trigger words'
+      })
+    })
+  })
+})

--- a/packages/app/src/renderer/src/components/inputs/InputLoRAChain.test.tsx
+++ b/packages/app/src/renderer/src/components/inputs/InputLoRAChain.test.tsx
@@ -69,7 +69,10 @@ const renderControlled = ({
   onLoraSelected
 }: {
   initialValue: LoRAConfig[]
-  onLoraSelected?: (loraName: string, triggerWords?: string) => string | void | Promise<string | void>
+  onLoraSelected?: (
+    loraName: string,
+    triggerWords?: string
+  ) => string | void | Promise<string | void>
 }) => {
   const latest = { value: initialValue }
   const onChange = vi.fn((nextValue: LoRAConfig[]) => {

--- a/packages/app/src/renderer/src/components/inputs/InputLoRAChain.tsx
+++ b/packages/app/src/renderer/src/components/inputs/InputLoRAChain.tsx
@@ -37,8 +37,9 @@ export type LoRAConfig = {
 
 type InputLoraProps = {
   index: number
+  rowId: string
   currentLora: LoRAConfig
-  handleUpdate: (index: number, newValue: Partial<LoRAConfig>) => void
+  handleUpdateByRowId: (rowId: string, newValue: Partial<LoRAConfig>) => void
   loraOptions: string[]
   loraName2ImageName: Record<string, string>
   loraTriggerWordsByName: LoraTriggerWordsMap
@@ -56,8 +57,9 @@ type InputLoraProps = {
 
 const InputLora: React.FC<InputLoraProps> = ({
   index,
+  rowId,
   currentLora,
-  handleUpdate,
+  handleUpdateByRowId,
   loraOptions,
   loraName2ImageName,
   loraTriggerWordsByName,
@@ -71,24 +73,90 @@ const InputLora: React.FC<InputLoraProps> = ({
   const boxRef = useRef<HTMLDivElement>(null)
   const [gridTemplateColumns, setGridTemplateColumns] = useState<string>('1fr')
   const loraSelectionRequestRef = useRef(0)
+  const loraPreviewRequestRef = useRef(0)
+  const handleUpdateByRowIdRef = useRef(handleUpdateByRowId)
+  const currentLoraNameRef = useRef(currentLora.lora_name)
+  const imageObjUrlRef = useRef<string | null>(null)
 
   useEffect(() => {
+    handleUpdateByRowIdRef.current = handleUpdateByRowId
+  }, [handleUpdateByRowId])
+
+  useEffect(() => {
+    currentLoraNameRef.current = currentLora.lora_name
+  }, [currentLora.lora_name])
+
+  const updateImageObjUrl = useCallback((nextUrl: string | null) => {
+    setImageObjUrl((prev) => {
+      if (prev && prev !== nextUrl) {
+        URL.revokeObjectURL(prev)
+      }
+      imageObjUrlRef.current = nextUrl
+      return nextUrl
+    })
+  }, [])
+
+  useEffect(
+    () => () => {
+      loraSelectionRequestRef.current += 1
+      loraPreviewRequestRef.current += 1
+      if (imageObjUrlRef.current) {
+        URL.revokeObjectURL(imageObjUrlRef.current)
+        imageObjUrlRef.current = null
+      }
+    },
+    []
+  )
+
+  useEffect(() => {
+    const requestId = loraPreviewRequestRef.current + 1
+    loraPreviewRequestRef.current = requestId
+    let createdUrl: string | null = null
+
+    updateImageObjUrl(null)
+    setGridTemplateColumns(`1fr`)
+
+    const imageName = loraName2ImageName[currentLora.lora_name]
+    if (!imageName) {
+      return () => {
+        if (loraPreviewRequestRef.current === requestId) {
+          loraPreviewRequestRef.current += 1
+        }
+      }
+    }
+
     ;(async () => {
       try {
-        const imageName = loraName2ImageName[currentLora.lora_name]
-        if (imageName) {
-          const res = await comfyUtilsRef.current.viewImage({ name: imageName })
-          setImageObjUrl(bytesToObjectUrl(res.image, 'image/png'))
-          setGridTemplateColumns(`1fr 3fr`)
+        const res = await comfyUtilsRef.current.viewImage({ name: imageName })
+        createdUrl = bytesToObjectUrl(res.image, 'image/png')
+        if (loraPreviewRequestRef.current !== requestId) {
+          URL.revokeObjectURL(createdUrl)
+          createdUrl = null
           return
         }
+        updateImageObjUrl(createdUrl)
+        createdUrl = null
+        setGridTemplateColumns(`1fr 3fr`)
       } catch (error) {
+        if (loraPreviewRequestRef.current !== requestId) {
+          return
+        }
         console.info('failed to view image', currentLora.lora_name, error)
+        updateImageObjUrl(null)
+        setGridTemplateColumns(`1fr`)
       }
-      setImageObjUrl(null)
-      setGridTemplateColumns(`1fr`)
     })()
-  }, [currentLora.lora_name, loraName2ImageName, comfyUtilsRef])
+
+    return () => {
+      if (loraPreviewRequestRef.current === requestId) {
+        loraPreviewRequestRef.current += 1
+      }
+      if (createdUrl) {
+        URL.revokeObjectURL(createdUrl)
+        createdUrl = null
+      }
+    }
+  }, [currentLora.lora_name, loraName2ImageName, comfyUtilsRef, updateImageObjUrl])
 
   useLayoutEffect(() => {
     if (boxRef.current) {
@@ -110,7 +178,7 @@ const InputLora: React.FC<InputLoraProps> = ({
           loraSelectionRequestRef.current = requestId
           const nextLoraName = newValue || ''
           const nextTriggerWords = nextLoraName ? loraTriggerWordsByName[nextLoraName] || '' : ''
-          handleUpdate(index, {
+          handleUpdateByRowIdRef.current(rowId, {
             lora_name: nextLoraName,
             trigger_words: nextTriggerWords
           })
@@ -120,11 +188,15 @@ const InputLora: React.FC<InputLoraProps> = ({
           if (nextLoraName) {
             void Promise.resolve(onLoraSelected?.(nextLoraName, nextTriggerWords))
               .then((loadedTriggerWords) => {
-                if (!loadedTriggerWords || loraSelectionRequestRef.current !== requestId) {
+                if (
+                  !loadedTriggerWords ||
+                  loraSelectionRequestRef.current !== requestId ||
+                  currentLoraNameRef.current !== nextLoraName
+                ) {
                   return
                 }
                 handleTriggerWordsChange(nextLoraName, loadedTriggerWords)
-                handleUpdate(index, {
+                handleUpdateByRowIdRef.current(rowId, {
                   lora_name: nextLoraName,
                   trigger_words: loadedTriggerWords
                 })
@@ -152,21 +224,25 @@ const InputLora: React.FC<InputLoraProps> = ({
             overflow: 'auto'
           }
         }}
-        renderOption={(props, option) => (
-          <li
-            {...props}
-            style={{ whiteSpace: 'normal', wordBreak: 'break-word', padding: '8px 16px' }}
-          >
-            <Box sx={{ minWidth: 0 }}>
-              <Typography variant="body2">{option}</Typography>
-              {loraTriggerWordsByName[option] && (
-                <Typography variant="caption" color="text.secondary">
-                  {loraTriggerWordsByName[option]}
-                </Typography>
-              )}
-            </Box>
-          </li>
-        )}
+        renderOption={(props, option) => {
+          const { key, ...optionProps } = props
+          return (
+            <li
+              key={key}
+              {...optionProps}
+              style={{ whiteSpace: 'normal', wordBreak: 'break-word', padding: '8px 16px' }}
+            >
+              <Box sx={{ minWidth: 0 }}>
+                <Typography variant="body2">{option}</Typography>
+                {loraTriggerWordsByName[option] && (
+                  <Typography variant="caption" color="text.secondary">
+                    {loraTriggerWordsByName[option]}
+                  </Typography>
+                )}
+              </Box>
+            </li>
+          )
+        }}
         sx={{
           '& .MuiOutlinedInput-root': {
             backgroundColor: 'background.paper'
@@ -192,7 +268,7 @@ const InputLora: React.FC<InputLoraProps> = ({
             value={currentLora.strength_model}
             label={`Lora ${index} 模型强度`}
             onChange={(v) =>
-              handleUpdate(index, {
+              handleUpdateByRowIdRef.current(rowId, {
                 strength_model: v
               })
             }
@@ -205,7 +281,7 @@ const InputLora: React.FC<InputLoraProps> = ({
             value={currentLora.strength_clip}
             label={`Lora ${index} CLIP强度`}
             onChange={(v) =>
-              handleUpdate(index, {
+              handleUpdateByRowIdRef.current(rowId, {
                 strength_clip: v
               })
             }
@@ -223,7 +299,7 @@ const InputLora: React.FC<InputLoraProps> = ({
                 return
               }
               const nextTriggerWords = event.target.value
-              handleUpdate(index, { trigger_words: nextTriggerWords })
+              handleUpdateByRowIdRef.current(rowId, { trigger_words: nextTriggerWords })
               handleTriggerWordsChange(currentLora.lora_name, nextTriggerWords)
             }}
             onBlur={() => {
@@ -269,18 +345,49 @@ const InputLoRAChain: React.FC<InputLoRAChainProps> = ({
   const [loraTriggerWordsByName, setLoraTriggerWordsByName] = useState<LoraTriggerWordsMap>(() =>
     readLoraTriggerWordsMap()
   )
+  const rowIdsRef = useRef<string[]>([])
+  const nextRowIdRef = useRef(0)
+  const valueRef = useRef(value)
+  valueRef.current = value
 
-  const handleChange = (newValue: LoRAConfig[]) => {
-    onChange(newValue)
+  const createRowId = () => `lora-row-${nextRowIdRef.current++}`
+  while (rowIdsRef.current.length < value.length) {
+    rowIdsRef.current.push(createRowId())
   }
-  const handleUpdate = (index: number, newValue: Partial<LoRAConfig>) => {
-    handleChange(value.map((lora, i) => (i === index ? { ...lora, ...newValue } : lora)))
+  if (rowIdsRef.current.length > value.length) {
+    rowIdsRef.current = rowIdsRef.current.slice(0, value.length)
   }
+
+  const handleChange = useCallback(
+    (newValue: LoRAConfig[]) => {
+      valueRef.current = newValue
+      onChange(newValue)
+    },
+    [onChange]
+  )
+  const handleUpdateByRowId = useCallback(
+    (rowId: string, newValue: Partial<LoRAConfig>) => {
+      const rowIndex = rowIdsRef.current.indexOf(rowId)
+      if (rowIndex === -1) {
+        return
+      }
+      const currentValue = valueRef.current
+      if (!currentValue[rowIndex]) {
+        return
+      }
+      handleChange(
+        currentValue.map((lora, i) => (i === rowIndex ? { ...lora, ...newValue } : lora))
+      )
+    },
+    [handleChange]
+  )
   const handleDelete = (index: number) => {
-    handleChange(value.filter((lora, i) => i !== index))
+    rowIdsRef.current.splice(index, 1)
+    handleChange(valueRef.current.filter((lora, i) => i !== index))
   }
   const handleAdd = () => {
-    handleChange([...value, { ...defaultLoraConfig }])
+    rowIdsRef.current.push(createRowId())
+    handleChange([...valueRef.current, { ...defaultLoraConfig }])
   }
   const handleTriggerWordsChange = useCallback((loraName: string, triggerWords: string) => {
     setLoraTriggerWordsByName((prev) => {
@@ -319,12 +426,13 @@ const InputLoRAChain: React.FC<InputLoRAChainProps> = ({
       <Stack sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
         {value &&
           value.map((currentLora, index) => (
-            <Card key={index}>
+            <Card key={rowIdsRef.current[index] ?? index}>
               <CardContent>
                 <InputLora
                   index={index}
+                  rowId={rowIdsRef.current[index] ?? `${index}`}
                   currentLora={currentLora}
-                  handleUpdate={handleUpdate}
+                  handleUpdateByRowId={handleUpdateByRowId}
                   loraOptions={lora_options}
                   loraName2ImageName={loraName2ImageName}
                   loraTriggerWordsByName={loraTriggerWordsByName}

--- a/packages/app/src/renderer/src/components/inputs/InputLoRAChain.tsx
+++ b/packages/app/src/renderer/src/components/inputs/InputLoRAChain.tsx
@@ -224,25 +224,22 @@ const InputLora: React.FC<InputLoraProps> = ({
             overflow: 'auto'
           }
         }}
-        renderOption={(props, option) => {
-          const { key, ...optionProps } = props
-          return (
-            <li
-              key={key}
-              {...optionProps}
-              style={{ whiteSpace: 'normal', wordBreak: 'break-word', padding: '8px 16px' }}
-            >
-              <Box sx={{ minWidth: 0 }}>
-                <Typography variant="body2">{option}</Typography>
-                {loraTriggerWordsByName[option] && (
-                  <Typography variant="caption" color="text.secondary">
-                    {loraTriggerWordsByName[option]}
-                  </Typography>
-                )}
-              </Box>
-            </li>
-          )
-        }}
+        renderOption={(props, option) => (
+          <li
+            {...props}
+            key={option}
+            style={{ whiteSpace: 'normal', wordBreak: 'break-word', padding: '8px 16px' }}
+          >
+            <Box sx={{ minWidth: 0 }}>
+              <Typography variant="body2">{option}</Typography>
+              {loraTriggerWordsByName[option] && (
+                <Typography variant="caption" color="text.secondary">
+                  {loraTriggerWordsByName[option]}
+                </Typography>
+              )}
+            </Box>
+          </li>
+        )}
         sx={{
           '& .MuiOutlinedInput-root': {
             backgroundColor: 'background.paper'

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/useCanvasViewportPlacement.test.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/useCanvasViewportPlacement.test.tsx
@@ -5,18 +5,21 @@ import { useCanvasViewportPlacement } from './useCanvasViewportPlacement'
 describe('useCanvasViewportPlacement', () => {
   it('uses the live stage transform refs when resolving drop points at tiny zoom', () => {
     const canvasContainer = document.createElement('div')
-    canvasContainer.getBoundingClientRect = () =>
-      ({
-        left: 40,
-        top: 80,
-        right: 840,
-        bottom: 680,
-        width: 800,
-        height: 600,
-        x: 40,
-        y: 80,
-        toJSON: () => ({})
-      }) as DOMRect
+    Object.defineProperty(canvasContainer, 'getBoundingClientRect', {
+      configurable: true,
+      value: () =>
+        ({
+          left: 40,
+          top: 80,
+          right: 840,
+          bottom: 680,
+          width: 800,
+          height: 600,
+          x: 40,
+          y: 80,
+          toJSON: () => ({})
+        }) as DOMRect
+    })
 
     const { result } = renderHook(() =>
       useCanvasViewportPlacement({

--- a/packages/app/src/renderer/src/pages/QuickAppPage/QAppExecutePanel/QAppInputPanel.test.tsx
+++ b/packages/app/src/renderer/src/pages/QuickAppPage/QAppExecutePanel/QAppInputPanel.test.tsx
@@ -17,13 +17,14 @@ vi.mock('@renderer/hooks/useMessage', () => ({
   })
 }))
 
-vi.mock('@renderer/store/hooks/comfyStatus', () => ({
-  useComfyStatus: () => ({
-    state: {
-      isConnected: true,
-      objectInfos: {}
-    }
-  })
+vi.mock('@renderer/store', () => ({
+  useAppSelector: (selector: (state: unknown) => unknown) =>
+    selector({
+      comfyStatus: {
+        isConnected: true,
+        objectInfos: {}
+      }
+    })
 }))
 
 vi.mock('@renderer/hooks/useConfig', () => ({

--- a/packages/app/src/renderer/src/pages/QuickAppPage/QAppExecutePanel/QAppInputPanel.tsx
+++ b/packages/app/src/renderer/src/pages/QuickAppPage/QAppExecutePanel/QAppInputPanel.tsx
@@ -1,8 +1,9 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useEffect, useMemo } from 'react'
 import { PanelProps } from './PanelProps'
 import { useMessage } from '@renderer/hooks/useMessage'
 import buildQApp from './buildQApp'
-import { useComfyStatus } from '@renderer/store/hooks/comfyStatus'
+import { useAppSelector } from '@renderer/store'
+import { shallowEqual } from 'react-redux'
 import { useConfig } from '@renderer/hooks/useConfig'
 import { useQAppContext } from '../components/QAppContext'
 import { getQAppSessionKey } from '../utils/qAppSessionIdentity'
@@ -27,29 +28,33 @@ const QAppPanel: React.FC<QAppPanelProps> = ({ fallback, isDesignMode }) => {
     ? getQAppSessionKey({ qAppKey: currentQAppKey })
     : config.client_id
 
-  const [Panel, setPanel] = useState<React.FC<PanelProps> | null>(null)
-
-  // QuickApp 全局状态
-  const {
-    state: { isConnected, objectInfos }
-  } = useComfyStatus()
-
-  const buildQAppInputPanel = useCallback(() => {
+  const panelBuild = useMemo(() => {
     if (!qAppCfg || !workflow) {
-      return
+      return { Panel: null, error: '' }
     }
+
     try {
-      const NewPanel = buildQApp(qAppCfg, workflow)
-      setPanel(() => NewPanel)
+      return { Panel: buildQApp(qAppCfg, workflow), error: '' }
     } catch (error) {
-      notifyError(`构建 QApp 输入面板失败: ${error}`)
-      setPanel(null)
+      return { Panel: null, error: `构建 QApp 输入面板失败: ${error}` }
     }
-  }, [notifyError, qAppCfg, workflow])
+  }, [qAppCfg, workflow])
+  const Panel = panelBuild.Panel
 
   useEffect(() => {
-    buildQAppInputPanel()
-  }, [buildQAppInputPanel])
+    if (panelBuild.error) {
+      notifyError(panelBuild.error)
+    }
+  }, [notifyError, panelBuild.error])
+
+  // QuickApp 全局状态：只订阅输入面板实际需要的字段，避免结果/队列状态更新时重建输入区。
+  const { isConnected, objectInfos } = useAppSelector(
+    (state) => ({
+      isConnected: state.comfyStatus.isConnected,
+      objectInfos: state.comfyStatus.objectInfos
+    }),
+    shallowEqual
+  )
 
   const panelProps: PanelProps = {
     objectInfos,

--- a/packages/app/src/renderer/src/pages/QuickAppPage/QAppExecutePanel/buildQApp.tsx
+++ b/packages/app/src/renderer/src/pages/QuickAppPage/QAppExecutePanel/buildQApp.tsx
@@ -96,32 +96,44 @@ const buildQApp = (cfg: QAppCfg, workflowTemplate: Workflow): React.FC<PanelProp
       return buildComfyOrgExtraData(comfyOrgApiKey)
     }, [comfyOrgApiKey, requiresComfyOrgAuth])
 
+    const validateRef = useRef(validate)
+    const buildWorkflowRef = useRef(buildWorkflow)
+    const buildSubmitExtraDataRef = useRef(buildSubmitExtraData)
+    validateRef.current = validate
+    buildWorkflowRef.current = buildWorkflow
+    buildSubmitExtraDataRef.current = buildSubmitExtraData
+
+    const stableValidate = useCallback(() => validateRef.current(), [])
+    const stableBuildWorkflow = useCallback(() => buildWorkflowRef.current(), [])
+    const stableBuildSubmitExtraData = useCallback(() => buildSubmitExtraDataRef.current(), [])
+
     useEffect(() => {
-      setValidate(validate)
-      setBuildWorkflow(buildWorkflow)
-      setBuildSubmitExtraData(buildSubmitExtraData)
-      setSubmitClientId(clientId)
-      setSubmitSessionKey(submitSessionKey)
+      setValidate(stableValidate)
+      setBuildWorkflow(stableBuildWorkflow)
+      setBuildSubmitExtraData(stableBuildSubmitExtraData)
       return () => {
         setValidate(undefined)
         setBuildWorkflow(undefined)
         setBuildSubmitExtraData(undefined)
-        setSubmitClientId(undefined)
-        setSubmitSessionKey(undefined)
       }
     }, [
-      buildSubmitExtraData,
-      buildWorkflow,
-      clientId,
-      currentQAppKey,
       setBuildSubmitExtraData,
       setBuildWorkflow,
-      setSubmitClientId,
-      setSubmitSessionKey,
       setValidate,
-      submitSessionKey,
-      validate
+      stableBuildSubmitExtraData,
+      stableBuildWorkflow,
+      stableValidate
     ])
+
+    useEffect(() => {
+      setSubmitClientId(clientId)
+      return () => setSubmitClientId(undefined)
+    }, [clientId, setSubmitClientId])
+
+    useEffect(() => {
+      setSubmitSessionKey(submitSessionKey)
+      return () => setSubmitSessionKey(undefined)
+    }, [setSubmitSessionKey, submitSessionKey])
 
     return (
       <Stack

--- a/packages/app/src/renderer/src/pages/QuickAppPage/ResultList/ResultList.tsx
+++ b/packages/app/src/renderer/src/pages/QuickAppPage/ResultList/ResultList.tsx
@@ -185,7 +185,7 @@ export default function ResultList({}: ResultListProps) {
                   typeof result.type
                 >
                 return (
-                  <Box key={index} sx={{ width: '100%', minWidth: 0 }}>
+                  <Box key={result.id} sx={{ width: '100%', minWidth: 0 }}>
                     <ResultCard
                       result={result}
                       index={index}
@@ -209,7 +209,7 @@ export default function ResultList({}: ResultListProps) {
                 >
                 return (
                   <ResultCard
-                    key={index}
+                    key={result.id}
                     result={result}
                     index={index}
                     config={config}

--- a/packages/app/src/renderer/src/pages/QuickAppPage/ResultList/resultTransformers/transformImage.ts
+++ b/packages/app/src/renderer/src/pages/QuickAppPage/ResultList/resultTransformers/transformImage.ts
@@ -1,7 +1,7 @@
 import { api } from '@renderer/utils/windowUtils'
 import { ResultTransformer } from './types'
 import { guessMimeTypeFromFileName } from '@renderer/utils/fileDisplay'
-import { ResultItem } from '@shared/qApp/resultTypes'
+import { ResultItemImage } from '@shared/qApp/resultTypes'
 import { collectImageFiles } from './mediaOutputs'
 import { readCanvasImageBlobMetadata } from '@renderer/pages/ProjectCanvasPage/canvasAssetIntakeHelpers'
 
@@ -9,28 +9,33 @@ const transformImage: ResultTransformer<'image'> = async (promptId, outputs, wor
   const imageResults = await Promise.all(
     Object.values(outputs)
       .flatMap((output) => collectImageFiles(output))
-      .map(async (item) => {
-        const bytes = await api()
-          .svcComfy.getView(item)
-          .then((res) => res.result)
-        const blob = new Blob([bytes as BlobPart], {
-          type: guessMimeTypeFromFileName(item.filename, 'image/png')
-        })
-        const objectUrl = URL.createObjectURL(blob)
-        const metadata = await readCanvasImageBlobMetadata(blob)
+      .map(async (item): Promise<ResultItemImage | null> => {
+        try {
+          const bytes = await api()
+            .svcComfy.getView(item)
+            .then((res) => res.result)
+          const blob = new Blob([bytes as BlobPart], {
+            type: guessMimeTypeFromFileName(item.filename, 'image/png')
+          })
+          const objectUrl = URL.createObjectURL(blob)
+          const metadata = await readCanvasImageBlobMetadata(blob)
 
-        return {
-          id: crypto.randomUUID(),
-          type: 'image',
-          objectUrl,
-          sourceBlob: blob,
-          fileItem: item,
-          promptId: promptId,
-          ...(metadata ? { sourceWidth: metadata.width, sourceHeight: metadata.height } : {})
-        } satisfies ResultItem
+          return {
+            id: crypto.randomUUID(),
+            type: 'image',
+            objectUrl,
+            sourceBlob: blob,
+            fileItem: item,
+            promptId: promptId,
+            ...(metadata ? { sourceWidth: metadata.width, sourceHeight: metadata.height } : {})
+          } satisfies ResultItemImage
+        } catch (error) {
+          console.warn('[transformImage] failed to load image result:', item, error)
+          return null
+        }
       })
   )
-  return imageResults
+  return imageResults.filter((result): result is ResultItemImage => result !== null)
 }
 
 export default transformImage

--- a/packages/app/src/renderer/src/pages/QuickAppPage/ResultList/resultTransformers/transformVideo.ts
+++ b/packages/app/src/renderer/src/pages/QuickAppPage/ResultList/resultTransformers/transformVideo.ts
@@ -2,30 +2,35 @@ import { api } from '@renderer/utils/windowUtils'
 import { bytesToObjectUrl } from '@renderer/utils/fileUtils'
 import { guessMimeTypeFromFileName } from '@renderer/utils/fileDisplay'
 import { ResultTransformer } from './types'
-import { ResultItem } from '@shared/qApp/resultTypes'
+import { ResultItemVideo } from '@shared/qApp/resultTypes'
 import { collectVideoFiles } from './mediaOutputs'
 
 const transformVideo: ResultTransformer<'video'> = async (promptId, outputs) => {
   const videoResults = await Promise.all(
     Object.values(outputs)
       .flatMap((output) => collectVideoFiles(output))
-      .map(async (item) => {
-        const bytes = await api()
-          .svcComfy.getView(item)
-          .then((res) => res.result)
-        const mimeType = guessMimeTypeFromFileName(item.filename, 'video/mp4')
+      .map(async (item): Promise<ResultItemVideo | null> => {
+        try {
+          const bytes = await api()
+            .svcComfy.getView(item)
+            .then((res) => res.result)
+          const mimeType = guessMimeTypeFromFileName(item.filename, 'video/mp4')
 
-        return {
-          id: crypto.randomUUID(),
-          type: 'video',
-          objectUrl: bytesToObjectUrl(bytes, mimeType),
-          fileItem: item,
-          promptId
-        } satisfies ResultItem
+          return {
+            id: crypto.randomUUID(),
+            type: 'video',
+            objectUrl: bytesToObjectUrl(bytes, mimeType),
+            fileItem: item,
+            promptId
+          } satisfies ResultItemVideo
+        } catch (error) {
+          console.warn('[transformVideo] failed to load video result:', item, error)
+          return null
+        }
       })
   )
 
-  return videoResults
+  return videoResults.filter((result): result is ResultItemVideo => result !== null)
 }
 
 export default transformVideo


### PR DESCRIPTION
## Summary
- avoid QuickApp input panel rebuild loops by deriving the generated panel with memoized inputs
- register QApp submit callbacks through stable wrappers to prevent context update cycles
- reduce ComfyUI polling churn by dispatching object info/connectivity updates only when values change
- keep uploaded image/mask values when preview loading temporarily fails
- make image/video result transformation tolerant of individual media load failures
- use stable result ids as React keys

## Verification
- npm run typecheck:web
- git diff --check