### PR TITLE
fix: reject duplicate active chat requests

### DIFF
--- a/packages/app/src/main/api/svcLLMProxyImpl.test.ts
+++ b/packages/app/src/main/api/svcLLMProxyImpl.test.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs/promises'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { newAbortHandler } from '@shared/api/apiUtils/abortHandler'
 import { DEFAULT_CONFIG, type Config } from '@shared/config/config'
 import { cliFromProfile } from '@shared/llm'
 import * as configModule from '../config/config'
@@ -10,7 +11,7 @@ import {
   clearTrustedLocalFileSelectionsForTest,
   rememberTrustedLocalFileSelections
 } from './trustedFileSelection'
-import { LLMProxySvcImpl } from './svcLLMProxyImpl'
+import { LLM_CONVERSATION_REQUEST_ACTIVE_ERROR_CODE, LLMProxySvcImpl } from './svcLLMProxyImpl'
 
 const {
   generateFromMessagesMock,
@@ -542,10 +543,276 @@ describe('LLMProxySvcImpl', () => {
       }
     )
 
-    expect(agentChat).toHaveBeenCalledWith({
-      messages: [{ role: 'user', content: 'hello' }],
-      systemPrompt: undefined,
-      signal: controller.signal
+    expect(agentChat).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: [{ role: 'user', content: 'hello' }],
+        systemPrompt: undefined,
+        signal: expect.any(AbortSignal)
+      })
+    )
+    expect(agentChat.mock.calls[0]?.[0]?.signal).not.toBe(controller.signal)
+    expect(agentChat.mock.calls[0]?.[0]?.signal?.aborted).toBe(false)
+  })
+
+  it('rejects a duplicate conversation request without replacing or cancelling the original', async () => {
+    let resolveOriginal!: (value: string) => void
+    let originalSignal: AbortSignal | undefined
+    const originalResult = new Promise<string>((resolve) => {
+      resolveOriginal = resolve
+    })
+    const agentChat = vi.fn(({ signal }: { signal?: AbortSignal }) => {
+      originalSignal = signal
+      return originalResult
+    })
+    vi.mocked(cliFromProfile).mockReturnValue({ chat: agentChat } as never)
+
+    mockConfig({
+      llm_config: {
+        ...DEFAULT_CONFIG.llm_config,
+        api_profiles: [
+          {
+            id: 'agent-profile',
+            model_name: 'Agent Model',
+            base_url: 'https://agent.example/v1',
+            api_key: 'agent-key'
+          }
+        ]
+      }
+    })
+
+    const svc = new LLMProxySvcImpl()
+    const original = svc.chat({
+      conversationId: 'conversation-duplicate',
+      profileId: 'agent-profile',
+      messages: [{ role: 'user', content: 'first' }]
+    })
+    await vi.waitFor(() => expect(agentChat).toHaveBeenCalledTimes(1))
+
+    await expect(
+      svc.chat({
+        conversationId: 'conversation-duplicate',
+        profileId: 'agent-profile',
+        messages: [{ role: 'user', content: 'second' }]
+      })
+    ).rejects.toMatchObject({
+      code: LLM_CONVERSATION_REQUEST_ACTIVE_ERROR_CODE,
+      message: 'A request is already active for conversation "conversation-duplicate".'
+    })
+
+    expect(agentChat).toHaveBeenCalledTimes(1)
+    expect(originalSignal?.aborted).toBe(false)
+
+    resolveOriginal('first response')
+    await expect(original).resolves.toEqual({ content: 'first response' })
+  })
+
+  it('keeps the original duplicate-guarded request cancellable', async () => {
+    let originalSignal: AbortSignal | undefined
+    const agentChat = vi.fn(
+      ({ signal }: { signal?: AbortSignal }) =>
+        new Promise<string>((_resolve, reject) => {
+          originalSignal = signal
+          signal?.addEventListener(
+            'abort',
+            () => reject(signal.reason instanceof Error ? signal.reason : new Error('aborted')),
+            { once: true }
+          )
+        })
+    )
+    vi.mocked(cliFromProfile).mockReturnValue({ chat: agentChat } as never)
+
+    mockConfig({
+      llm_config: {
+        ...DEFAULT_CONFIG.llm_config,
+        api_profiles: [
+          {
+            id: 'agent-profile',
+            model_name: 'Agent Model',
+            base_url: 'https://agent.example/v1',
+            api_key: 'agent-key'
+          }
+        ]
+      }
+    })
+
+    const svc = new LLMProxySvcImpl()
+    const original = svc.chat({
+      conversationId: 'conversation-cancellable',
+      profileId: 'agent-profile',
+      messages: [{ role: 'user', content: 'first' }]
+    })
+    await vi.waitFor(() => expect(agentChat).toHaveBeenCalledTimes(1))
+
+    await expect(
+      svc.chat({
+        conversationId: 'conversation-cancellable',
+        profileId: 'agent-profile',
+        messages: [{ role: 'user', content: 'second' }]
+      })
+    ).rejects.toMatchObject({ code: LLM_CONVERSATION_REQUEST_ACTIVE_ERROR_CODE })
+
+    await expect(
+      svc.cancelConversation({ conversationId: 'conversation-cancellable' })
+    ).resolves.toEqual({ cancelled: true })
+    await expect(original).rejects.toMatchObject({
+      name: 'AbortError',
+      message: 'Conversation cancelled by the user.'
+    })
+    expect(originalSignal?.aborted).toBe(true)
+  })
+
+  it('allows a conversationId to be reused after the active request completes', async () => {
+    const agentChat = vi
+      .fn()
+      .mockResolvedValueOnce('first response')
+      .mockResolvedValueOnce('second response')
+    vi.mocked(cliFromProfile).mockReturnValue({ chat: agentChat } as never)
+
+    mockConfig({
+      llm_config: {
+        ...DEFAULT_CONFIG.llm_config,
+        api_profiles: [
+          {
+            id: 'agent-profile',
+            model_name: 'Agent Model',
+            base_url: 'https://agent.example/v1',
+            api_key: 'agent-key'
+          }
+        ]
+      }
+    })
+
+    const svc = new LLMProxySvcImpl()
+    const request = {
+      conversationId: 'conversation-reusable',
+      profileId: 'agent-profile',
+      messages: [{ role: 'user' as const, content: 'hello' }]
+    }
+
+    await expect(svc.chat(request)).resolves.toEqual({ content: 'first response' })
+    await expect(svc.chat(request)).resolves.toEqual({ content: 'second response' })
+    expect(agentChat).toHaveBeenCalledTimes(2)
+  })
+
+  it('aborts an upstream streaming request without a conversationId when the renderer closes the stream', async () => {
+    let upstreamSignal: AbortSignal | undefined
+    const agentChat = vi.fn(
+      ({ signal }: { signal?: AbortSignal }) =>
+        new Promise<string>((_resolve, reject) => {
+          upstreamSignal = signal
+          signal?.addEventListener(
+            'abort',
+            () => reject(signal.reason instanceof Error ? signal.reason : new Error('aborted')),
+            { once: true }
+          )
+        })
+    )
+    vi.mocked(cliFromProfile).mockReturnValue({ chat: agentChat } as never)
+
+    mockConfig({
+      llm_config: {
+        ...DEFAULT_CONFIG.llm_config,
+        api_profiles: [
+          {
+            id: 'agent-profile',
+            model_name: 'Agent Model',
+            base_url: 'https://agent.example/v1',
+            api_key: 'agent-key'
+          }
+        ]
+      }
+    })
+
+    const [abortSender, abortReceiver] = newAbortHandler()
+    const onData = vi.fn()
+    const svc = new LLMProxySvcImpl()
+    const streaming = svc.chatStream(
+      {
+        profileId: 'agent-profile',
+        messages: [{ role: 'user', content: 'stream' }]
+      },
+      { onData, abortReceiver }
+    )
+    await vi.waitFor(() => expect(agentChat).toHaveBeenCalledTimes(1))
+
+    abortSender.abort()
+    await streaming
+
+    expect(upstreamSignal?.aborted).toBe(true)
+    expect(upstreamSignal?.reason).toMatchObject({
+      name: 'AbortError',
+      message: 'Streaming request aborted by the renderer.'
+    })
+    expect(onData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'done',
+        done: true,
+        error: 'Streaming request aborted by the renderer.'
+      })
+    )
+  })
+
+  it('aborts an upstream streaming request when the renderer closes the stream', async () => {
+    let upstreamSignal: AbortSignal | undefined
+    const agentChat = vi.fn(
+      ({ signal }: { signal?: AbortSignal }) =>
+        new Promise<string>((_resolve, reject) => {
+          upstreamSignal = signal
+          signal?.addEventListener(
+            'abort',
+            () => reject(signal.reason instanceof Error ? signal.reason : new Error('aborted')),
+            { once: true }
+          )
+        })
+    )
+    vi.mocked(cliFromProfile).mockReturnValue({ chat: agentChat } as never)
+
+    mockConfig({
+      llm_config: {
+        ...DEFAULT_CONFIG.llm_config,
+        api_profiles: [
+          {
+            id: 'agent-profile',
+            model_name: 'Agent Model',
+            base_url: 'https://agent.example/v1',
+            api_key: 'agent-key'
+          }
+        ]
+      }
+    })
+
+    const [abortSender, abortReceiver] = newAbortHandler()
+    const onData = vi.fn()
+    const svc = new LLMProxySvcImpl()
+    const streaming = svc.chatStream(
+      {
+        conversationId: 'conversation-stream',
+        profileId: 'agent-profile',
+        messages: [{ role: 'user', content: 'stream' }]
+      },
+      { onData, abortReceiver }
+    )
+    await vi.waitFor(() => expect(agentChat).toHaveBeenCalledTimes(1))
+
+    abortSender.abort()
+    await streaming
+
+    expect(upstreamSignal?.aborted).toBe(true)
+    expect(upstreamSignal?.reason).toMatchObject({
+      name: 'AbortError',
+      message: 'Streaming request aborted by the renderer.'
+    })
+    expect(onData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'done',
+        done: true,
+        error: 'Streaming request aborted by the renderer.'
+      })
+    )
+    await expect(
+      svc.cancelConversation({ conversationId: 'conversation-stream' })
+    ).resolves.toEqual({
+      cancelled: false
     })
   })
 

--- a/packages/app/src/main/api/svcLLMProxyImpl.ts
+++ b/packages/app/src/main/api/svcLLMProxyImpl.ts
@@ -27,6 +27,7 @@ import {
   ChatAttachment
 } from '@shared/api/svcLLMProxy'
 import { ServerStreaming } from '@shared/api/apiUtils/streaming'
+import { ServiceError } from '@shared/api/apiUtils/serviceValidation'
 import { getConfig } from '../config/config'
 import { Config, LLMAPIProfile, resolveCustomSkillContextMessageLimit } from '@shared/config/config'
 import {
@@ -344,6 +345,13 @@ const createAbortError = (message: string): Error => {
   error.name = 'AbortError'
   return error
 }
+
+export const LLM_CONVERSATION_REQUEST_ACTIVE_ERROR_CODE = 'LLM_CONVERSATION_REQUEST_ACTIVE'
+
+const createConversationRequestActiveError = (conversationId: string): ServiceError =>
+  new ServiceError(`A request is already active for conversation "${conversationId}".`, {
+    code: LLM_CONVERSATION_REQUEST_ACTIVE_ERROR_CODE
+  })
 
 type ExplicitToolCommand =
   | {
@@ -918,32 +926,43 @@ export class LLMProxySvcImpl implements LLMProxySvc {
     signal?: AbortSignal
   ): {
     signal?: AbortSignal
+    abort: (reason?: unknown) => void
     cleanup: () => void
   } {
-    if (!conversationId) {
+    const normalizedConversationId = String(conversationId || '').trim()
+    if (
+      normalizedConversationId &&
+      this.conversationAbortControllers.has(normalizedConversationId)
+    ) {
+      throw createConversationRequestActiveError(normalizedConversationId)
+    }
+
+    if (!normalizedConversationId && !signal) {
       return {
         signal,
+        abort: () => undefined,
         cleanup: () => undefined
       }
     }
 
     const controller = new AbortController()
-    this.conversationAbortControllers.set(conversationId, controller)
+    if (normalizedConversationId) {
+      this.conversationAbortControllers.set(normalizedConversationId, controller)
+    }
 
-    const handleAbort = () => {
+    const abort = (reason?: unknown) => {
       if (controller.signal.aborted) return
 
-      if (signal?.reason instanceof Error) {
-        controller.abort(signal.reason)
+      if (reason instanceof Error) {
+        controller.abort(reason)
         return
       }
 
       controller.abort(
-        createAbortError(
-          typeof signal?.reason === 'string' ? signal.reason : 'The request was aborted.'
-        )
+        createAbortError(typeof reason === 'string' ? reason : 'The request was aborted.')
       )
     }
+    const handleAbort = () => abort(signal?.reason)
 
     if (signal?.aborted) {
       handleAbort()
@@ -953,13 +972,14 @@ export class LLMProxySvcImpl implements LLMProxySvc {
 
     return {
       signal: controller.signal,
+      abort,
       cleanup: () => {
         if (signal) {
           signal.removeEventListener('abort', handleAbort)
         }
-        const current = this.conversationAbortControllers.get(conversationId)
+        const current = this.conversationAbortControllers.get(normalizedConversationId)
         if (current === controller) {
-          this.conversationAbortControllers.delete(conversationId)
+          this.conversationAbortControllers.delete(normalizedConversationId)
         }
       }
     }
@@ -1714,7 +1734,14 @@ export class LLMProxySvcImpl implements LLMProxySvc {
     req: LLMChatStreamReq,
     resp: ServerStreaming<LLMChatStreamResp>
   ): Promise<void> => {
-    const abortContext = this.createConversationAbortContext(req.conversationId)
+    const streamAbortController = new AbortController()
+    const abortContext = this.createConversationAbortContext(
+      req.conversationId,
+      streamAbortController.signal
+    )
+    resp.abortReceiver?.onAbort(() => {
+      abortContext.abort(createAbortError('Streaming request aborted by the renderer.'))
+    })
     let streamedText = ''
     let lastSessionUrl = req.sessionUrl?.trim() || undefined
     const seenAttachmentKeys = new Set<string>()

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/ProjectCanvasPageStageScene.test.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/ProjectCanvasPageStageScene.test.tsx
@@ -700,6 +700,25 @@ describe('ProjectCanvasPageStageScene WebGL integration seam', () => {
     expect(imageInteractionOverlayProps.has(offscreenItem.id)).toBe(false)
   })
 
+  it('routes GIF images to the animated DOM layer instead of the static WebGL path', async () => {
+    const gifItem = {
+      ...createImageItem('image-animated-gif'),
+      src: 'file:///image-animated-gif.gif',
+      fileName: 'image-animated-gif.gif'
+    }
+    setMockWebGLRuntime({ loadedIds: [gifItem.id] })
+
+    render(<ProjectCanvasPageStageScene {...createBaseProps([gifItem])} />)
+
+    await waitFor(() => {
+      expect(latestWebGLItems).toEqual([])
+    })
+    const animatedImage = document.querySelector(
+      '[data-project-canvas-animated-image-layer="dom"] img[data-canvas-source-image-preview="true"]'
+    )
+    expect(animatedImage?.getAttribute('src')).toBe('file:///image-animated-gif.gif')
+  })
+
   it('adds a high-resolution source overlay for jumbo resident WebGL images at close zoom', async () => {
     const item = {
       ...createImageItem('image-jumbo-webgl-source'),

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/ProjectCanvasPageStageScene.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/ProjectCanvasPageStageScene.tsx
@@ -8,6 +8,7 @@ import { Box } from '@mui/material'
 import MaxSizeLayout from '../../components/MaxSizeLayout'
 import CanvasItemPlaceholder from './components/CanvasItemPlaceholder'
 import CanvasImageDomPreview from './components/CanvasImageDomPreview'
+import CanvasAnimatedImageDomLayer from './components/CanvasAnimatedImageDomLayer'
 import { CanvasTextOverlayContent, CanvasTextOverlayFrame } from './components/CanvasTextOverlay'
 import ProjectCanvasImageCropOverlay from './components/ProjectCanvasImageCropOverlay'
 import ProjectCanvasImageInteractionOverlay from './components/ProjectCanvasImageInteractionOverlay'
@@ -57,6 +58,7 @@ import {
   takeProjectCanvasWebGLPendingRuntimeState
 } from './projectCanvasWebGLRuntimeState'
 import { resolveCanvasImageLodDecision } from './canvasImageLodPolicy'
+import { isAnimatedGifCanvasImage } from './canvasAnimatedImageUtils'
 import type {
   CanvasAnnotationItem,
   CanvasFileItem,
@@ -1292,12 +1294,23 @@ export default function ProjectCanvasPageStageScene(props: any) {
         .sort((left, right) => left.zIndex - right.zIndex),
     [allCanvasItems]
   )
+  const animatedGifImageItems = React.useMemo(
+    () => sortedAllImageItems.filter(isAnimatedGifCanvasImage),
+    [sortedAllImageItems]
+  )
+  const animatedGifImageIdSet = React.useMemo(
+    () => new Set(animatedGifImageItems.map((item) => item.id)),
+    [animatedGifImageItems]
+  )
   const webglImageItems = React.useMemo(
     () =>
       sortedAllImageItems.filter(
-        (item) => item.id !== cropTargetId && !generatedCooldownImageIds.has(item.id)
+        (item) =>
+          item.id !== cropTargetId &&
+          !generatedCooldownImageIds.has(item.id) &&
+          !animatedGifImageIdSet.has(item.id)
       ),
-    [cropTargetId, generatedCooldownImageIds, sortedAllImageItems]
+    [animatedGifImageIdSet, cropTargetId, generatedCooldownImageIds, sortedAllImageItems]
   )
   const canvas2DFallbackImageItems = React.useMemo(
     () =>
@@ -1305,9 +1318,10 @@ export default function ProjectCanvasPageStageScene(props: any) {
         (item): item is CanvasImageItem =>
           item.type === 'image' &&
           imageRuntimeRouteById.get(item.id) === 'fallback-image-proxy' &&
+          !animatedGifImageIdSet.has(item.id) &&
           !canvas2DFailedImageIds.has(item.id)
       ),
-    [canvas2DFailedImageIds, imageRuntimeRouteById, visibleItems]
+    [animatedGifImageIdSet, canvas2DFailedImageIds, imageRuntimeRouteById, visibleItems]
   )
   const canvas2DFallbackImageIdSet = React.useMemo(
     () => new Set(canvas2DFallbackImageItems.map((item) => item.id)),
@@ -2803,6 +2817,7 @@ export default function ProjectCanvasPageStageScene(props: any) {
           const canRenderImagePreview =
             Boolean(imageItem.image) || (tool === 'select' && !!imageItem.src)
           const imageProxyVisualVariant =
+            animatedGifImageIdSet.has(item.id) ||
             imageRuntimeRoute === 'webgl-primary' ||
             (canvas2DVisualOwnerImageIdSet.has(item.id) && !isSelected) ||
             (!canRenderImagePreview && imageFallbackReason === 'unloaded')
@@ -3255,6 +3270,11 @@ export default function ProjectCanvasPageStageScene(props: any) {
               onFailedIdsChange={handleCanvas2DFailedIdsChange}
             />
           )}
+          <CanvasAnimatedImageDomLayer
+            items={animatedGifImageItems}
+            stageScale={stageScale}
+            registerViewportLayer={registerViewportLayer}
+          />
           {highResolutionDomImagePreviewItems.length > 0 && (
             <Box
               data-project-canvas-high-res-image-layer="dom"
@@ -3377,6 +3397,7 @@ export default function ProjectCanvasPageStageScene(props: any) {
                 const isSelected = selectedIds.has(imageItem.id) && tool === 'select'
                 const imageRuntimeRoute = getImageRuntimeRoute(imageItem)
                 const suppressDomImagePreview =
+                  animatedGifImageIdSet.has(imageItem.id) ||
                   imageRuntimeRoute === 'webgl-primary' ||
                   (canvas2DVisualOwnerImageIdSet.has(imageItem.id) && !isSelected)
                 const shouldShowSelectionChrome = isSelected && !shouldSuppressSelectionChrome

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasAnimatedImageUtils.test.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasAnimatedImageUtils.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { isAnimatedGifCanvasImage } from './canvasAnimatedImageUtils'
+import type { CanvasImageItem } from './types'
+
+function createItem(overrides: Partial<CanvasImageItem> = {}): CanvasImageItem {
+  return {
+    id: 'image-1',
+    type: 'image',
+    src: 'https://example.com/image.png',
+    x: 0,
+    y: 0,
+    width: 100,
+    height: 100,
+    rotation: 0,
+    scaleX: 1,
+    scaleY: 1,
+    zIndex: 1,
+    locked: false,
+    ...overrides
+  }
+}
+
+describe('isAnimatedGifCanvasImage', () => {
+  it('recognizes GIFs from data MIME, blob MIME, filenames, provenance, and URL paths', () => {
+    expect(isAnimatedGifCanvasImage(createItem({ src: 'data:image/gif;base64,R0lGODlh' }))).toBe(
+      true
+    )
+    expect(
+      isAnimatedGifCanvasImage(
+        createItem({ src: 'blob:local-image', sourceFile: new Blob([], { type: 'image/gif' }) })
+      )
+    ).toBe(true)
+    expect(isAnimatedGifCanvasImage(createItem({ fileName: 'animation.GIF' }))).toBe(true)
+    expect(
+      isAnimatedGifCanvasImage(
+        createItem({ provenance: { kind: 'imported-file', sourceFileName: 'source.gif' } })
+      )
+    ).toBe(true)
+    expect(
+      isAnimatedGifCanvasImage(
+        createItem({ src: 'https://example.com/path/animation.gif?token=1' })
+      )
+    ).toBe(true)
+  })
+
+  it('does not classify static image sources as GIFs', () => {
+    expect(isAnimatedGifCanvasImage(createItem())).toBe(false)
+    expect(isAnimatedGifCanvasImage(createItem({ src: 'data:image/png;base64,AA==' }))).toBe(false)
+  })
+})

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasAnimatedImageUtils.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasAnimatedImageUtils.ts
@@ -1,0 +1,29 @@
+import type { CanvasImageItem } from './types'
+
+function hasGifExtension(value: string | null | undefined): boolean {
+  const normalized = String(value || '').trim()
+  if (!normalized) {
+    return false
+  }
+
+  try {
+    return new URL(normalized).pathname.toLowerCase().endsWith('.gif')
+  } catch {
+    return normalized.split(/[?#]/, 1)[0].toLowerCase().endsWith('.gif')
+  }
+}
+
+export function isAnimatedGifCanvasImage(
+  item: Pick<CanvasImageItem, 'src' | 'fileName' | 'sourceFile' | 'provenance'>
+): boolean {
+  const normalizedSrc = item.src.trim().toLowerCase()
+  const sourceMimeType = item.sourceFile?.type?.trim().toLowerCase()
+
+  return (
+    normalizedSrc.startsWith('data:image/gif') ||
+    sourceMimeType === 'image/gif' ||
+    hasGifExtension(item.fileName) ||
+    hasGifExtension(item.provenance?.sourceFileName) ||
+    hasGifExtension(item.src)
+  )
+}

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/CanvasAnimatedImageDomLayer.test.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/CanvasAnimatedImageDomLayer.test.tsx
@@ -1,0 +1,78 @@
+import { act, render } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import CanvasAnimatedImageDomLayer from './CanvasAnimatedImageDomLayer'
+import type { CanvasImageItem } from '../types'
+
+function createItem(overrides: Partial<CanvasImageItem> = {}): CanvasImageItem {
+  const image = document.createElement('img')
+  Object.defineProperty(image, 'naturalWidth', { value: 200 })
+  Object.defineProperty(image, 'naturalHeight', { value: 120 })
+
+  return {
+    id: 'animated-image',
+    type: 'image',
+    src: 'file:///animated-image.gif',
+    fileName: 'animated-image.gif',
+    x: 100,
+    y: 140,
+    width: 200,
+    height: 120,
+    rotation: 0,
+    scaleX: 1,
+    scaleY: 1,
+    zIndex: 2,
+    locked: false,
+    image,
+    sourceWidth: 200,
+    sourceHeight: 120,
+    ...overrides
+  }
+}
+
+describe('CanvasAnimatedImageDomLayer', () => {
+  it('renders supplied GIF sources as persistent DOM images', () => {
+    const registerViewportLayer = vi.fn()
+    const gifItem = createItem()
+
+    render(
+      <CanvasAnimatedImageDomLayer
+        items={[gifItem]}
+        stageScale={1}
+        registerViewportLayer={registerViewportLayer}
+      />
+    )
+
+    const layer = document.querySelector('[data-project-canvas-animated-image-layer="dom"]')
+    const gifImage = layer?.querySelector('img[data-canvas-source-image-preview="true"]')
+    expect(layer).not.toBeNull()
+    expect(gifImage?.getAttribute('src')).toBe('file:///animated-image.gif')
+  })
+
+  it('follows live canvas transform sync while an image is dragged or resized', () => {
+    const item = createItem()
+    render(
+      <CanvasAnimatedImageDomLayer
+        items={[item]}
+        stageScale={1}
+        registerViewportLayer={() => undefined}
+      />
+    )
+
+    const animatedItem = document.querySelector(
+      '[data-project-canvas-animated-image-item-id="animated-image"]'
+    ) as HTMLElement
+    expect(animatedItem.style.transform).toContain('translate3d(100px, 140px, 0)')
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(`canvas-sync-${item.id}`, {
+          detail: { x: 320, y: 180, rotation: 15, scaleX: 1.5, scaleY: 0.75 }
+        })
+      )
+    })
+
+    expect(animatedItem.style.transform).toBe(
+      'translate3d(320px, 180px, 0) rotate(15deg) scale(1.5, 0.75)'
+    )
+  })
+})

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/CanvasAnimatedImageDomLayer.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/CanvasAnimatedImageDomLayer.tsx
@@ -1,0 +1,102 @@
+import { Box } from '@mui/material'
+import React from 'react'
+import type { CanvasImageItem } from '../types'
+import { STAGE_VIEWPORT_LAYER_BASE_STYLE } from '../useStageViewportTransformDriver'
+import CanvasImageDomPreview from './CanvasImageDomPreview'
+
+export type CanvasAnimatedImageDomLayerProps = {
+  items: CanvasImageItem[]
+  stageScale: number
+  registerViewportLayer: (element: HTMLElement | null) => void
+}
+
+type CanvasAnimatedImageItemProps = {
+  item: CanvasImageItem
+  stageScale: number
+}
+
+function buildCanvasAnimatedImageTransform(
+  item: Pick<CanvasImageItem, 'x' | 'y' | 'rotation' | 'scaleX' | 'scaleY'>
+) {
+  return `translate3d(${item.x}px, ${item.y}px, 0) rotate(${item.rotation}deg) scale(${item.scaleX}, ${item.scaleY})`
+}
+
+function CanvasAnimatedImageItem({ item, stageScale }: CanvasAnimatedImageItemProps) {
+  const itemRef = React.useRef<HTMLDivElement | null>(null)
+
+  React.useEffect(() => {
+    const element = itemRef.current
+    if (!element) {
+      return
+    }
+
+    const applyTransform = (source: CanvasImageItem) => {
+      element.style.transform = buildCanvasAnimatedImageTransform(source)
+    }
+    const handleCanvasSync = (event: Event) => {
+      const detail = (event as CustomEvent<Partial<CanvasImageItem>>).detail
+      applyTransform({ ...item, ...detail })
+    }
+
+    applyTransform(item)
+    window.addEventListener(`canvas-sync-${item.id}`, handleCanvasSync)
+    return () => {
+      window.removeEventListener(`canvas-sync-${item.id}`, handleCanvasSync)
+    }
+  }, [item])
+
+  return (
+    <Box
+      ref={itemRef}
+      data-project-canvas-animated-image-item-id={item.id}
+      sx={{
+        position: 'absolute',
+        left: 0,
+        top: 0,
+        width: item.width,
+        height: item.height,
+        overflow: 'hidden',
+        transform: buildCanvasAnimatedImageTransform(item),
+        transformOrigin: '0 0',
+        pointerEvents: 'none',
+        zIndex: item.zIndex
+      }}
+    >
+      <CanvasImageDomPreview
+        item={item}
+        previewMode="animated-gif-source"
+        borderRadius="4px"
+        stageScale={stageScale}
+        sourceImagePreview
+      />
+    </Box>
+  )
+}
+
+export default function CanvasAnimatedImageDomLayer({
+  items,
+  stageScale,
+  registerViewportLayer
+}: CanvasAnimatedImageDomLayerProps) {
+  if (items.length === 0) {
+    return null
+  }
+
+  return (
+    <Box
+      data-project-canvas-animated-image-layer="dom"
+      sx={{
+        position: 'absolute',
+        inset: 0,
+        overflow: 'visible',
+        pointerEvents: 'none'
+      }}
+    >
+      <div ref={registerViewportLayer} style={STAGE_VIEWPORT_LAYER_BASE_STYLE}>
+        {items.map((item) => (
+          <CanvasAnimatedImageItem key={item.id} item={item} stageScale={stageScale} />
+        ))}
+      </div>
+    </Box>
+  )
+}


### PR DESCRIPTION
## Summary
- atomically reject a second active request for the same conversation ID instead of overwriting the original AbortController
- preserve cancellation of the original request and allow ID reuse after completion
- abort upstream streaming work when the renderer closes the MessagePort, including requests without a conversation ID

## Verification
- targeted `svcLLMProxyImpl.test.ts`: 72/72 passed in the isolated request-guard workspace
- included in private overlay integration run: 99/99 targeted tests passed
- node/web typecheck passed through `check:codex-overlay:typecheck`

## Scope
- no version bump
- no packaging or release workflow trigger
- runtime ComfyUI data untouched
