### PR TITLE
fix(release): pass publish mode directly

### DIFF
--- a/.github/workflows/call-release.yml
+++ b/.github/workflows/call-release.yml
@@ -71,7 +71,7 @@ jobs:
           # Keep electron-builder in package-only mode even when Actions exposes repository tokens.
           Remove-Item Env:GH_TOKEN -ErrorAction SilentlyContinue
           Remove-Item Env:GITHUB_TOKEN -ErrorAction SilentlyContinue
-          npm run package:win -- --publish=never
+          npx electron-builder --config config/electron/electron-builder.config.js --win --x64 --publish never
 
           $portableRoot = Join-Path $PWD 'dist\embedded\win-unpacked\ComfyUI_windows_portable'
           $requiredPortableFiles = @(
@@ -105,7 +105,7 @@ jobs:
           # Keep electron-builder in package-only mode even when Actions exposes repository tokens.
           Remove-Item Env:GH_TOKEN -ErrorAction SilentlyContinue
           Remove-Item Env:GITHUB_TOKEN -ErrorAction SilentlyContinue
-          npm run package:win -- --publish=never
+          npx electron-builder --config config/electron/electron-builder.config.js --win --x64 --publish never
 
       - name: Prepare release assets
         shell: pwsh


### PR DESCRIPTION
## Summary
- invoke electron-builder directly for Windows package builds
- pass `--publish never` without npm's extra argument delimiter
- prevent package-only steps from attempting GitHub publication

## Root cause
The previous `npm run package:win -- --publish=never` invocation became `electron-builder ... --x64 -- --publish=never`. The extra standalone `--` prevented electron-builder from parsing the publish mode, so it attempted GitHub publication and failed because the package step intentionally had no token.

## Verification
- workflow YAML parsed with js-yaml
- `git diff --check` passed
- installed electron-builder CLI lists `never` as a supported `--publish` value