### PR TITLE
fix(llm): respect configured OpenAI endpoint

### DIFF
--- a/packages/app/src/renderer/src/pages/QuickAppPage/QAppExecutePanel/qAppExecuteInputs/api/LLM.ts
+++ b/packages/app/src/renderer/src/pages/QuickAppPage/QAppExecutePanel/qAppExecuteInputs/api/LLM.ts
@@ -15,7 +15,6 @@ import {
   ClaudeAPICli as SharedClaudeAPICli,
   OllamaAPICli as SharedOllamaAPICli,
   convertImageToBase64,
-  normalizeOpenAIBaseUrl,
   normalizeGeminiModelName,
   normalizeGeminiBaseUrl,
   normalizeClaudeBaseUrl,
@@ -91,8 +90,7 @@ async function compressImage(
 export class OpenAIAPICli extends SharedOpenAIAPICli implements LLMCliWithPrompt {
   async generatePrompt(params: GeneratePromptParams): Promise<string> {
     const { prompt, systemPrompt, imageObjUrl } = params
-    const base = normalizeOpenAIBaseUrl(this.baseUrl)
-    const endpoint = `${base}/chat/completions`
+    const endpoint = this.baseUrl.trim().replace(/\/$/, '')
 
     type Role = 'system' | 'user' | 'assistant'
     type TextMessage = { role: Role; content: string }

--- a/packages/app/src/shared/llm/clients.test.ts
+++ b/packages/app/src/shared/llm/clients.test.ts
@@ -61,6 +61,30 @@ describe('shared llm endpoint normalization', () => {
     )
   })
 
+  it('uses the configured OpenAI-compatible endpoint without appending chat completions', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ choices: [{ message: { content: 'ok' } }] })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const client = new OpenAIAPICli(
+      'sk-test',
+      'https://codexapis.com/v1/images/generations',
+      'gpt-image-2'
+    )
+
+    await expect(
+      client.chat({ messages: [{ role: 'user', content: 'draw an image' }] })
+    ).resolves.toMatchObject({
+      content: 'ok'
+    })
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://codexapis.com/v1/images/generations',
+      expect.objectContaining({ method: 'POST' })
+    )
+  })
+
   it('forces the OpenAI image generation tool for image profiles', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/packages/app/src/shared/llm/clients.ts
+++ b/packages/app/src/shared/llm/clients.ts
@@ -284,7 +284,7 @@ export class OpenAIAPICli implements LLMCli {
       return this.chatViaResponsesApi(params, base)
     }
 
-    return this.chatViaChatCompletions(params, base)
+    return this.chatViaChatCompletions(params, this.baseUrl.trim().replace(/\/$/, ''))
   }
 
   private async chatViaResponsesApi(params: LLMChatParams, base: string): Promise<LLMChatResult> {
@@ -397,7 +397,7 @@ export class OpenAIAPICli implements LLMCli {
     base: string
   ): Promise<LLMChatResult> {
     const { messages, systemPrompt, signal } = params
-    const endpoint = `${base}/chat/completions`
+    const endpoint = base
 
     type Role = 'system' | 'user' | 'assistant'
     type TextMessage = { role: Role; content: string }
@@ -898,10 +898,15 @@ export class OpencodeZenAPICli implements LLMCli {
         }).chat(params)
       case 'openai-completions':
       default:
-        return new OpenAIAPICli(this.apiKey, baseUrl, modelName, {
-          apiMode: 'chat-completions',
-          fetchImpl: this.options?.fetchImpl
-        }).chat(params)
+        return new OpenAIAPICli(
+          this.apiKey,
+          `${baseUrl.replace(/\/$/, '')}/chat/completions`,
+          modelName,
+          {
+            apiMode: 'chat-completions',
+            fetchImpl: this.options?.fetchImpl
+          }
+        ).chat(params)
     }
   }
 }


### PR DESCRIPTION
## Summary
- Stop appending /chat/completions to configured OpenAI-compatible endpoints.
- Keep OpenCode Zen completions routing on its explicit chat endpoint.
- Add regression coverage for directly configured image generation endpoints.

## Tests
- npm run test:node -- packages/app/src/shared/llm/clients.test.ts
- npm run typecheck:node
- npm run typecheck:web