### PR TITLE
fix(release): isolate package builds from GitHub tokens

### DIFF
--- a/.github/workflows/call-release.yml
+++ b/.github/workflows/call-release.yml
@@ -68,6 +68,9 @@ jobs:
           npm run prepare:embedded
           npm run build:image-worker
           $env:PACKAGE_MODE = 'embedded'
+          # Keep electron-builder in package-only mode even when Actions exposes repository tokens.
+          Remove-Item Env:GH_TOKEN -ErrorAction SilentlyContinue
+          Remove-Item Env:GITHUB_TOKEN -ErrorAction SilentlyContinue
           npm run package:win -- --publish=never
 
           $portableRoot = Join-Path $PWD 'dist\embedded\win-unpacked\ComfyUI_windows_portable'
@@ -99,6 +102,9 @@ jobs:
           npm run build:pure
           npm run build:image-worker
           $env:PACKAGE_MODE = 'pure'
+          # Keep electron-builder in package-only mode even when Actions exposes repository tokens.
+          Remove-Item Env:GH_TOKEN -ErrorAction SilentlyContinue
+          Remove-Item Env:GITHUB_TOKEN -ErrorAction SilentlyContinue
           npm run package:win -- --publish=never
 
       - name: Prepare release assets


### PR DESCRIPTION
## Summary
- unset `GH_TOKEN` and `GITHUB_TOKEN` before Windows electron-builder package-only runs
- keep `--publish=never` builds from initializing or cleaning up a GitHub publisher
- apply the guard to both embedded and pure Windows packages

## Root cause
Nightly run 29466593767 generated the Windows artifacts, then electron-builder failed during publisher cleanup with `GitHub Personal Access Token is not set`. Repository tokens must not be exposed to package-only invocations.

## Verification
- `npm run typecheck`
- `npm run test:embedded-staging` (3 tests passed)
- `actionlint .github/workflows/call-release.yml`
- `git diff --check`
