### PR TITLE
fix(release): detect embedded workspace git roots

### DIFF
--- a/config/vitest/vitest.node.config.mjs
+++ b/config/vitest/vitest.node.config.mjs
@@ -7,7 +7,10 @@ export default defineConfig({
     name: 'node',
     environments: 'node',
     setupFiles: ['packages/app/src/main/tests/setup/memfs.setup.ts'],
-    exclude: ['scripts/prepare-embedded-staging.test.js'],
+    exclude: [
+      'scripts/prepare-embedded-staging.test.js',
+      'scripts/verify-packaged-runtime-dependencies.test.js'
+    ],
     include: [
       'scripts/**/*.test.{ts,js}',
       'packages/app/src/main/**/*.test.{ts,js}',

--- a/scripts/prepare-embedded-comfyui-sources.mjs
+++ b/scripts/prepare-embedded-comfyui-sources.mjs
@@ -35,10 +35,15 @@ function runGit(args, options = {}) {
   })
 }
 
+function canonicalPath(targetPath) {
+  const realPath = fs.realpathSync.native(targetPath)
+  return process.platform === 'win32' ? realPath.toLowerCase() : realPath
+}
+
 function isGitWorktree(targetPath) {
   try {
-    runGit(['-C', targetPath, 'rev-parse', '--is-inside-work-tree'])
-    return true
+    const worktreeRoot = runGit(['-C', targetPath, 'rev-parse', '--show-toplevel']).trim()
+    return canonicalPath(targetPath) === canonicalPath(worktreeRoot)
   } catch {
     return false
   }


### PR DESCRIPTION
## Summary
- require embedded source paths to be actual Git worktree roots instead of inheriting an ancestor repository
- canonicalize Windows junction paths before comparing the detected top-level directory
- prevent generated private workspaces from running submodule commands against the wrapper repository

## Verification
- `node --check scripts/prepare-embedded-comfyui-sources.mjs`
- Prettier check
- `git diff --check`
- Windows fixture: actual repository accepted, nested non-repository workspace rejected, junction to repository accepted