### PR TITLE
Constrain embedded Python numpy for release builds

### DIFF
--- a/scripts/prepare-embedded-python.mjs
+++ b/scripts/prepare-embedded-python.mjs
@@ -217,6 +217,7 @@ function writeConstraints() {
       `transformers==${transformersVersion}`,
       `huggingface-hub==${huggingfaceHubVersion}`,
       `decorator==${decoratorVersion}`,
+      'numpy<2.5',
       ''
     ].join('\n')
   )


### PR DESCRIPTION
## Summary
- Adds `numpy<2.5` to the embedded Python constraints file generated during release packaging.
- Prevents custom node requirements from upgrading numpy to 2.5.0, which conflicts with numba's `<2.5` requirement.

## Root cause
The Windows embedded release build installs custom node requirements after the base runtime. `ComfyUI-SeedVR2_VideoUpscaler` declares unbounded `numpy`, so pip upgraded numpy to 2.5.0. The final `pip check` then failed because `numba 0.65.1` requires `numpy<2.5`.

## Checks
- `git diff --check`
- `npm run check:text-encoding`