### PR TITLE
fix: distinguish candidate fixtures from leaks

### DIFF
--- a/scripts/create-open-candidate.mjs
+++ b/scripts/create-open-candidate.mjs
@@ -21,6 +21,7 @@ const textExtensions = new Set([
   '.jsx',
   '.md',
   '.mjs',
+  '.pem',
   '.ts',
   '.tsx',
   '.txt',
@@ -272,6 +273,8 @@ const codexFunctionalPattern = new RegExp(
   'gi'
 )
 
+const isTestFixture = (relativeFile) => /(?:^|\/)[^/]+\.(?:test|spec)\.[^/]+$/i.test(relativeFile)
+
 const addContentIssues = ({ file, relativeFile, text, issues }) => {
   const rules = [
     {
@@ -280,17 +283,21 @@ const addContentIssues = ({ file, relativeFile, text, issues }) => {
     },
     {
       rule: 'private-path-reference',
+      skip: isTestFixture(relativeFile),
       pattern:
         /(?:[A-Za-z]:[\\/][^\r\n"'`]*(?:private|internal|premium|open-private)[\\/][^\r\n"'`]*)|(?:(?:^|[\\/"'`\s])(?:private|internal|premium|open-private)[\\/][^\r\n"'`\s)]+)/gi
     },
     {
       rule: 'high-confidence-secret',
       pattern:
-        /(?:sk-[A-Za-z0-9_-]{32,}|gh[pousr]_[A-Za-z0-9_]{36,}|AKIA[0-9A-Z]{16}|xox[baprs]-[A-Za-z0-9-]{20,}|-----BEGIN (?:RSA |OPENSSH |EC |DSA )?PRIVATE KEY-----)/g
+        /(?:sk-[A-Za-z0-9_-]{32,}|gh[pousr]_[A-Za-z0-9_]{36,}|AKIA[0-9A-Z]{16}|xox[baprs]-[A-Za-z0-9-]{20,}|-----BEGIN ((?:RSA |OPENSSH |EC |DSA )?)PRIVATE KEY-----[A-Za-z0-9+/=\r\n]{32,8192}-----END \1PRIVATE KEY-----)/g
     }
   ]
 
-  for (const { rule, pattern } of rules) {
+  for (const { rule, pattern, skip = false } of rules) {
+    if (skip) {
+      continue
+    }
     for (const match of text.matchAll(pattern)) {
       const line = getLineNumber(text, match.index ?? 0)
       issues.push({

--- a/scripts/create-open-candidate.test.js
+++ b/scripts/create-open-candidate.test.js
@@ -163,6 +163,44 @@ describe('create-open-candidate policy', () => {
     ])
   })
 
+  it('ignores private-path fixtures and PEM format markers while retaining secret checks', () => {
+    const candidate = makeCandidate()
+    const completePem = [
+      '-----BEGIN PRIVATE KEY-----',
+      'QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVo0123456789=',
+      '-----END PRIVATE KEY-----'
+    ].join('\n')
+
+    writeFile(candidate, 'packages/app/src/example.test.ts', "const fixture = '/private/path'\n")
+    writeFile(candidate, 'packages/app/src/example.ts', "const marker = '-----BEGIN PRIVATE KEY-----'\n")
+
+    expect(auditOpenCandidate(candidate)).toEqual([])
+
+    writeFile(candidate, 'config/private-key.pem', completePem)
+    expect(auditOpenCandidate(candidate)).toEqual([
+      {
+        file: 'config/private-key.pem',
+        line: 1,
+        rule: 'high-confidence-secret',
+        message: completePem
+      }
+    ])
+  })
+
+  it('continues to reject private paths outside test fixtures', () => {
+    const candidate = makeCandidate()
+    writeFile(candidate, 'packages/app/src/runtime.ts', "const path = '/private/path'\n")
+
+    expect(auditOpenCandidate(candidate)).toEqual([
+      {
+        file: 'packages/app/src/runtime.ts',
+        line: 1,
+        rule: 'private-path-reference',
+        message: '/private/path'
+      }
+    ])
+  })
+
   it('verifies an already-generated candidate even when it is not a git repository', () => {
     const candidate = makeCandidate()
     writeFile(candidate, 'README.md', '# MagicPot Open\n')


### PR DESCRIPTION
## Summary
- prevent open-candidate verification from treating test-only `/private/...` fixtures as wrapper leaks
- require complete PEM blocks instead of flagging format-validation markers
- retain private-path checks for production sources and secret checks for complete keys/tokens

## Verification
- create-open-candidate tests: 8/8 passed
- full candidate generation and audit passed
- diff check passed
