### PR TITLE
fix: restore Codex model discovery and settings persistence

### DIFF
--- a/packages/app/src/main/config/config.test.ts
+++ b/packages/app/src/main/config/config.test.ts
@@ -166,7 +166,6 @@ describe('config', () => {
     const configModule = await loadConfigModule()
     await configModule.initConfig()
 
-    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1234567890)
     const writeFileSpy = vi.spyOn(fs, 'writeFile')
     const renameSpy = vi.spyOn(fs, 'rename')
 
@@ -175,21 +174,106 @@ describe('config', () => {
         use_remote_llm: !DEFAULT_CONFIG.use_remote_llm
       })
 
-      const tempPath = `${configPath}.1234567890.tmp`
       expect(writeFileSpy).toHaveBeenCalledTimes(1)
       expect(writeFileSpy).toHaveBeenCalledWith(
-        tempPath,
+        expect.stringMatching(/^.*config\.json\.[0-9a-f-]+\.tmp$/),
         expect.stringContaining('"use_remote_llm"'),
         'utf-8'
       )
       expect(renameSpy).toHaveBeenCalledTimes(1)
+      const tempPath = writeFileSpy.mock.calls[0][0]
       expect(renameSpy).toHaveBeenCalledWith(tempPath, configPath)
 
       const savedConfig = JSON.parse(await fs.readFile(configPath, 'utf8'))
       expect(savedConfig.use_remote_llm).toBe(!DEFAULT_CONFIG.use_remote_llm)
     } finally {
-      nowSpy.mockRestore()
       writeFileSpy.mockRestore()
+      renameSpy.mockRestore()
+    }
+  })
+
+  it('serializes concurrent saves and merges them in call order', async () => {
+    const configModule = await loadConfigModule()
+    await configModule.initConfig()
+
+    const originalRename = fs.rename.bind(fs)
+    const renameGate = Promise.withResolvers<void>()
+    let firstRename = true
+    const renameSpy = vi.spyOn(fs, 'rename').mockImplementation(async (oldPath, newPath) => {
+      if (firstRename) {
+        firstRename = false
+        await renameGate.promise
+      }
+      await originalRename(oldPath, newPath)
+    })
+
+    try {
+      const firstSave = configModule.saveConfig({
+        remote_llm_server_config: { server_origin: 'https://first.example' }
+      })
+      const secondSave = configModule.saveConfig({
+        remote_llm_server_config: { access_token: 'second-token' }
+      })
+      const thirdSave = configModule.saveConfig({
+        remote_llm_server_config: { server_origin: 'https://latest.example' }
+      })
+
+      await vi.waitFor(() => expect(renameSpy).toHaveBeenCalledTimes(1))
+      expect(configModule.getConfig().remote_llm_server_config).toEqual(
+        DEFAULT_CONFIG.remote_llm_server_config
+      )
+
+      renameGate.resolve()
+      await Promise.all([firstSave, secondSave, thirdSave])
+
+      const expectedRemoteConfig = {
+        server_origin: 'https://latest.example',
+        access_token: 'second-token'
+      }
+      expect(configModule.getConfig().remote_llm_server_config).toEqual(expectedRemoteConfig)
+      expect(renameSpy).toHaveBeenCalledTimes(3)
+      expect(new Set(renameSpy.mock.calls.map(([tempPath]) => tempPath)).size).toBe(3)
+      const savedConfig = JSON.parse(await fs.readFile(path.join(tempDir, 'config.json'), 'utf8'))
+      expect(savedConfig.remote_llm_server_config).toEqual(expectedRemoteConfig)
+    } finally {
+      renameGate.resolve()
+      renameSpy.mockRestore()
+    }
+  })
+
+  it('continues processing queued saves after a save fails', async () => {
+    const configModule = await loadConfigModule()
+    await configModule.initConfig()
+
+    const originalRename = fs.rename.bind(fs)
+    let shouldFail = true
+    const renameSpy = vi.spyOn(fs, 'rename').mockImplementation(async (oldPath, newPath) => {
+      if (shouldFail) {
+        shouldFail = false
+        throw new Error('simulated rename failure')
+      }
+      await originalRename(oldPath, newPath)
+    })
+
+    try {
+      const failedSave = configModule.saveConfig({
+        remote_llm_server_config: { server_origin: 'https://failed.example' }
+      })
+      const nextSave = configModule.saveConfig({
+        remote_llm_server_config: { access_token: 'survived-token' }
+      })
+
+      await expect(failedSave).rejects.toThrow('simulated rename failure')
+      await expect(nextSave).resolves.toBeUndefined()
+
+      const expectedRemoteConfig = {
+        ...DEFAULT_CONFIG.remote_llm_server_config,
+        access_token: 'survived-token'
+      }
+      expect(configModule.getConfig().remote_llm_server_config).toEqual(expectedRemoteConfig)
+      const savedConfig = JSON.parse(await fs.readFile(path.join(tempDir, 'config.json'), 'utf8'))
+      expect(savedConfig.remote_llm_server_config).toEqual(expectedRemoteConfig)
+    } finally {
       renameSpy.mockRestore()
     }
   })

--- a/packages/app/src/main/config/config.ts
+++ b/packages/app/src/main/config/config.ts
@@ -1,5 +1,6 @@
 import fs from 'fs/promises'
 import path from 'path'
+import { randomUUID } from 'crypto'
 import { Config, DEFAULT_CONFIG } from '@shared/config/config'
 import { deepMerge, DeepPartial } from '@shared/utils/utilTypes'
 import { getBuildEnv } from './buildEnv'
@@ -18,7 +19,7 @@ function sanitizeConfigText(text: string): string {
 }
 
 async function writeConfigAtomically(configPath: string, contents: string) {
-  const tempPath = `${configPath}.${Date.now()}.tmp`
+  const tempPath = `${configPath}.${randomUUID()}.tmp`
   await fs.writeFile(tempPath, contents, 'utf-8')
   await fs.rename(tempPath, configPath)
 }
@@ -29,6 +30,7 @@ function getConfigPath() {
 }
 
 let configCache: Config | null = null
+let saveQueue: Promise<void> = Promise.resolve()
 const eventCenter: EventCenter<Config> = new EventCenter<Config>()
 
 async function loadConfigFromFile(): Promise<Config> {
@@ -83,14 +85,19 @@ export function getConfig(): Config {
   return configCache
 }
 
-export async function saveConfig(config: DeepPartial<Config>) {
-  const configPath = getConfigPath()
-  const oldConfig = getConfig()
+export function saveConfig(config: DeepPartial<Config>): Promise<void> {
+  const save = saveQueue.then(async () => {
+    const configPath = getConfigPath()
+    const newConfig = deepMerge(getConfig() as never, config as never) as Config
 
-  const newConfig = deepMerge(oldConfig as never, config as never) as Config
-  await writeConfigAtomically(configPath, serializeConfig(newConfig))
-  configCache = newConfig
-  await eventCenter.emit(newConfig)
+    await writeConfigAtomically(configPath, serializeConfig(newConfig))
+    configCache = newConfig
+    await eventCenter.emit(newConfig)
+  })
+
+  // Keep the internal queue fulfilled so one rejected save cannot block later calls.
+  saveQueue = save.catch(() => undefined)
+  return save
 }
 
 export function listenConfig(listener: EventListener<Config>) {

--- a/packages/app/src/renderer/src/pages/ChatPage/hooks/useChatProfiles.test.tsx
+++ b/packages/app/src/renderer/src/pages/ChatPage/hooks/useChatProfiles.test.tsx
@@ -1,0 +1,125 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { rendererHostExtensionApiV1 } from '@renderer/extensions/generatedRegistry'
+import { DEFAULT_CONFIG, type Config, type LLMAPIProfile } from '@shared/config/config'
+import { useChatProfiles } from './useChatProfiles'
+
+const buildProfile = (overrides: Partial<LLMAPIProfile> = {}): LLMAPIProfile => ({
+  id: 'profile-1',
+  model_name: 'Original Model',
+  base_url: 'https://example.test/v1',
+  api_key: 'test-token',
+  ...overrides
+})
+
+const buildConfig = (profiles: LLMAPIProfile[], useRemoteLlm = false): Config => ({
+  ...DEFAULT_CONFIG,
+  use_remote_llm: useRemoteLlm,
+  llm_config: {
+    ...DEFAULT_CONFIG.llm_config,
+    api_profiles: profiles
+  }
+})
+
+describe('useChatProfiles', () => {
+  afterEach(() => {
+    delete rendererHostExtensionApiV1.chat
+    vi.unstubAllGlobals()
+  })
+
+  it('discovers and expands models for a runnable Codex OAuth profile', async () => {
+    const profile = buildProfile({
+      id: 'codex-oauth',
+      model_name: 'Codex OAuth',
+      auth_mode: 'codex_oauth',
+      call_type: 'codex'
+    })
+    const discoverModelNames = vi.fn().mockResolvedValue(['gpt-5.2', 'gpt-5.1-codex'])
+    rendererHostExtensionApiV1.chat = { discoverModelNames }
+
+    const config = buildConfig([profile])
+    const { result } = renderHook(() => useChatProfiles(config, true))
+
+    await waitFor(() => expect(result.current.availableProfiles).toHaveLength(2))
+    expect(discoverModelNames).toHaveBeenCalledOnce()
+    expect(discoverModelNames).toHaveBeenCalledWith(profile)
+    expect(result.current.availableProfiles).toEqual([
+      {
+        ...profile,
+        id: 'codex-oauth::codex-model::gpt-5.2',
+        model_name: 'gpt-5.2'
+      },
+      {
+        ...profile,
+        id: 'codex-oauth::codex-model::gpt-5.1-codex',
+        model_name: 'gpt-5.1-codex'
+      }
+    ])
+  })
+
+  it('discovers and expands models for a runnable CLIProxyAPI profile', async () => {
+    const profile = buildProfile({
+      id: 'cliproxyapi',
+      model_name: 'CLIProxyAPI',
+      call_type: 'cliproxyapi'
+    })
+    const discoverModelNames = vi.fn().mockResolvedValue(['claude-sonnet-4-5', 'gemini-2.5-pro'])
+    rendererHostExtensionApiV1.chat = { discoverModelNames }
+
+    const config = buildConfig([profile])
+    const { result } = renderHook(() => useChatProfiles(config, true))
+
+    await waitFor(() => expect(result.current.availableProfiles).toHaveLength(2))
+    expect(discoverModelNames).toHaveBeenCalledOnce()
+    expect(discoverModelNames).toHaveBeenCalledWith(profile)
+    expect(result.current.availableProfiles).toEqual([
+      {
+        ...profile,
+        id: 'cliproxyapi::codex-model::claude-sonnet-4-5',
+        model_name: 'claude-sonnet-4-5'
+      },
+      {
+        ...profile,
+        id: 'cliproxyapi::codex-model::gemini-2.5-pro',
+        model_name: 'gemini-2.5-pro'
+      }
+    ])
+  })
+
+  it('keeps a regular profile when the renderer extension returns undefined', async () => {
+    const profile = buildProfile()
+    const discoverModelNames = vi.fn().mockResolvedValue(undefined)
+    rendererHostExtensionApiV1.chat = { discoverModelNames }
+
+    const config = buildConfig([profile])
+    const { result } = renderHook(() => useChatProfiles(config, true))
+
+    await waitFor(() => expect(discoverModelNames).toHaveBeenCalledWith(profile))
+    expect(result.current.availableProfiles).toEqual([profile])
+  })
+
+  it.each([
+    { mode: 'disabled', enabled: false, isReady: true, useRemoteLlm: false },
+    { mode: 'not ready', enabled: true, isReady: false, useRemoteLlm: false },
+    { mode: 'remote', enabled: true, isReady: true, useRemoteLlm: true }
+  ])('does not discover models when $mode', async ({ enabled, isReady, useRemoteLlm }) => {
+    const profile = buildProfile()
+    const discoverModelNames = vi.fn().mockResolvedValue(['unexpected-model'])
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ profiles: [] })
+    })
+    rendererHostExtensionApiV1.chat = { discoverModelNames }
+    vi.stubGlobal('fetch', fetchMock)
+
+    const config = buildConfig([profile], useRemoteLlm)
+    renderHook(() => useChatProfiles(config, isReady, enabled))
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(discoverModelNames).not.toHaveBeenCalled()
+    expect(fetchMock).toHaveBeenCalledTimes(useRemoteLlm ? 1 : 0)
+  })
+})

--- a/packages/app/src/renderer/src/pages/ChatPage/hooks/useChatProfiles.ts
+++ b/packages/app/src/renderer/src/pages/ChatPage/hooks/useChatProfiles.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Config, LLMAPIProfile } from '@shared/config/config'
+import { isRunnableProfile } from '@shared/llm'
 import { rendererHostExtensionApiV1 } from '@renderer/extensions/generatedRegistry'
 import {
   buildChatAvailableProfiles,
@@ -16,7 +17,7 @@ import {
  */
 export function useChatProfiles(config: Config, isReady: boolean, enabled: boolean = true) {
   const [remoteProfiles, setRemoteProfiles] = useState<LLMAPIProfile[]>([])
-  const [cliProxyModelsByProfileId, setCliProxyModelsByProfileId] = useState<
+  const [discoveredModelsByProfileId, setDiscoveredModelsByProfileId] = useState<
     Record<string, string[]>
   >({})
   const remoteLlmServerOrigin = useMemo(
@@ -70,17 +71,13 @@ export function useChatProfiles(config: Config, isReady: boolean, enabled: boole
 
   useEffect(() => {
     if (!enabled || !isReady || useRemoteLlm) {
-      setCliProxyModelsByProfileId({})
+      setDiscoveredModelsByProfileId({})
       return
     }
 
-    const profiles = (config?.llm_config?.api_profiles || []).filter(
-      (profile) =>
-        profile.call_type === 'cliproxyapi' &&
-        Boolean(profile.base_url?.trim() && profile.api_key?.trim())
-    )
+    const profiles = (config?.llm_config?.api_profiles || []).filter(isRunnableProfile)
     if (profiles.length === 0) {
-      setCliProxyModelsByProfileId({})
+      setDiscoveredModelsByProfileId({})
       return
     }
 
@@ -99,7 +96,7 @@ export function useChatProfiles(config: Config, isReady: boolean, enabled: boole
       })
     ).then((entries) => {
       if (!cancelled) {
-        setCliProxyModelsByProfileId(Object.fromEntries(entries))
+        setDiscoveredModelsByProfileId(Object.fromEntries(entries))
       }
     })
 
@@ -110,8 +107,8 @@ export function useChatProfiles(config: Config, isReady: boolean, enabled: boole
   }, [config?.llm_config?.api_profiles, enabled, isReady, useRemoteLlm])
 
   const availableProfiles = useMemo(
-    () => buildChatAvailableProfiles(config, remoteProfiles, cliProxyModelsByProfileId),
-    [cliProxyModelsByProfileId, config, remoteProfiles]
+    () => buildChatAvailableProfiles(config, remoteProfiles, discoveredModelsByProfileId),
+    [config, discoveredModelsByProfileId, remoteProfiles]
   )
 
   return { availableProfiles, remoteProfiles }

--- a/packages/app/src/renderer/src/pages/SettingsPage/PanelLLM.test.tsx
+++ b/packages/app/src/renderer/src/pages/SettingsPage/PanelLLM.test.tsx
@@ -396,6 +396,71 @@ describe('PanelLLM Agent API settings', () => {
     })
   })
 
+  it('persists API address and key changes immediately without waiting for blur', () => {
+    const saveSettings = vi.fn()
+    rendererHostExtensionApiV1.settings = {
+      buildAgentApiProfileCallTypeOptions: ({ baseOptions }) => [
+        ...baseOptions,
+        { label: 'CLIProxyAPI/Codex', value: 'cliproxyapi' }
+      ],
+      resolveAgentApiProfileUi: ({ baseUi, profile }) =>
+        profile.call_type === 'cliproxyapi'
+          ? {
+              ...baseUi,
+              apiKeyLabel: 'CLIProxyAPI API Key',
+              showModelNameInput: false,
+              showApiKeyInput: true,
+              showBaseUrlInput: true
+            }
+          : undefined
+    }
+
+    const { unmount } = render(
+      <PanelLLM
+        settingsValue={buildSettingsWithProfile({
+          model_name: '',
+          base_url: '',
+          api_key: '',
+          call_type: 'cliproxyapi'
+        })}
+        saveSettings={saveSettings}
+      />
+    )
+
+    fireEvent.change(screen.getByLabelText('Base URL'), {
+      target: { value: 'https://proxy.example.test/v1' }
+    })
+    expect(saveSettings).toHaveBeenLastCalledWith({
+      llm_config: {
+        api_profiles: [
+          expect.objectContaining({
+            id: 'profile-1',
+            base_url: 'https://proxy.example.test/v1',
+            api_key: ''
+          })
+        ]
+      }
+    })
+
+    fireEvent.change(screen.getByLabelText('CLIProxyAPI API Key'), {
+      target: { value: 'proxy-secret' }
+    })
+    expect(saveSettings).toHaveBeenLastCalledWith({
+      llm_config: {
+        api_profiles: [
+          expect.objectContaining({
+            id: 'profile-1',
+            base_url: 'https://proxy.example.test/v1',
+            api_key: 'proxy-secret'
+          })
+        ]
+      }
+    })
+
+    unmount()
+    expect(saveSettings).toHaveBeenCalledTimes(2)
+  })
+
   it('clears old protocol overrides when the API address is edited', () => {
     const saveSettings = vi.fn()
 

--- a/packages/app/src/renderer/src/pages/SettingsPage/PanelLLM.tsx
+++ b/packages/app/src/renderer/src/pages/SettingsPage/PanelLLM.tsx
@@ -721,6 +721,11 @@ const ApiProfileCard: React.FC<ApiProfileCardProps> = ({
     configuredHy3dRegion
   )
   const [isClearingHy3dCosPrefix, setIsClearingHy3dCosPrefix] = React.useState(false)
+  const latestProfileRef = React.useRef(profile)
+
+  React.useEffect(() => {
+    latestProfileRef.current = profile
+  }, [profile])
 
   const updateProfile = React.useCallback(
     (nextProfile: LLMAPIProfile) => {
@@ -736,14 +741,15 @@ const ApiProfileCard: React.FC<ApiProfileCardProps> = ({
           { profile: nextProfile, callType: nextCallType },
           () => nextProfile
         )
+        latestProfileRef.current = extensionProfile
         onUpdate(profile.id, extensionProfile)
         return
       }
 
       if (nextCallType === 'local') {
-        onUpdate(profile.id, {
+        const localProfile = {
           ...stripVideoSecretProfile(stripHunyuan3DProfile(stripExternalAuthProfile(nextProfile))),
-          call_type: 'local',
+          call_type: 'local' as const,
           base_url: '',
           api_key: '',
           backup_api_keys: undefined,
@@ -751,7 +757,9 @@ const ApiProfileCard: React.FC<ApiProfileCardProps> = ({
           deployment: undefined,
           is_ollama: false,
           local_model_path: normalizeLocalModelPath(nextProfile.local_model_path)
-        })
+        }
+        latestProfileRef.current = localProfile
+        onUpdate(profile.id, localProfile)
         return
       }
 
@@ -775,7 +783,7 @@ const ApiProfileCard: React.FC<ApiProfileCardProps> = ({
         ? normalizedProfile
         : stripVideoSecretProfile(normalizedProfile)
 
-      onUpdate(profile.id, {
+      const updatedProfile: LLMAPIProfile = {
         ...outputProfile,
         call_type: normalizedNextProfile.call_type,
         provider: shouldKeepVideoProvider
@@ -787,7 +795,9 @@ const ApiProfileCard: React.FC<ApiProfileCardProps> = ({
           (isOllamaUrl(nextBaseUrl) ||
             Boolean(normalizedProfile.is_ollama) ||
             preserveLegacyOllamaOverride)
-      })
+      }
+      latestProfileRef.current = updatedProfile
+      onUpdate(profile.id, updatedProfile)
     },
     [onUpdate, profile.id, profile.provider]
   )
@@ -1027,9 +1037,10 @@ const ApiProfileCard: React.FC<ApiProfileCardProps> = ({
           <InputText
             label={copy('API 地址', t('llm.base_url'))}
             value={profile.base_url}
-            onChange={(value) => updateProfile({ ...profile, base_url: value })}
+            onChange={(value) => updateProfile({ ...latestProfileRef.current, base_url: value })}
             placeholder={baseUrlPlaceholder}
             shrinkLabel
+            updateMode="change"
           />
         )}
 
@@ -1039,12 +1050,13 @@ const ApiProfileCard: React.FC<ApiProfileCardProps> = ({
             value={profile.api_key}
             onChange={(value) =>
               updateProfile({
-                ...stripExternalAuthProfile(profile),
+                ...stripExternalAuthProfile(latestProfileRef.current),
                 api_key: value
               })
             }
             placeholder={apiKeyPlaceholder}
             shrinkLabel
+            updateMode="change"
           />
         )}
 


### PR DESCRIPTION
## Summary
- let renderer extensions discover models for all runnable profiles, including Codex OAuth and CLIProxyAPI
- persist Base URL and API key changes immediately without losing consecutive edits
- serialize config writes so rapid settings saves merge in order and cannot overwrite newer values

## Tests
- PanelLLM: 37 passed
- useChatProfiles: 6 passed
- config: 15 passed
- npm run typecheck
- targeted ESLint and Prettier checks

No version bump, packaging, or Release workflow is included.