### PR TITLE
feat: unify agent dispatch and canvas media resources

### DIFF
--- a/packages/app/src/main/agentKernel/agentKernel.dispatch.test.ts
+++ b/packages/app/src/main/agentKernel/agentKernel.dispatch.test.ts
@@ -1,0 +1,303 @@
+import { actionsFromArray, type AgentAction } from '@shared/agent'
+import { describe, expect, it, vi } from 'vitest'
+import { AgentKernel } from './index'
+
+const event = (eventId = 'event-1') => ({
+  eventId,
+  type: 'test.requested',
+  payload: { value: 1 },
+  createdAt: 1,
+  correlationId: 'correlation-1',
+  sessionId: 'session-1',
+  agentId: 'agent-1',
+  provenance: { source: 'test', requestedBy: 'vitest' }
+})
+
+const collect = async (actions: AsyncIterable<AgentAction>): Promise<AgentAction[]> => {
+  const result: AgentAction[] = []
+  for await (const action of actions) result.push(action)
+  return result
+}
+
+const deferred = () => {
+  let resolve!: () => void
+  const promise = new Promise<void>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+
+describe('AgentKernel dispatch', () => {
+  it('streams actions before handler completion and preserves order', async () => {
+    const kernel = new AgentKernel()
+    const release = deferred()
+    kernel.registerActionHandler('test.requested', async function* () {
+      yield { actionId: 'action-2', type: 'test.second', payload: { order: 2 } }
+      await release.promise
+      yield { actionId: 'action-1', type: 'test.first', payload: { order: 1 } }
+    })
+
+    const iterator = kernel.dispatch(event())[Symbol.asyncIterator]()
+    await expect(iterator.next()).resolves.toMatchObject({ value: { actionId: 'action-2' } })
+    const pending = iterator.next()
+    let completed = false
+    void pending.then(() => {
+      completed = true
+    })
+    await Promise.resolve()
+    expect(completed).toBe(false)
+    release.resolve()
+    await expect(pending).resolves.toMatchObject({ value: { actionId: 'action-1' } })
+    await expect(iterator.next()).resolves.toEqual({ done: true, value: undefined })
+  })
+
+  it('supports the array adapter and unregistering handlers', async () => {
+    const kernel = new AgentKernel()
+    const unregister = kernel.registerActionHandler('test.requested', () =>
+      actionsFromArray([{ actionId: 'action-1', type: 'test.done', payload: null }])
+    )
+    await expect(collect(kernel.dispatch(event()))).resolves.toHaveLength(1)
+    unregister()
+    await expect(collect(kernel.dispatch(event('event-2')))).rejects.toThrow(
+      'No Agent action handler has been registered for "test.requested".'
+    )
+  })
+
+  it('propagates AbortSignal and consumer cancellation into the handler', async () => {
+    const kernel = new AgentKernel()
+    const observed = deferred()
+    kernel.registerActionHandler('test.requested', async function* (_event, context) {
+      yield { actionId: 'action-1', type: 'test.started', payload: null }
+      await new Promise<void>((_resolve, reject) => {
+        context.signal.addEventListener(
+          'abort',
+          () => {
+            observed.resolve()
+            reject(context.signal.reason)
+          },
+          { once: true }
+        )
+      })
+    })
+
+    const iterator = kernel.dispatch(event())[Symbol.asyncIterator]()
+    await iterator.next()
+    await iterator.return?.()
+    await observed.promise
+
+    const preAborted = new AbortController()
+    preAborted.abort('stopped')
+    expect(() => kernel.dispatch(event('event-2'), preAborted.signal)).toThrowError(
+      expect.objectContaining({ name: 'AbortError', message: 'stopped' })
+    )
+  })
+
+  it('detaches one cancelled subscriber while another shared subscriber completes', async () => {
+    const kernel = new AgentKernel()
+    const release = deferred()
+    const handlerAborted = vi.fn()
+    kernel.registerActionHandler('test.requested', async function* (_event, context) {
+      context.signal.addEventListener('abort', handlerAborted, { once: true })
+      yield { actionId: 'action-1', type: 'test.started', payload: null }
+      await release.promise
+      yield { actionId: 'action-2', type: 'test.done', payload: null }
+    })
+
+    const cancelled = new AbortController()
+    const first = kernel.dispatch(event(), cancelled.signal)[Symbol.asyncIterator]()
+    const second = kernel.dispatch(event())[Symbol.asyncIterator]()
+    await Promise.all([first.next(), second.next()])
+    const firstPending = first.next()
+    const secondPending = second.next()
+    cancelled.abort('subscriber stopped')
+    await expect(firstPending).rejects.toMatchObject({
+      name: 'AbortError',
+      message: 'subscriber stopped'
+    })
+    expect(handlerAborted).not.toHaveBeenCalled()
+    release.resolve()
+    await expect(secondPending).resolves.toMatchObject({ value: { actionId: 'action-2' } })
+    await expect(second.next()).resolves.toEqual({ done: true, value: undefined })
+    expect(handlerAborted).not.toHaveBeenCalled()
+  })
+
+  it('detaches an early-returning subscriber while another shared subscriber completes', async () => {
+    const kernel = new AgentKernel()
+    const release = deferred()
+    const handlerAborted = vi.fn()
+    kernel.registerActionHandler('test.requested', async function* (_event, context) {
+      context.signal.addEventListener('abort', handlerAborted, { once: true })
+      yield { actionId: 'action-1', type: 'test.started', payload: null }
+      await release.promise
+      yield { actionId: 'action-2', type: 'test.done', payload: null }
+    })
+
+    const first = kernel.dispatch(event())[Symbol.asyncIterator]()
+    const second = kernel.dispatch(event())[Symbol.asyncIterator]()
+    await Promise.all([first.next(), second.next()])
+    const secondPending = second.next()
+    await first.return?.()
+    expect(handlerAborted).not.toHaveBeenCalled()
+    release.resolve()
+    await expect(secondPending).resolves.toMatchObject({ value: { actionId: 'action-2' } })
+    await expect(second.next()).resolves.toEqual({ done: true, value: undefined })
+  })
+
+  it('snapshots handler input and defensively clones streamed and replayed actions', async () => {
+    const kernel = new AgentKernel()
+    let handlerEventPayload: unknown
+    kernel.registerActionHandler('test.requested', (received) => {
+      handlerEventPayload = received.payload
+      ;(received.payload as { value: number }).value = 99
+      return actionsFromArray([
+        { actionId: 'action-1', type: 'test.done', payload: { nested: { value: 1 } } }
+      ])
+    })
+    const input = event()
+    const first = await collect(kernel.dispatch(input))
+    ;(input.payload as { value: number }).value = 42
+    ;(first[0].payload as { nested: { value: number } }).nested.value = 77
+
+    const replay = await collect(kernel.dispatch(event()))
+    expect(handlerEventPayload).toEqual({ value: 99 })
+    expect(replay).toEqual([
+      { actionId: 'action-1', type: 'test.done', payload: { nested: { value: 1 } } }
+    ])
+  })
+
+  it('joins concurrent duplicates and replays the same successful actions', async () => {
+    const kernel = new AgentKernel()
+    const release = deferred()
+    const handler = vi.fn(async function* () {
+      yield { actionId: 'action-1', type: 'test.first', payload: null }
+      await release.promise
+      yield { actionId: 'action-2', type: 'test.second', payload: null }
+    })
+    kernel.registerActionHandler('test.requested', handler)
+
+    const first = collect(kernel.dispatch(event()))
+    const second = collect(kernel.dispatch(event()))
+    release.resolve()
+    const expected = [
+      { actionId: 'action-1', type: 'test.first', payload: null },
+      { actionId: 'action-2', type: 'test.second', payload: null }
+    ]
+    await expect(first).resolves.toEqual(expected)
+    await expect(second).resolves.toEqual(expected)
+    await expect(collect(kernel.dispatch(event()))).resolves.toEqual(expected)
+    expect(handler).toHaveBeenCalledOnce()
+  })
+
+  it('shares a failure with concurrent subscribers and retries after they detach', async () => {
+    const kernel = new AgentKernel()
+    const release = deferred()
+    const failure = new Error('handler failed')
+    let attempt = 0
+    const handler = vi.fn(async function* () {
+      await release.promise
+      if (attempt++ === 0) throw failure
+      yield { actionId: 'retry-action', type: 'test.done', payload: null }
+    })
+    kernel.registerActionHandler('test.requested', handler)
+
+    const first = collect(kernel.dispatch(event()))
+    const second = collect(kernel.dispatch(event()))
+    release.resolve()
+    await expect(first).rejects.toBe(failure)
+    await expect(second).rejects.toBe(failure)
+    await expect(collect(kernel.dispatch(event()))).resolves.toEqual([
+      { actionId: 'retry-action', type: 'test.done', payload: null }
+    ])
+    expect(handler).toHaveBeenCalledTimes(2)
+  })
+
+  it('allows the same event ID to retry after its only subscriber aborts', async () => {
+    const kernel = new AgentKernel()
+    let attempt = 0
+    const handler = vi.fn(async function* (_event, context) {
+      if (attempt++ === 0) {
+        await new Promise<void>((_resolve, reject) => {
+          context.signal.addEventListener('abort', () => reject(context.signal.reason), {
+            once: true
+          })
+        })
+      }
+      yield { actionId: 'retry-action', type: 'test.done', payload: null }
+    })
+    kernel.registerActionHandler('test.requested', handler)
+
+    const controller = new AbortController()
+    const first = collect(kernel.dispatch(event(), controller.signal))
+    controller.abort('cancel first attempt')
+    await expect(first).rejects.toMatchObject({ name: 'AbortError' })
+    await vi.waitFor(() => expect(handler).toHaveBeenCalledOnce())
+    await expect(collect(kernel.dispatch(event()))).resolves.toEqual([
+      { actionId: 'retry-action', type: 'test.done', payload: null }
+    ])
+    expect(handler).toHaveBeenCalledTimes(2)
+  })
+
+  it('validates events and handler outputs', async () => {
+    const kernel = new AgentKernel()
+    kernel.registerActionHandler('test.requested', () =>
+      actionsFromArray([{ actionId: '', type: 'test.done', payload: null }])
+    )
+
+    expect(() => kernel.dispatch({ ...event(), eventId: '' })).toThrow('eventId is required')
+    expect(() => kernel.dispatch({ ...event(), type: '' })).toThrow('type is required')
+    expect(() => kernel.dispatch({ ...event(), createdAt: Number.NaN })).toThrow(
+      'createdAt must be finite and nonnegative'
+    )
+    expect(() => kernel.dispatch({ ...event(), createdAt: -1 })).toThrow(
+      'createdAt must be finite and nonnegative'
+    )
+    expect(() => kernel.dispatch({ ...event(), payload: { value: BigInt(1) } as never })).toThrow(
+      'payload must be JSON serializable'
+    )
+    await expect(collect(kernel.dispatch(event('bad-output')))).rejects.toThrow(
+      'actionId is required'
+    )
+
+    const wrongOutput = new AgentKernel()
+    wrongOutput.registerActionHandler('test.requested', (() => []) as never)
+    await expect(collect(wrongOutput.dispatch(event('wrong-output')))).rejects.toThrow(
+      'must return an AsyncIterable'
+    )
+  })
+
+  it('scopes action IDs to an event and rejects conflicting duplicates within an event', async () => {
+    const kernel = new AgentKernel()
+    kernel.registerActionHandler('test.requested', ({ eventId }) =>
+      actionsFromArray([{ actionId: 'shared', type: 'test.done', payload: { eventId } }])
+    )
+    await expect(collect(kernel.dispatch(event()))).resolves.toHaveLength(1)
+    await expect(collect(kernel.dispatch(event('event-2')))).resolves.toHaveLength(1)
+
+    const conflicting = new AgentKernel()
+    conflicting.registerActionHandler('test.requested', () =>
+      actionsFromArray([
+        { actionId: 'shared', type: 'test.done', payload: { value: 1 } },
+        { actionId: 'shared', type: 'test.done', payload: { value: 2 } }
+      ])
+    )
+    await expect(collect(conflicting.dispatch(event()))).rejects.toThrow(
+      'Conflicting Agent action already exists'
+    )
+  })
+
+  it('bounds completed dispatch retention and rejects conflicting event ID reuse while retained', async () => {
+    const kernel = new AgentKernel({ maxDispatchResults: 1 })
+    const handler = vi.fn(({ eventId }) =>
+      actionsFromArray([{ actionId: eventId, type: 'test.done', payload: null }])
+    )
+    kernel.registerActionHandler('test.requested', handler)
+
+    await collect(kernel.dispatch(event('event-1')))
+    await expect(
+      collect(kernel.dispatch({ ...event('event-1'), payload: { value: 2 } }))
+    ).rejects.toThrow('Conflicting Agent event already exists')
+    await collect(kernel.dispatch(event('event-2')))
+    await collect(kernel.dispatch(event('event-1')))
+    expect(handler).toHaveBeenCalledTimes(3)
+  })
+})

--- a/packages/app/src/main/agentKernel/agentKernel.ts
+++ b/packages/app/src/main/agentKernel/agentKernel.ts
@@ -1,7 +1,10 @@
 import { AssistantRoute } from '../assistantRuntime/types'
 import {
+  AgentAction,
+  AgentActionHandler,
   AgentCapabilityDescriptor,
   AgentCapabilityRegistry,
+  AgentEvent,
   AgentMasterRunSpec,
   AgentOrchestrationEvent,
   AgentOrchestrationRun,
@@ -15,6 +18,7 @@ import {
   AgentToolRegistration,
   buildAgentSessionIdentity,
   createAgentToolInvocationResult,
+  isJsonValue,
   normalizeAgentRoute,
   throwIfAborted
 } from '@shared/agent'
@@ -28,6 +32,7 @@ export type AgentKernelRetentionPolicy = {
   maxEvents?: number
   maxTerminalRuns?: number
   maxInactiveSessions?: number
+  maxDispatchResults?: number
 }
 
 type ResolvedAgentKernelRetentionPolicy = Required<AgentKernelRetentionPolicy>
@@ -35,10 +40,25 @@ type ResolvedAgentKernelRetentionPolicy = Required<AgentKernelRetentionPolicy>
 export const DEFAULT_AGENT_KERNEL_RETENTION_POLICY: Readonly<ResolvedAgentKernelRetentionPolicy> = {
   maxEvents: 10_000,
   maxTerminalRuns: 1_000,
-  maxInactiveSessions: 1_000
+  maxInactiveSessions: 1_000,
+  maxDispatchResults: 1_000
+}
+
+type DispatchRecord = {
+  eventFingerprint: string
+  actions: AgentAction[]
+  actionFingerprints: Map<string, string>
+  controller: AbortController
+  waiters: Set<() => void>
+  activeSubscribers: number
+  started: boolean
+  completed: boolean
+  error?: unknown
 }
 
 const now = (): number => Date.now()
+
+const cloneJsonCompatible = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T
 
 const normalizeRunStatus = (status?: AgentRunStatus): AgentRunStatus => status || 'pending'
 
@@ -92,6 +112,8 @@ export class AgentKernel {
   private readonly sessions = new Map<string, SessionRegistration>()
   private readonly runs = new Map<string, AgentOrchestrationRun>()
   private readonly events: AgentOrchestrationEvent[] = []
+  private readonly actionHandlers = new Map<string, AgentActionHandler>()
+  private readonly dispatchRecords = new Map<string, DispatchRecord>()
   private readonly retention: ResolvedAgentKernelRetentionPolicy
 
   constructor(retention: AgentKernelRetentionPolicy = {}) {
@@ -107,6 +129,10 @@ export class AgentKernel {
       maxInactiveSessions: normalizeRetentionLimit(
         retention.maxInactiveSessions,
         DEFAULT_AGENT_KERNEL_RETENTION_POLICY.maxInactiveSessions
+      ),
+      maxDispatchResults: normalizeRetentionLimit(
+        retention.maxDispatchResults,
+        DEFAULT_AGENT_KERNEL_RETENTION_POLICY.maxDispatchResults
       )
     }
   }
@@ -170,6 +196,231 @@ export class AgentKernel {
 
   listCapabilities(): AgentCapabilityDescriptor[] {
     return this.capabilities.snapshot()
+  }
+
+  registerActionHandler(type: string, handler: AgentActionHandler): () => void {
+    const normalizedType = String(type || '').trim()
+    if (!normalizedType) throw new Error('Agent action handler type is required.')
+    if (this.actionHandlers.has(normalizedType)) {
+      throw new Error(`An Agent action handler is already registered for "${normalizedType}".`)
+    }
+    this.actionHandlers.set(normalizedType, handler)
+    return () => {
+      if (this.actionHandlers.get(normalizedType) === handler)
+        this.actionHandlers.delete(normalizedType)
+    }
+  }
+
+  dispatch(event: AgentEvent, signal?: AbortSignal): AsyncIterable<AgentAction> {
+    this.validateEvent(event)
+    throwIfAborted(signal)
+    const eventSnapshot = cloneJsonCompatible(event)
+    const eventFingerprint = JSON.stringify(eventSnapshot)
+    return {
+      [Symbol.asyncIterator]: () =>
+        this.iterateDispatch(eventSnapshot, eventFingerprint, signal)[Symbol.asyncIterator]()
+    }
+  }
+
+  private async *iterateDispatch(
+    eventSnapshot: AgentEvent,
+    eventFingerprint: string,
+    signal?: AbortSignal
+  ): AsyncIterable<AgentAction> {
+    let record = this.dispatchRecords.get(eventSnapshot.eventId)
+    if (record && record.eventFingerprint !== eventFingerprint) {
+      throw new Error(
+        `Conflicting Agent event already exists for eventId "${eventSnapshot.eventId}".`
+      )
+    }
+    if (!record) {
+      const handler = this.actionHandlers.get(eventSnapshot.type)
+      if (!handler) {
+        throw new Error(`No Agent action handler has been registered for "${eventSnapshot.type}".`)
+      }
+      record = {
+        eventFingerprint,
+        actions: [],
+        actionFingerprints: new Map(),
+        controller: new AbortController(),
+        waiters: new Set(),
+        activeSubscribers: 0,
+        started: false,
+        completed: false
+      }
+      this.dispatchRecords.set(eventSnapshot.eventId, record)
+    }
+    if (!record.started) {
+      const handler = this.actionHandlers.get(eventSnapshot.type)
+      if (!handler) {
+        this.dispatchRecords.delete(eventSnapshot.eventId)
+        throw new Error(`No Agent action handler has been registered for "${eventSnapshot.type}".`)
+      }
+      record.started = true
+      this.startDispatch(eventSnapshot, handler, record)
+    }
+    yield* this.subscribeToDispatch(record, signal)
+  }
+
+  private validateEvent(event: AgentEvent): void {
+    if (!event || typeof event !== 'object') throw new TypeError('Agent event is required.')
+    if (!String(event.eventId || '').trim()) throw new TypeError('Agent event eventId is required.')
+    if (!String(event.type || '').trim()) throw new TypeError('Agent event type is required.')
+    if (!Number.isFinite(event.createdAt) || event.createdAt < 0) {
+      throw new TypeError(
+        `Agent event "${event.eventId}" createdAt must be finite and nonnegative.`
+      )
+    }
+    if (!isJsonValue(event.payload)) {
+      throw new TypeError(`Agent event "${event.eventId}" payload must be JSON serializable.`)
+    }
+    if (event.provenance !== undefined && !isJsonValue(event.provenance)) {
+      throw new TypeError(`Agent event "${event.eventId}" provenance must be JSON serializable.`)
+    }
+    for (const [name, value] of [
+      ['correlationId', event.correlationId],
+      ['sessionId', event.sessionId],
+      ['agentId', event.agentId],
+      ['provenance.source', event.provenance?.source]
+    ] as const) {
+      if (value !== undefined && !String(value).trim()) {
+        throw new TypeError(`Agent event ${name} must be non-empty when provided.`)
+      }
+    }
+  }
+
+  private validateAction(action: AgentAction): void {
+    if (!action || typeof action !== 'object') throw new TypeError('Agent action is required.')
+    if (!String(action.actionId || '').trim())
+      throw new TypeError('Agent action actionId is required.')
+    if (!String(action.type || '').trim()) throw new TypeError('Agent action type is required.')
+    if (!isJsonValue(action.payload)) {
+      throw new TypeError(`Agent action "${action.actionId}" payload must be JSON serializable.`)
+    }
+    if (action.provenance !== undefined && !isJsonValue(action.provenance)) {
+      throw new TypeError(`Agent action "${action.actionId}" provenance must be JSON serializable.`)
+    }
+  }
+
+  private startDispatch(
+    event: AgentEvent,
+    handler: AgentActionHandler,
+    record: DispatchRecord
+  ): void {
+    void (async () => {
+      try {
+        const output = handler(cloneJsonCompatible(event), { signal: record.controller.signal })
+        if (!output || typeof output[Symbol.asyncIterator] !== 'function') {
+          throw new TypeError(
+            `Agent action handler for "${event.type}" must return an AsyncIterable.`
+          )
+        }
+        for await (const action of output) {
+          throwIfAborted(record.controller.signal)
+          this.validateAction(action)
+          const actionSnapshot = cloneJsonCompatible(action)
+          const fingerprint = JSON.stringify(actionSnapshot)
+          const existing = record.actionFingerprints.get(actionSnapshot.actionId)
+          if (existing !== undefined) {
+            if (existing !== fingerprint) {
+              throw new Error(
+                `Conflicting Agent action already exists for actionId "${actionSnapshot.actionId}" in event "${event.eventId}".`
+              )
+            }
+            continue
+          }
+          record.actionFingerprints.set(actionSnapshot.actionId, fingerprint)
+          record.actions.push(actionSnapshot)
+          this.notifyDispatchWaiters(record)
+        }
+      } catch (error) {
+        record.error = error
+      } finally {
+        record.completed = true
+        this.notifyDispatchWaiters(record)
+        this.deleteRetryableDispatchRecord(event.eventId, record)
+        this.pruneDispatchRecords()
+      }
+    })()
+  }
+
+  private subscribeToDispatch(
+    record: DispatchRecord,
+    signal?: AbortSignal
+  ): AsyncIterable<AgentAction> {
+    const deleteRetryableRecord = (): void => this.deleteRetryableDispatchRecordByReference(record)
+    const pruneDispatchRecords = (): void => this.pruneDispatchRecords()
+    return {
+      [Symbol.asyncIterator]: async function* () {
+        let index = 0
+        const abort = (): void => {
+          const waiters = [...record.waiters]
+          record.waiters.clear()
+          waiters.forEach((resolve) => resolve())
+        }
+        record.activeSubscribers += 1
+        signal?.addEventListener('abort', abort, { once: true })
+        try {
+          while (true) {
+            throwIfAborted(signal)
+            while (index < record.actions.length) {
+              yield cloneJsonCompatible(record.actions[index++])
+            }
+            if (record.completed) {
+              if (record.error !== undefined) throw record.error
+              return
+            }
+            await new Promise<void>((resolve) => record.waiters.add(resolve))
+          }
+        } finally {
+          signal?.removeEventListener('abort', abort)
+          record.activeSubscribers -= 1
+          if (!record.completed && record.activeSubscribers === 0) {
+            record.controller.abort(signal?.reason)
+          }
+          if (record.completed && record.error !== undefined && record.activeSubscribers === 0) {
+            deleteRetryableRecord()
+          }
+          if (record.completed && record.activeSubscribers === 0) pruneDispatchRecords()
+        }
+      }
+    }
+  }
+
+  private deleteRetryableDispatchRecord(eventId: string, record: DispatchRecord): void {
+    if (
+      record.completed &&
+      record.error !== undefined &&
+      record.activeSubscribers === 0 &&
+      this.dispatchRecords.get(eventId) === record
+    ) {
+      this.dispatchRecords.delete(eventId)
+    }
+  }
+
+  private deleteRetryableDispatchRecordByReference(record: DispatchRecord): void {
+    for (const [eventId, candidate] of this.dispatchRecords) {
+      if (candidate === record) {
+        this.deleteRetryableDispatchRecord(eventId, record)
+        return
+      }
+    }
+  }
+
+  private notifyDispatchWaiters(record: DispatchRecord): void {
+    const waiters = [...record.waiters]
+    record.waiters.clear()
+    waiters.forEach((resolve) => resolve())
+  }
+
+  private pruneDispatchRecords(): void {
+    const completed = [...this.dispatchRecords.entries()].filter(
+      ([, record]) => record.completed && record.activeSubscribers === 0
+    )
+    const overflow = completed.length - this.retention.maxDispatchResults
+    for (let index = 0; index < overflow; index += 1) {
+      this.dispatchRecords.delete(completed[index][0])
+    }
   }
 
   removeCapability(capabilityId: string): boolean {
@@ -357,6 +608,12 @@ export class AgentKernel {
     this.sessions.clear()
     this.runs.clear()
     this.events.length = 0
+    this.actionHandlers.clear()
+    for (const record of this.dispatchRecords.values()) {
+      record.controller.abort('Kernel cleared.')
+      this.notifyDispatchWaiters(record)
+    }
+    this.dispatchRecords.clear()
   }
 
   private appendEvent(event: AgentOrchestrationEvent): void {

--- a/packages/app/src/main/api/svcDialogImpl.test.ts
+++ b/packages/app/src/main/api/svcDialogImpl.test.ts
@@ -1,4 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { showMessageBoxMock, showOpenDialogMock, getFocusedWindowMock } = vi.hoisted(() => ({
   showMessageBoxMock: vi.fn(),
@@ -18,9 +21,23 @@ vi.mock('electron', () => ({
 
 import { DialogSvcImpl } from './svcDialogImpl'
 import {
+  clearScopedLocalMediaPathsForTest,
+  resolveAuthorizedLocalMediaPath
+} from '../localMediaAccess'
+import {
   clearTrustedLocalFileSelectionsForTest,
   consumeTrustedLocalFileSelection
 } from './trustedFileSelection'
+
+const cleanupPaths: string[] = []
+
+function makeTempDir(prefix: string): string {
+  const tempRoot = os.tmpdir()
+  fs.mkdirSync(tempRoot, { recursive: true })
+  const directory = fs.mkdtempSync(path.join(tempRoot, prefix))
+  cleanupPaths.push(directory)
+  return directory
+}
 
 describe('DialogSvcImpl', () => {
   beforeEach(() => {
@@ -28,6 +45,11 @@ describe('DialogSvcImpl', () => {
     showOpenDialogMock.mockReset()
     getFocusedWindowMock.mockReset()
     clearTrustedLocalFileSelectionsForTest()
+    clearScopedLocalMediaPathsForTest()
+  })
+
+  afterEach(() => {
+    cleanupPaths.splice(0).forEach((target) => fs.rmSync(target, { recursive: true, force: true }))
   })
 
   it('remembers file selections as trusted local file paths', async () => {
@@ -46,6 +68,41 @@ describe('DialogSvcImpl', () => {
     await svc.showOpenDialog({ properties: ['openDirectory'] })
 
     expect(() => consumeTrustedLocalFileSelection('C:/models')).toThrow('trusted dialog')
+  })
+
+  it('authorizes only descendants of a main-process directory picker result for local media', async () => {
+    const selectedDirectory = makeTempDir('magicpot-dialog-selected-')
+    const outsideDirectory = makeTempDir('magicpot-dialog-outside-')
+    const selectedFile = path.join(selectedDirectory, 'nested', 'image.png')
+    const outsideFile = path.join(outsideDirectory, 'image.png')
+    fs.mkdirSync(path.dirname(selectedFile), { recursive: true })
+    fs.writeFileSync(selectedFile, 'selected')
+    fs.writeFileSync(outsideFile, 'outside')
+    showOpenDialogMock.mockResolvedValue({ canceled: false, filePaths: [selectedDirectory] })
+
+    const svc = new DialogSvcImpl()
+    await svc.showOpenDialog({ properties: ['openDirectory'] })
+
+    expect(resolveAuthorizedLocalMediaPath(selectedFile, [])).toBe(
+      path.resolve(fs.realpathSync.native(selectedFile))
+    )
+    expect(resolveAuthorizedLocalMediaPath(outsideFile, [])).toBeNull()
+    expect(() => consumeTrustedLocalFileSelection(selectedDirectory)).toThrow('trusted dialog')
+  })
+
+  it('does not grant local-media directory access for canceled or mixed picker results', async () => {
+    const directory = makeTempDir('magicpot-dialog-not-authorized-')
+    const filePath = path.join(directory, 'image.png')
+    fs.writeFileSync(filePath, 'image')
+    const svc = new DialogSvcImpl()
+
+    showOpenDialogMock.mockResolvedValueOnce({ canceled: true, filePaths: [directory] })
+    await svc.showOpenDialog({ properties: ['openDirectory'] })
+    expect(resolveAuthorizedLocalMediaPath(filePath, [])).toBeNull()
+
+    showOpenDialogMock.mockResolvedValueOnce({ canceled: false, filePaths: [directory] })
+    await svc.showOpenDialog({ properties: ['openFile', 'openDirectory'] })
+    expect(resolveAuthorizedLocalMediaPath(filePath, [])).toBeNull()
   })
 
   it('uses the focused window as the parent for message boxes', async () => {

--- a/packages/app/src/main/api/svcDialogImpl.ts
+++ b/packages/app/src/main/api/svcDialogImpl.ts
@@ -10,7 +10,10 @@ import {
   dialog
 } from 'electron'
 import { rememberTrustedLocalFileSelections } from './trustedFileSelection'
-import { authorizeScopedLocalMediaPath } from '../localMediaAccess'
+import {
+  authorizeScopedLocalMediaDirectory,
+  authorizeScopedLocalMediaPath
+} from '../localMediaAccess'
 
 export class DialogSvcImpl implements DialogSvc {
   private getDialogParentWindow(): BrowserWindow | null {
@@ -21,9 +24,15 @@ export class DialogSvcImpl implements DialogSvc {
     const result = await dialog.showOpenDialog(options)
     const properties = options.properties || []
     const selectedFiles = properties.includes('openFile') && !properties.includes('openDirectory')
-    if (selectedFiles && !result.canceled && result.filePaths?.length) {
-      rememberTrustedLocalFileSelections(result.filePaths)
-      result.filePaths.forEach(authorizeScopedLocalMediaPath)
+    const selectedDirectories =
+      properties.includes('openDirectory') && !properties.includes('openFile')
+    if (!result.canceled && result.filePaths?.length) {
+      if (selectedFiles) {
+        rememberTrustedLocalFileSelections(result.filePaths)
+        result.filePaths.forEach(authorizeScopedLocalMediaPath)
+      } else if (selectedDirectories) {
+        result.filePaths.forEach(authorizeScopedLocalMediaDirectory)
+      }
     }
     return result
   }

--- a/packages/app/src/main/api/svcFsImpl.test.ts
+++ b/packages/app/src/main/api/svcFsImpl.test.ts
@@ -1,6 +1,13 @@
 import fs from 'fs'
 import path from 'path'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  app: {
+    getAppPath: vi.fn(() => process.cwd()),
+    getPath: vi.fn((name: string) => path.join(process.cwd(), '.magicpot-trash', name))
+  }
+}))
 import {
   fsSvcDef,
   MAX_FULL_FILE_BYTES,
@@ -9,6 +16,10 @@ import {
 } from '@shared/api/svcFs'
 import { validateServiceValue } from '@shared/api/apiUtils/serviceValidation'
 import { FsSvcImpl } from './svcFsImpl'
+import {
+  authorizeScopedLocalMediaDirectory,
+  clearScopedLocalMediaPathsForTest
+} from '../localMediaAccess'
 
 const getTestRoot = (): string =>
   path.join(
@@ -29,7 +40,26 @@ describe('FsSvcImpl', () => {
   })
 
   afterEach(() => {
+    clearScopedLocalMediaPathsForTest()
     fs.rmSync(testRoot, { recursive: true, force: true })
+  })
+
+  describe('readImageFromPath authorization', () => {
+    it('rejects arbitrary renderer paths but permits images under a trusted directory selection', async () => {
+      const fullPath = path.join(testRoot, 'nested', 'image.png')
+      fs.mkdirSync(path.dirname(fullPath), { recursive: true })
+      fs.writeFileSync(fullPath, Buffer.from([10, 20, 30]))
+
+      await expect(service.readImageFromPath({ fullPath })).rejects.toThrow(
+        'Local image path is not authorized'
+      )
+
+      expect(authorizeScopedLocalMediaDirectory(testRoot)).toBe(true)
+      await expect(service.readImageFromPath({ fullPath })).resolves.toEqual({
+        image: new Uint8Array([10, 20, 30]),
+        filename: 'image.png'
+      })
+    })
   })
 
   describe('readFileFromPath', () => {

--- a/packages/app/src/main/api/svcFsImpl.ts
+++ b/packages/app/src/main/api/svcFsImpl.ts
@@ -31,6 +31,7 @@ import fs from 'fs/promises'
 import * as path from 'path'
 import { getCurrentUserDataDirectoryState } from '../config/userDataDirectory'
 import { app } from 'electron'
+import { resolveAuthorizedLocalMediaPath } from '../localMediaAccess'
 import { execFile } from 'child_process'
 import { promisify } from 'util'
 
@@ -342,7 +343,17 @@ export class FsSvcImpl implements FsSvc {
   }
 
   readImageFromPath = async (req: ReadImageFromPathReq): Promise<ReadImageFromPathResp> => {
-    const { fullPath } = req
+    const storageState = getCurrentUserDataDirectoryState()
+    const fullPath = resolveAuthorizedLocalMediaPath(req.fullPath, [
+      app.getPath('userData'),
+      path.join(app.getPath('temp'), 'magicpot-local-media'),
+      storageState.projectRoot,
+      storageState.autoSaveRoot
+    ])
+
+    if (!fullPath) {
+      throw new Error('Local image path is not authorized')
+    }
 
     if (!(await pathExists(fullPath))) {
       throw new Error(`File not found: ${fullPath}`)

--- a/packages/app/src/main/appRuntime.test.ts
+++ b/packages/app/src/main/appRuntime.test.ts
@@ -39,12 +39,25 @@ vi.mock('@electron-toolkit/utils', () => ({
   }
 }))
 
+const { initializeLocalMediaAccessMock } = vi.hoisted(() => ({
+  initializeLocalMediaAccessMock: vi.fn()
+}))
+
+vi.mock('./localMediaAccess', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./localMediaAccess')>()
+  return { ...actual, initializeLocalMediaAccess: initializeLocalMediaAccessMock }
+})
+
 vi.mock('./testWindowRuntime', () => ({
   getTestWindowPolicy: vi.fn()
 }))
 
 import { protocol } from 'electron'
-import { initializeMainProcessRuntime, withLocalMediaCorsHeaders } from './appRuntime'
+import {
+  initializeMainProcessRuntime,
+  setupReadyAppRuntime,
+  withLocalMediaCorsHeaders
+} from './appRuntime'
 
 describe('appRuntime local-media protocol helpers', () => {
   it('registers local-media as a CORS-enabled privileged scheme without bypassing CSP', () => {
@@ -69,6 +82,22 @@ describe('appRuntime local-media protocol helpers', () => {
         }
       ).mock.calls[0][0][0].privileges.bypassCSP
     ).toBeUndefined()
+  })
+
+  it('loads durable local-media grants before registering the protocol handler', async () => {
+    const order: string[] = []
+    initializeLocalMediaAccessMock.mockImplementationOnce(() => order.push('grants'))
+    vi.mocked(protocol.handle).mockImplementationOnce(() => {
+      order.push('protocol')
+    })
+
+    await setupReadyAppRuntime()
+
+    expect(initializeLocalMediaAccessMock).toHaveBeenCalledWith(
+      expect.stringMatching(/userData[\\/]local-media-grants\.json$/)
+    )
+    expect(protocol.handle).toHaveBeenCalledWith('local-media', expect.any(Function))
+    expect(order).toEqual(['grants', 'protocol'])
   })
 
   it('adds CORS headers while preserving the proxied local file response metadata', async () => {

--- a/packages/app/src/main/appRuntime.ts
+++ b/packages/app/src/main/appRuntime.ts
@@ -4,7 +4,11 @@ import { getTestWindowPolicy } from './testWindowRuntime'
 import path from 'node:path'
 import { type TestUiPolicy } from './testUiPolicy'
 import { normalizeLocalFilePath, toFileUrl } from './utils/localFileUrl'
-import { hasLocalMediaTraversal, resolveAuthorizedLocalMediaPath } from './localMediaAccess'
+import {
+  hasLocalMediaTraversal,
+  initializeLocalMediaAccess,
+  resolveAuthorizedLocalMediaPath
+} from './localMediaAccess'
 import { getCurrentUserDataDirectoryState } from './config/userDataDirectory'
 
 const silentErrorCodes = [
@@ -166,7 +170,7 @@ function getLocalMediaAllowedRoots(): string[] {
   const storageState = getCurrentUserDataDirectoryState()
   return [
     app.getPath('userData'),
-    app.getPath('temp'),
+    path.join(app.getPath('temp'), 'magicpot-local-media'),
     storageState.projectRoot,
     storageState.autoSaveRoot
   ].map((root) => path.resolve(root))
@@ -222,6 +226,7 @@ export function initializeMainProcessRuntime(getMainWindow: () => BrowserWindow 
 }
 
 export async function setupReadyAppRuntime(): Promise<void> {
+  initializeLocalMediaAccess(path.join(app.getPath('userData'), 'local-media-grants.json'))
   protocol.handle('local-media', handleLocalMediaRequest)
   console.log('[App] local-media:// 协议已注册')
 

--- a/packages/app/src/main/assistantRuntime/executionAdapter.test.ts
+++ b/packages/app/src/main/assistantRuntime/executionAdapter.test.ts
@@ -1,0 +1,240 @@
+import { beforeEach } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+import { createToolResultAction, ToolInvokeAction, ToolResultAction } from '@shared/agent'
+
+const bridge = vi.hoisted(() => ({
+  invoke: vi.fn(),
+  sync: vi.fn()
+}))
+
+vi.mock('../agentKernel/toolBridge', () => ({
+  invokeAssistantToolViaKernel: bridge.invoke,
+  syncAssistantToolsWithAgentKernel: bridge.sync
+}))
+
+vi.mock('electron', () => ({
+  app: { isPackaged: false, getPath: () => process.cwd() },
+  BrowserWindow: class {},
+  ipcMain: { handle: vi.fn(), on: vi.fn() }
+}))
+
+import {
+  AssistantExecutionAdapter,
+  buildAssistantToolInvokeAction,
+  validateAssistantToolInvokeAction
+} from './executionAdapter'
+
+describe('AssistantExecutionAdapter tool actions', () => {
+  it('builds stable action and invocation IDs from run, index, name, and canonical args', () => {
+    const first = buildAssistantToolInvokeAction({
+      runId: 'run-1',
+      toolCallIndex: 2,
+      toolName: 'demo.echo',
+      args: { nested: { b: true, a: 1 }, text: 'hello' },
+      requestedAt: 10
+    })
+    const reordered = buildAssistantToolInvokeAction({
+      runId: 'run-1',
+      toolCallIndex: 2,
+      toolName: 'demo.echo',
+      args: { text: 'hello', nested: { a: 1, b: true } },
+      requestedAt: 20
+    })
+
+    expect(first.actionId).toBe(reordered.actionId)
+    expect(first.payload.invocationId).toBe(first.actionId)
+    expect(first.payload.idempotencyKey).toBe(first.actionId)
+    expect(reordered.payload.requestedAt).toBe(20)
+  })
+
+  it('rejects non-JSON invocation args and result metadata by construction', () => {
+    expect(() =>
+      buildAssistantToolInvokeAction({
+        runId: 'run-1',
+        toolCallIndex: 0,
+        toolName: 'demo.echo',
+        args: { invalid: undefined },
+        requestedAt: 10
+      })
+    ).toThrow('Tool invocation args must be a JSON object.')
+
+    expect(() =>
+      createToolResultAction({
+        actionId: 'result-1',
+        payload: {
+          invocationId: 'invocation-1',
+          toolName: 'demo.echo',
+          ok: true,
+          metadata: { invalid: undefined } as never,
+          startedAt: 10,
+          finishedAt: 10,
+          durationMs: 0
+        }
+      })
+    ).toThrow('Tool result metadata must be a JSON object.')
+  })
+})
+
+type ToolCallRequest = Parameters<AssistantExecutionAdapter['callTool']>[2]
+
+const makeRequest = (): ToolCallRequest =>
+  ({
+    config: {},
+    route: { channel: 'test', conversationId: 'conversation' },
+    sessionStore: {},
+    taskState: {}
+  }) as unknown as ToolCallRequest
+
+describe('AssistantExecutionAdapter tool lifecycle', () => {
+  beforeEach(() => {
+    bridge.invoke.mockReset()
+    bridge.sync.mockReset()
+  })
+
+  it('callTool observes invoke then success, preserves original metadata, and calls the kernel once', async () => {
+    const originalMetadata = { safe: true, optional: undefined }
+    bridge.invoke.mockResolvedValue({ content: 'ok', metadata: originalMetadata })
+    const actions: Array<ToolInvokeAction | ToolResultAction> = []
+    const adapter = new AssistantExecutionAdapter({
+      chatService: { chat: vi.fn() },
+      onAgentAction: (action) => {
+        actions.push(action)
+        if (action.type === 'tool.result' && action.payload.metadata) {
+          action.payload.metadata.safe = false
+        }
+      }
+    })
+
+    const result = await adapter.callTool('demo.echo', { value: 1 }, makeRequest())
+    expect(result).toEqual({
+      content: 'ok',
+      metadata: { safe: true, optional: undefined }
+    })
+    expect(result.metadata).toBe(originalMetadata)
+    expect(originalMetadata.safe).toBe(true)
+    expect(actions.map((action) => action.type)).toEqual(['tool.invoke', 'tool.result'])
+    expect((actions[1] as ToolResultAction).payload).toMatchObject({
+      ok: true,
+      metadata: { safe: false }
+    })
+    expect(bridge.invoke).toHaveBeenCalledTimes(1)
+  })
+
+  it('callTool preserves cooperative checkpoint and enter/leave hooks', async () => {
+    bridge.invoke.mockResolvedValue({ content: 'ok' })
+    const leave = vi.fn()
+    const checkpoint = vi.fn(async () => undefined)
+    const enter = vi.fn(() => leave)
+    const request = {
+      ...makeRequest(),
+      cooperativeExecution: { checkpoint, enter }
+    } as Parameters<AssistantExecutionAdapter['callTool']>[2]
+    const adapter = new AssistantExecutionAdapter({ chatService: { chat: vi.fn() } })
+
+    await adapter.callTool('demo.echo', {}, request)
+
+    expect(checkpoint).toHaveBeenCalledWith('tool-invocation')
+    expect(enter).toHaveBeenCalledWith('tool-invocation')
+    expect(leave).toHaveBeenCalledTimes(1)
+  })
+
+  it('callTool observes a failed result and rethrows the original error', async () => {
+    const original = Object.assign(new Error('broken'), { code: 'BROKEN' })
+    bridge.invoke.mockRejectedValue(original)
+    const actions: Array<ToolInvokeAction | ToolResultAction> = []
+    const adapter = new AssistantExecutionAdapter({
+      chatService: { chat: vi.fn() },
+      onAgentAction: (action) => {
+        actions.push(action)
+      }
+    })
+
+    await expect(adapter.callTool('demo.echo', {}, makeRequest())).rejects.toBe(original)
+    expect(actions.map((action) => action.type)).toEqual(['tool.invoke', 'tool.result'])
+    expect((actions[1] as ToolResultAction).payload).toMatchObject({
+      ok: false,
+      error: { message: 'broken', code: 'BROKEN' }
+    })
+  })
+
+  it('/tool observes invoke then successful result in order', async () => {
+    bridge.invoke.mockResolvedValue({ content: 'from tool' })
+    const actions: Array<ToolInvokeAction | ToolResultAction> = []
+    const adapter = new AssistantExecutionAdapter({
+      chatService: { chat: vi.fn() },
+      onAgentAction: (action) => {
+        actions.push(action)
+      }
+    })
+
+    const result = await adapter.run({
+      ...makeRequest(),
+      runId: 'run-tool',
+      req: { text: '/tool demo.echo {"value":1}' },
+      messages: []
+    } as never)
+
+    expect(result.reply.content).toBe('from tool')
+    expect(actions.map((action) => action.type)).toEqual(['tool.invoke', 'tool.result'])
+    expect(bridge.invoke).toHaveBeenCalledTimes(1)
+  })
+  it('allowlist denial observes invoke then failure without calling the kernel', async () => {
+    const actions: Array<ToolInvokeAction | ToolResultAction> = []
+    const adapter = new AssistantExecutionAdapter({
+      chatService: { chat: vi.fn() },
+      onAgentAction: (action) => {
+        actions.push(action)
+      }
+    })
+
+    await expect(
+      adapter.callTool('demo.echo', {}, makeRequest(), { allowedToolNames: ['other.tool'] })
+    ).rejects.toThrow()
+    expect(actions.map((action) => action.type)).toEqual(['tool.invoke', 'tool.result'])
+    expect((actions[1] as ToolResultAction).payload.ok).toBe(false)
+    expect(bridge.invoke).not.toHaveBeenCalled()
+  })
+
+  it('rejects tampered deterministic identity before observation or execution', () => {
+    const descriptor = {
+      runId: 'run-1',
+      toolCallIndex: 0,
+      toolName: 'demo.echo',
+      args: { value: 1 },
+      requestedAt: 10
+    }
+    const action = buildAssistantToolInvokeAction(descriptor)
+    const tampered = { ...action, actionId: 'tampered' }
+
+    expect(() => validateAssistantToolInvokeAction(tampered, descriptor)).toThrow(
+      'trusted descriptor'
+    )
+  })
+
+  it('fails closed on proposed observer failure and never retries after terminal failure', async () => {
+    bridge.invoke.mockResolvedValue({ content: 'ok' })
+    const proposedFailure = new Error('observer unavailable')
+    const proposedAdapter = new AssistantExecutionAdapter({
+      chatService: { chat: vi.fn() },
+      onAgentAction: () => {
+        throw proposedFailure
+      }
+    })
+    await expect(proposedAdapter.callTool('demo.echo', {}, makeRequest())).rejects.toBe(
+      proposedFailure
+    )
+    expect(bridge.invoke).not.toHaveBeenCalled()
+
+    const terminalFailure = new Error('terminal observer unavailable')
+    const terminalAdapter = new AssistantExecutionAdapter({
+      chatService: { chat: vi.fn() },
+      onAgentAction: (action) => {
+        if (action.type === 'tool.result') throw terminalFailure
+      }
+    })
+    await expect(terminalAdapter.callTool('demo.echo', {}, makeRequest())).rejects.toBe(
+      terminalFailure
+    )
+    expect(bridge.invoke).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/app/src/main/assistantRuntime/executionAdapter.ts
+++ b/packages/app/src/main/assistantRuntime/executionAdapter.ts
@@ -1,4 +1,13 @@
+import { createHash } from 'node:crypto'
 import { ChatAttachment, ChatMessage, LLMChatResp, LLMProxySvc } from '@shared/api/svcLLMProxy'
+import {
+  createToolInvokeAction,
+  createToolResultAction,
+  isJsonValue,
+  JsonObject,
+  ToolInvokeAction,
+  ToolResultAction
+} from '@shared/agent'
 import { Config } from '@shared/config/config'
 import { AssistantSessionStore } from './sessionStore'
 import {
@@ -12,7 +21,7 @@ import {
   AssistantTaskGroupState,
   getAssistantSessionKey
 } from './types'
-import { AssistantToolRegistry } from './toolRegistry'
+import { AssistantToolCallResult, AssistantToolRegistry } from './toolRegistry'
 import {
   invokeAssistantToolViaKernel,
   syncAssistantToolsWithAgentKernel
@@ -26,6 +35,22 @@ import { assertAssistantToolAllowed, filterAssistantToolsByAllowlist } from './t
 type AssistantExecutionAdapterDeps = {
   chatService: Pick<LLMProxySvc, 'chat'>
   toolRegistry?: AssistantToolRegistry
+  onAgentAction?: (action: ToolInvokeAction | ToolResultAction) => void | Promise<void>
+}
+
+export type AssistantToolActionDescriptor = {
+  runId: string
+  toolCallIndex: number
+  toolName: string
+  args: Record<string, unknown>
+  requestedAt: number
+}
+
+type AssistantToolExecutionContext = Omit<
+  AssistantExecutionRequest,
+  'messages' | 'req' | 'runId' | 'profileId' | 'systemPrompt' | 'cooperativeExecution'
+> & {
+  cooperativeExecution?: AssistantExecutionRequest['cooperativeExecution']
 }
 
 type AssistantExecutionRequest = {
@@ -182,6 +207,82 @@ const buildExecutionMetadata = (
   ...(request.executionTraceLabel ? { executionTraceLabel: request.executionTraceLabel } : {})
 })
 
+const canonicalJson = (value: unknown): string => {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`
+  if (value && typeof value === 'object') {
+    return `{${Object.entries(value)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => `${JSON.stringify(key)}:${canonicalJson(entry)}`)
+      .join(',')}}`
+  }
+  return JSON.stringify(value)
+}
+
+const asJsonObject = (value: unknown, label: string): JsonObject => {
+  if (!isJsonValue(value) || value === null || Array.isArray(value)) {
+    throw new TypeError(`${label} must be a JSON object.`)
+  }
+  return value as JsonObject
+}
+
+export const buildAssistantToolInvokeAction = (options: {
+  runId: string
+  toolCallIndex: number
+  toolName: string
+  args: Record<string, unknown>
+  requestedAt?: number
+}): ToolInvokeAction => {
+  const toolName = cleanString(options.toolName)
+  if (!toolName) throw new TypeError('Tool name is required.')
+  const args = asJsonObject(options.args, 'Tool invocation args')
+  const digest = createHash('sha256')
+    .update(`${options.runId}\n${options.toolCallIndex}\n${toolName}\n${canonicalJson(args)}`)
+    .digest('hex')
+  const invocationId = `${options.runId}:tool:${options.toolCallIndex}:${digest.slice(0, 24)}`
+  return createToolInvokeAction({
+    actionId: invocationId,
+    correlationId: options.runId,
+    payload: {
+      invocationId,
+      toolName,
+      args,
+      requestedAt: options.requestedAt ?? Date.now(),
+      idempotencyKey: invocationId
+    }
+  })
+}
+
+export const validateAssistantToolInvokeAction = (
+  action: ToolInvokeAction,
+  descriptor: AssistantToolActionDescriptor
+): void => {
+  const expected = buildAssistantToolInvokeAction(descriptor)
+  if (canonicalJson(action) !== canonicalJson(expected)) {
+    throw new TypeError('Tool invocation action does not match its trusted descriptor.')
+  }
+}
+
+const toSafeError = (error: unknown): { message: string; code?: string } => ({
+  message: error instanceof Error ? error.message : 'Tool invocation failed.',
+  ...(error && typeof error === 'object' && 'code' in error && typeof error.code === 'string'
+    ? { code: error.code }
+    : {})
+})
+
+const toJsonMetadata = (metadata: Record<string, unknown> | undefined): JsonObject | undefined => {
+  if (metadata === undefined) return undefined
+  try {
+    const serialized = JSON.stringify(metadata)
+    if (serialized === undefined) return undefined
+    const parsed: unknown = JSON.parse(serialized)
+    return isJsonValue(parsed) && parsed !== null && !Array.isArray(parsed)
+      ? (parsed as JsonObject)
+      : undefined
+  } catch {
+    return undefined
+  }
+}
+
 const parseToolInvocation = (
   text?: string
 ): { toolName: string; args: Record<string, unknown> } | null => {
@@ -241,15 +342,106 @@ const toArtifactRef = (
 export class AssistantExecutionAdapter {
   private readonly chatService: Pick<LLMProxySvc, 'chat'>
   private readonly toolRegistry: AssistantToolRegistry
+  private readonly onAgentAction: NonNullable<AssistantExecutionAdapterDeps['onAgentAction']>
 
   constructor(deps: AssistantExecutionAdapterDeps) {
     this.chatService = deps.chatService
     this.toolRegistry = deps.toolRegistry || new AssistantToolRegistry()
+    this.onAgentAction = deps.onAgentAction || (() => undefined)
   }
 
   listTools(allowedToolNames?: string[] | null) {
     syncAssistantToolsWithAgentKernel(this.toolRegistry)
     return filterAssistantToolsByAllowlist(this.toolRegistry.listTools(), allowedToolNames)
+  }
+
+  async executeToolInvokeAction(
+    action: ToolInvokeAction,
+    descriptor: AssistantToolActionDescriptor,
+    request: AssistantToolExecutionContext,
+    allowedToolNames?: string[] | null
+  ): Promise<{ action: ToolResultAction; result: AssistantToolCallResult }> {
+    validateAssistantToolInvokeAction(action, descriptor)
+    const toolName = action.payload.toolName
+    const args = action.payload.args
+    await this.onAgentAction(action)
+    const startedAt = Date.now()
+    let leaveTool: (() => void) | undefined
+    let executionCompleted = false
+    try {
+      assertAssistantToolAllowed(toolName, allowedToolNames)
+      await request.cooperativeExecution?.checkpoint('tool-invocation')
+      leaveTool = request.cooperativeExecution?.enter('tool-invocation')
+      const result = await invokeAssistantToolViaKernel({
+        toolRegistry: this.toolRegistry,
+        toolName,
+        args,
+        signal: request.signal,
+        context: {
+          config: request.config,
+          route: request.route,
+          sessionStore: request.sessionStore,
+          taskState: request.taskState,
+          workspaceMemoryFile: request.workspaceMemoryFile,
+          workspaceTaskContextFile: request.workspaceTaskContextFile,
+          workspaceContextFile: request.workspaceContextFile,
+          workspacePinnedContextFile: request.workspacePinnedContextFile,
+          workspaceMetaFile: request.workspaceMetaFile,
+          workspaceRootDir: request.workspaceRootDir,
+          resumeRun: request.resumeRun,
+          resumeWorkflow: request.resumeWorkflow,
+          startTaskGroup: request.startTaskGroup,
+          progressTaskGroup: request.progressTaskGroup,
+          approveTaskGroup: request.approveTaskGroup,
+          exportTaskGroup: request.exportTaskGroup,
+          cancelTaskGroup: request.cancelTaskGroup,
+          resumeTaskGroup: request.resumeTaskGroup
+        }
+      })
+      const finishedAt = Date.now()
+      const resultAction = createToolResultAction({
+        actionId: `${action.actionId}:result`,
+        correlationId: action.correlationId,
+        payload: {
+          invocationId: action.payload.invocationId,
+          toolName,
+          ok: true,
+          content: result.content,
+          metadata: toJsonMetadata(result.metadata),
+          startedAt,
+          finishedAt,
+          durationMs: Math.max(0, finishedAt - startedAt)
+        }
+      })
+      executionCompleted = true
+      // Terminal observer failure is surfaced, but tool execution is never retried.
+      await this.onAgentAction(resultAction)
+      return { action: resultAction, result }
+    } catch (error) {
+      if (executionCompleted) throw error
+      const finishedAt = Date.now()
+      const resultAction = createToolResultAction({
+        actionId: `${action.actionId}:result`,
+        correlationId: action.correlationId,
+        payload: {
+          invocationId: action.payload.invocationId,
+          toolName,
+          ok: false,
+          error: toSafeError(error),
+          startedAt,
+          finishedAt,
+          durationMs: Math.max(0, finishedAt - startedAt)
+        }
+      })
+      try {
+        await this.onAgentAction(resultAction)
+      } catch {
+        // Preserve the original execution or authorization failure.
+      }
+      throw error
+    } finally {
+      leaveTool?.()
+    }
   }
 
   async callTool(
@@ -262,36 +454,22 @@ export class AssistantExecutionAdapter {
     options?: {
       allowedToolNames?: string[] | null
     }
-  ) {
-    assertAssistantToolAllowed(name, options?.allowedToolNames)
-    return invokeAssistantToolViaKernel({
-      toolRegistry: this.toolRegistry,
+  ): Promise<AssistantToolCallResult> {
+    const descriptor: AssistantToolActionDescriptor = {
+      runId: `call-tool:${crypto.randomUUID()}`,
+      toolCallIndex: 0,
       toolName: name,
       args,
-      signal: request.signal,
-      context: {
-        config: request.config,
-        route: request.route,
-        sessionStore: request.sessionStore,
-        taskState: request.taskState,
-        workspaceMemoryFile: request.workspaceMemoryFile,
-        workspaceTaskContextFile: request.workspaceTaskContextFile,
-        workspaceContextFile: request.workspaceContextFile,
-        workspacePinnedContextFile: request.workspacePinnedContextFile,
-        workspaceMetaFile: request.workspaceMetaFile,
-        workspaceRootDir: request.workspaceRootDir,
-        resumeRun: request.resumeRun,
-        resumeWorkflow: request.resumeWorkflow,
-        startTaskGroup: request.startTaskGroup,
-        progressTaskGroup: request.progressTaskGroup,
-        approveTaskGroup: request.approveTaskGroup,
-        exportTaskGroup: request.exportTaskGroup,
-        cancelTaskGroup: request.cancelTaskGroup,
-        resumeTaskGroup: request.resumeTaskGroup
-      }
-    })
+      requestedAt: Date.now()
+    }
+    const execution = await this.executeToolInvokeAction(
+      buildAssistantToolInvokeAction(descriptor),
+      descriptor,
+      request,
+      options?.allowedToolNames
+    )
+    return execution.result
   }
-
   async run(request: AssistantExecutionRequest): Promise<AssistantExecutionResult> {
     const startedAt = Date.now()
     const executionMetadata = buildExecutionMetadata(request)
@@ -299,7 +477,13 @@ export class AssistantExecutionAdapter {
     if (toolInvocation) {
       if (request.maxToolCalls !== undefined && request.maxToolCalls < 1)
         throw new Error('Assistant tool-call budget exhausted.')
-      assertAssistantToolAllowed(toolInvocation.toolName, request.req.execution?.allowedToolNames)
+      const toolAction = buildAssistantToolInvokeAction({
+        runId: request.runId,
+        toolCallIndex: 0,
+        toolName: toolInvocation.toolName,
+        args: toolInvocation.args,
+        requestedAt: startedAt
+      })
       await request.emitEvent?.({
         type: 'progress',
         level: 'info',
@@ -307,46 +491,28 @@ export class AssistantExecutionAdapter {
         metadata: {
           ...executionMetadata,
           toolName: toolInvocation.toolName,
+          actionId: toolAction.actionId,
+          invocationId: toolAction.payload.invocationId,
           requestKind: 'tool-invocation'
         }
       })
-      await request.cooperativeExecution?.checkpoint('tool-invocation')
-      const leaveTool = request.cooperativeExecution?.enter('tool-invocation')
-      let toolResult
-      try {
-        toolResult = await invokeAssistantToolViaKernel({
-          toolRegistry: this.toolRegistry,
+      const toolExecution = await this.executeToolInvokeAction(
+        toolAction,
+        {
+          runId: request.runId,
+          toolCallIndex: 0,
           toolName: toolInvocation.toolName,
           args: toolInvocation.args,
-          signal: request.signal,
-          context: {
-            config: request.config,
-            route: request.route,
-            sessionStore: request.sessionStore,
-            taskState: request.taskState,
-            workspaceMemoryFile: request.workspaceMemoryFile,
-            workspaceTaskContextFile: request.workspaceTaskContextFile,
-            workspaceContextFile: request.workspaceContextFile,
-            workspacePinnedContextFile: request.workspacePinnedContextFile,
-            workspaceMetaFile: request.workspaceMetaFile,
-            workspaceRootDir: request.workspaceRootDir,
-            resumeRun: request.resumeRun,
-            resumeWorkflow: request.resumeWorkflow,
-            startTaskGroup: request.startTaskGroup,
-            progressTaskGroup: request.progressTaskGroup,
-            approveTaskGroup: request.approveTaskGroup,
-            exportTaskGroup: request.exportTaskGroup,
-            cancelTaskGroup: request.cancelTaskGroup,
-            resumeTaskGroup: request.resumeTaskGroup
-          }
-        })
-      } finally {
-        leaveTool?.()
-      }
+          requestedAt: startedAt
+        },
+        request,
+        request.req.execution?.allowedToolNames
+      )
+      const toolResult = toolExecution.action
 
       return {
         reply: {
-          content: toolResult.content
+          content: toolResult.payload.content || ''
         },
         artifacts: [],
         toolCalls: [
@@ -367,8 +533,11 @@ export class AssistantExecutionAdapter {
             createdAt: startedAt,
             metadata: {
               ...executionMetadata,
-              ...(toolResult.metadata || {}),
+              ...(toolResult.payload.metadata || {}),
               toolName: toolInvocation.toolName,
+              actionId: toolAction.actionId,
+              invocationId: toolAction.payload.invocationId,
+              toolResultOk: toolResult.payload.ok,
               requestKind: 'tool-invocation'
             }
           }

--- a/packages/app/src/main/index.test.ts
+++ b/packages/app/src/main/index.test.ts
@@ -24,7 +24,8 @@ const {
   initializeAppUpdateManagerMock,
   isAppUpdateInstallInProgressMock,
   startLauncherSmokeTestMock,
-  confirmLauncherHealthMock
+  confirmLauncherHealthMock,
+  flushLocalMediaAccessGrantsMock
 } = vi.hoisted(() => {
   const listeners = new Map<string, (...args: unknown[]) => unknown>()
   const appMock = {
@@ -64,7 +65,8 @@ const {
     initializeAppUpdateManagerMock: vi.fn(() => Promise.resolve()),
     isAppUpdateInstallInProgressMock: vi.fn(() => false),
     startLauncherSmokeTestMock: vi.fn(() => false),
-    confirmLauncherHealthMock: vi.fn(() => Promise.resolve(false))
+    confirmLauncherHealthMock: vi.fn(() => Promise.resolve(false)),
+    flushLocalMediaAccessGrantsMock: vi.fn()
   }
 })
 
@@ -81,6 +83,10 @@ vi.mock('./appRuntime', () => ({
 
 vi.mock('./config/userDataDirectory', () => ({
   resolveStartupUserDataDirectory: resolveStartupUserDataDirectoryMock
+}))
+
+vi.mock('./localMediaAccess', () => ({
+  flushLocalMediaAccessGrants: flushLocalMediaAccessGrantsMock
 }))
 
 vi.mock('./lifeCycle', () => ({
@@ -160,6 +166,7 @@ describe('main process startup window opening', () => {
     beforeShowMock.mockReset()
     beforeShowMock.mockResolvedValue(undefined)
     beforeQuitMock.mockClear()
+    flushLocalMediaAccessGrantsMock.mockClear()
     startQAppWatcherMock.mockClear()
     stopQAppWatcherMock.mockClear()
     initScreenshotManagerMock.mockClear()
@@ -223,8 +230,7 @@ describe('main process startup window opening', () => {
     await loadModule()
 
     const activateHandler = appMock.on.mock.calls.find(([event]) => event === 'activate')?.[1] as
-      | (() => void)
-      | undefined
+      (() => void) | undefined
 
     expect(activateHandler).toBeTypeOf('function')
 
@@ -250,8 +256,7 @@ describe('main process startup window opening', () => {
     await loadModule()
 
     const activateHandler = appMock.on.mock.calls.find(([event]) => event === 'activate')?.[1] as
-      | (() => void)
-      | undefined
+      (() => void) | undefined
 
     expect(activateHandler).toBeTypeOf('function')
 
@@ -366,6 +371,7 @@ describe('main process startup window opening', () => {
     await beforeQuitHandler?.(event)
 
     expect(event.preventDefault).not.toHaveBeenCalled()
+    expect(flushLocalMediaAccessGrantsMock).toHaveBeenCalledTimes(1)
     expect(beforeQuitMock).not.toHaveBeenCalled()
     expect(cleanupScreenshotManagerMock).toHaveBeenCalled()
     expect(stopQAppWatcherMock).toHaveBeenCalled()

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -17,6 +17,7 @@ import { cleanupScreenshotManager, initScreenshotManager } from './screenshot/sc
 import { confirmLauncherHealth, startLauncherSmokeTest } from './appUpdate/appLauncherBridge'
 import { initializeAppUpdateManager, isAppUpdateInstallInProgress } from './appUpdate/updateManager'
 import { winController } from './winControls'
+import { flushLocalMediaAccessGrants } from './localMediaAccess'
 
 const startupUserData = resolveStartupUserDataDirectory()
 fs.mkdirSync(startupUserData.path, { recursive: true })
@@ -164,6 +165,7 @@ app.on('window-all-closed', () => {
 })
 
 app.on('before-quit', async (event) => {
+  flushLocalMediaAccessGrants()
   console.log('[App] 应用即将退出...')
   if (isAppUpdateInstallInProgress()) {
     cleanupScreenshotManager()

--- a/packages/app/src/main/localMediaAccess.test.ts
+++ b/packages/app/src/main/localMediaAccess.test.ts
@@ -1,10 +1,14 @@
 import fs from 'node:fs'
+import os from 'node:os'
 import path from 'node:path'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
+  authorizeScopedLocalMediaDirectory,
   authorizeScopedLocalMediaPath,
   clearScopedLocalMediaPathsForTest,
+  flushLocalMediaAccessGrants,
   hasLocalMediaTraversal,
+  initializeLocalMediaAccess,
   resolveAuthorizedLocalMediaPath
 } from './localMediaAccess'
 
@@ -16,8 +20,9 @@ afterEach(() => {
 })
 
 function makeTempDir(prefix: string): string {
-  fs.mkdirSync('/tmp', { recursive: true })
-  const directory = fs.mkdtempSync(path.join('/tmp', prefix))
+  const tempRoot = os.tmpdir()
+  fs.mkdirSync(tempRoot, { recursive: true })
+  const directory = fs.mkdtempSync(path.join(tempRoot, prefix))
   cleanupPaths.push(directory)
   return directory
 }
@@ -57,6 +62,134 @@ describe('local media access policy', () => {
       path.resolve(fs.realpathSync.native(selected))
     )
     expect(resolveAuthorizedLocalMediaPath(sibling, [])).toBeNull()
+  })
+
+  it('allows files inside a trusted directory selection without allowing siblings outside it', () => {
+    const selectedDirectory = makeTempDir('magicpot-media-selected-dir-')
+    const selectedFile = path.join(selectedDirectory, 'nested', 'selected.png')
+    const outsideDirectory = makeTempDir('magicpot-media-outside-dir-')
+    const outsideFile = path.join(outsideDirectory, 'outside.png')
+    fs.mkdirSync(path.dirname(selectedFile), { recursive: true })
+    fs.writeFileSync(selectedFile, 'selected')
+    fs.writeFileSync(outsideFile, 'outside')
+
+    expect(authorizeScopedLocalMediaDirectory(selectedDirectory)).toBe(true)
+    expect(resolveAuthorizedLocalMediaPath(selectedFile, [])).toBe(
+      path.resolve(fs.realpathSync.native(selectedFile))
+    )
+    expect(resolveAuthorizedLocalMediaPath(outsideFile, [])).toBeNull()
+  })
+
+  it('does not turn a file path into a directory grant', () => {
+    const directory = makeTempDir('magicpot-media-file-not-dir-')
+    const selectedFile = path.join(directory, 'selected.png')
+    const sibling = path.join(directory, 'sibling.png')
+    fs.writeFileSync(selectedFile, 'selected')
+    fs.writeFileSync(sibling, 'sibling')
+
+    expect(authorizeScopedLocalMediaDirectory(selectedFile)).toBe(false)
+    expect(resolveAuthorizedLocalMediaPath(sibling, [])).toBeNull()
+  })
+
+  it('persists trusted file and directory grants and reloads them after restart', () => {
+    const persistenceRoot = makeTempDir('magicpot-media-persistence-')
+    const grantsPath = path.join(persistenceRoot, 'local-media-grants.json')
+    const selectedDirectory = path.join(persistenceRoot, 'selected-directory')
+    const selectedFile = path.join(persistenceRoot, 'selected-file.png')
+    const nestedFile = path.join(selectedDirectory, 'nested.png')
+    fs.mkdirSync(selectedDirectory, { recursive: true })
+    fs.writeFileSync(selectedFile, 'selected')
+    fs.writeFileSync(nestedFile, 'nested')
+
+    initializeLocalMediaAccess(grantsPath)
+    expect(authorizeScopedLocalMediaPath(selectedFile)).toBe(true)
+    expect(authorizeScopedLocalMediaDirectory(selectedDirectory)).toBe(true)
+    flushLocalMediaAccessGrants()
+
+    clearScopedLocalMediaPathsForTest()
+    initializeLocalMediaAccess(grantsPath)
+
+    expect(resolveAuthorizedLocalMediaPath(selectedFile, [])).toBe(
+      path.resolve(fs.realpathSync.native(selectedFile))
+    )
+    expect(resolveAuthorizedLocalMediaPath(nestedFile, [])).toBe(
+      path.resolve(fs.realpathSync.native(nestedFile))
+    )
+  })
+
+  it('coalesces a burst of trusted grants into one explicit persistence flush', () => {
+    const persistenceRoot = makeTempDir('magicpot-media-coalesce-')
+    const grantsPath = path.join(persistenceRoot, 'local-media-grants.json')
+    initializeLocalMediaAccess(grantsPath)
+    const writeSpy = vi.spyOn(fs, 'writeFileSync')
+
+    for (let index = 0; index < 25; index += 1) {
+      const filePath = path.join(persistenceRoot, `image-${index}.png`)
+      fs.writeFileSync(filePath, 'image')
+      expect(authorizeScopedLocalMediaPath(filePath)).toBe(true)
+    }
+    const writesBeforeFlush = writeSpy.mock.calls.filter(([target]) =>
+      String(target).includes('local-media-grants.json')
+    )
+    expect(writesBeforeFlush).toHaveLength(0)
+
+    flushLocalMediaAccessGrants()
+    const grantWrites = writeSpy.mock.calls.filter(([target]) =>
+      String(target).includes('local-media-grants.json')
+    )
+    expect(grantWrites).toHaveLength(1)
+    writeSpy.mockRestore()
+  })
+
+  it('prunes missing and wrong-type grants while reloading persisted state', () => {
+    const persistenceRoot = makeTempDir('magicpot-media-prune-')
+    const grantsPath = path.join(persistenceRoot, 'local-media-grants.json')
+    const existingFile = path.join(persistenceRoot, 'existing.png')
+    const existingDirectory = path.join(persistenceRoot, 'existing-directory')
+    const missingFile = path.join(persistenceRoot, 'missing.png')
+    fs.writeFileSync(existingFile, 'existing')
+    fs.mkdirSync(existingDirectory)
+    fs.writeFileSync(
+      grantsPath,
+      JSON.stringify({
+        version: 1,
+        files: [existingFile, missingFile, existingDirectory],
+        directories: [existingDirectory, missingFile, existingFile]
+      })
+    )
+
+    initializeLocalMediaAccess(grantsPath)
+
+    expect(resolveAuthorizedLocalMediaPath(existingFile, [])).toBe(
+      path.resolve(fs.realpathSync.native(existingFile))
+    )
+    expect(
+      resolveAuthorizedLocalMediaPath(path.join(existingDirectory, 'missing-child.png'), [])
+    ).toBeNull()
+    expect(JSON.parse(fs.readFileSync(grantsPath, 'utf8'))).toEqual({
+      version: 1,
+      files: [path.resolve(fs.realpathSync.native(existingFile))],
+      directories: [path.resolve(fs.realpathSync.native(existingDirectory))]
+    })
+  })
+
+  it('rejects unscoped network paths before application-root fallback', () => {
+    const networkPath = '//server/share/image.png'
+    const canonical = path.resolve(networkPath)
+    const realpathSpy = vi.spyOn(fs.realpathSync, 'native').mockReturnValue(canonical)
+
+    expect(resolveAuthorizedLocalMediaPath(networkPath, [canonical])).toBeNull()
+    realpathSpy.mockRestore()
+  })
+
+  it('allows an exact network path only after a trusted picker grant', () => {
+    const networkPath = '//server/share/image.png'
+    const canonical = path.resolve(networkPath)
+    const realpathSpy = vi.spyOn(fs.realpathSync, 'native').mockReturnValue(canonical)
+
+    expect(authorizeScopedLocalMediaPath(networkPath)).toBe(true)
+    expect(resolveAuthorizedLocalMediaPath(networkPath, [])).toBe(canonical)
+    realpathSpy.mockRestore()
   })
 
   it('rejects symlink escapes from an allowed root', () => {

--- a/packages/app/src/main/localMediaAccess.ts
+++ b/packages/app/src/main/localMediaAccess.ts
@@ -2,7 +2,20 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 const MAX_SCOPED_LOCAL_MEDIA_PATHS = 1_000
+const MAX_SCOPED_LOCAL_MEDIA_DIRECTORIES = 200
+const LOCAL_MEDIA_GRANTS_VERSION = 1
+const LOCAL_MEDIA_GRANTS_FLUSH_DELAY_MS = 250
 const scopedLocalMediaPaths = new Map<string, string>()
+const scopedLocalMediaDirectories = new Map<string, string>()
+let localMediaGrantsPath: string | null = null
+let localMediaGrantsDirty = false
+let localMediaGrantsFlushTimer: ReturnType<typeof setTimeout> | null = null
+
+type PersistedLocalMediaGrants = {
+  version: typeof LOCAL_MEDIA_GRANTS_VERSION
+  files: string[]
+  directories: string[]
+}
 
 function comparisonKey(filePath: string): string {
   return process.platform === 'win32' ? filePath.toLowerCase() : filePath
@@ -21,6 +34,134 @@ function canonicalizeExistingPath(filePath: string): string | null {
   }
 }
 
+function isExistingDirectory(filePath: string): boolean {
+  try {
+    return fs.statSync(filePath).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+function isExistingFile(filePath: string): boolean {
+  try {
+    return fs.statSync(filePath).isFile()
+  } catch {
+    return false
+  }
+}
+
+function persistScopedLocalMediaGrants(): void {
+  if (!localMediaGrantsPath || !localMediaGrantsDirty) return
+
+  const payload: PersistedLocalMediaGrants = {
+    version: LOCAL_MEDIA_GRANTS_VERSION,
+    files: Array.from(scopedLocalMediaPaths.values()),
+    directories: Array.from(scopedLocalMediaDirectories.values())
+  }
+  const tempPath = `${localMediaGrantsPath}.${process.pid}.tmp`
+  try {
+    fs.mkdirSync(path.dirname(localMediaGrantsPath), { recursive: true })
+    fs.writeFileSync(tempPath, `${JSON.stringify(payload, null, 2)}\n`, { mode: 0o600 })
+    fs.renameSync(tempPath, localMediaGrantsPath)
+    localMediaGrantsDirty = false
+  } catch (error) {
+    try {
+      fs.rmSync(tempPath, { force: true })
+    } catch {
+      // Ignore cleanup failures after a persistence error.
+    }
+    console.warn('[LocalMedia] Failed to persist scoped grants:', error)
+  }
+}
+
+function scheduleScopedLocalMediaGrantsPersistence(): void {
+  if (!localMediaGrantsPath) return
+  localMediaGrantsDirty = true
+  if (localMediaGrantsFlushTimer) return
+  localMediaGrantsFlushTimer = setTimeout(() => {
+    localMediaGrantsFlushTimer = null
+    persistScopedLocalMediaGrants()
+  }, LOCAL_MEDIA_GRANTS_FLUSH_DELAY_MS)
+  localMediaGrantsFlushTimer.unref?.()
+}
+
+export function flushLocalMediaAccessGrants(): void {
+  if (localMediaGrantsFlushTimer) {
+    clearTimeout(localMediaGrantsFlushTimer)
+    localMediaGrantsFlushTimer = null
+  }
+  persistScopedLocalMediaGrants()
+}
+
+function loadPersistedPaths(
+  values: unknown,
+  store: Map<string, string>,
+  limit: number,
+  isExpectedType: (filePath: string) => boolean
+): void {
+  if (!Array.isArray(values)) return
+  for (const value of values.slice(-limit)) {
+    if (typeof value !== 'string' || !path.isAbsolute(value) || value.includes('\0')) continue
+    const canonical = canonicalizeExistingPath(value)
+    if (!canonical || !isExpectedType(canonical)) continue
+    rememberBoundedPath(store, comparisonKey(canonical), canonical, limit)
+  }
+}
+
+/** Loads durable grants after Electron's userData path is finalized. */
+export function initializeLocalMediaAccess(grantsPath: string): void {
+  if (localMediaGrantsFlushTimer) {
+    clearTimeout(localMediaGrantsFlushTimer)
+    localMediaGrantsFlushTimer = null
+  }
+  localMediaGrantsPath = path.resolve(grantsPath)
+  localMediaGrantsDirty = false
+  scopedLocalMediaPaths.clear()
+  scopedLocalMediaDirectories.clear()
+
+  try {
+    const parsed = JSON.parse(
+      fs.readFileSync(localMediaGrantsPath, 'utf8')
+    ) as Partial<PersistedLocalMediaGrants>
+    if (parsed.version === LOCAL_MEDIA_GRANTS_VERSION) {
+      loadPersistedPaths(
+        parsed.files,
+        scopedLocalMediaPaths,
+        MAX_SCOPED_LOCAL_MEDIA_PATHS,
+        isExistingFile
+      )
+      loadPersistedPaths(
+        parsed.directories,
+        scopedLocalMediaDirectories,
+        MAX_SCOPED_LOCAL_MEDIA_DIRECTORIES,
+        isExistingDirectory
+      )
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      console.warn('[LocalMedia] Failed to load scoped grants:', error)
+    }
+  }
+
+  localMediaGrantsDirty = true
+  flushLocalMediaAccessGrants()
+}
+
+function rememberBoundedPath(
+  store: Map<string, string>,
+  key: string,
+  value: string,
+  limit: number
+): void {
+  store.delete(key)
+  store.set(key, value)
+  while (store.size > limit) {
+    const oldest = store.keys().next().value
+    if (!oldest) break
+    store.delete(oldest)
+  }
+}
+
 /** Authorizes one file obtained from an OS file picker or Electron File object. */
 export function authorizeScopedLocalMediaPath(filePath: string): boolean {
   const trimmed = String(filePath || '').trim()
@@ -30,13 +171,27 @@ export function authorizeScopedLocalMediaPath(filePath: string): boolean {
   if (!canonical) return false
 
   const key = comparisonKey(canonical)
-  scopedLocalMediaPaths.delete(key)
-  scopedLocalMediaPaths.set(key, canonical)
-  while (scopedLocalMediaPaths.size > MAX_SCOPED_LOCAL_MEDIA_PATHS) {
-    const oldest = scopedLocalMediaPaths.keys().next().value
-    if (!oldest) break
-    scopedLocalMediaPaths.delete(oldest)
-  }
+  rememberBoundedPath(scopedLocalMediaPaths, key, canonical, MAX_SCOPED_LOCAL_MEDIA_PATHS)
+  scheduleScopedLocalMediaGrantsPersistence()
+  return true
+}
+
+/** Authorizes one directory returned directly by the main-process OS directory picker. */
+export function authorizeScopedLocalMediaDirectory(directoryPath: string): boolean {
+  const trimmed = String(directoryPath || '').trim()
+  if (!trimmed || trimmed.includes('\0') || !path.isAbsolute(trimmed)) return false
+
+  const canonical = canonicalizeExistingPath(trimmed)
+  if (!canonical || !isExistingDirectory(canonical)) return false
+
+  const key = comparisonKey(canonical)
+  rememberBoundedPath(
+    scopedLocalMediaDirectories,
+    key,
+    canonical,
+    MAX_SCOPED_LOCAL_MEDIA_DIRECTORIES
+  )
+  scheduleScopedLocalMediaGrantsPersistence()
   return true
 }
 
@@ -61,19 +216,22 @@ export function resolveAuthorizedLocalMediaPath(
   allowedRoots: readonly string[]
 ): string | null {
   const trimmed = String(filePath || '').trim()
-  if (
-    !trimmed ||
-    trimmed.includes('\0') ||
-    trimmed.startsWith('\\\\') ||
-    trimmed.startsWith('//') ||
-    !path.isAbsolute(trimmed)
-  ) {
+  const isNetworkPath = trimmed.startsWith('\\\\') || trimmed.startsWith('//')
+  if (!trimmed || trimmed.includes('\0') || !path.isAbsolute(trimmed)) {
     return null
   }
 
   const canonical = canonicalizeExistingPath(trimmed)
   if (!canonical) return null
   if (scopedLocalMediaPaths.has(comparisonKey(canonical))) return canonical
+  if (
+    Array.from(scopedLocalMediaDirectories.values()).some((directory) =>
+      isSameOrInside(directory, canonical)
+    )
+  ) {
+    return canonical
+  }
+  if (isNetworkPath) return null
 
   return allowedRoots.some((root) => {
     const canonicalRoot = canonicalizeExistingPath(root)
@@ -83,6 +241,19 @@ export function resolveAuthorizedLocalMediaPath(
     : null
 }
 
+/** Checks an already-authorized path without expanding the scoped allowlist. */
+export function isScopedLocalMediaPathAuthorized(filePath: string): boolean {
+  const canonical = canonicalizeExistingPath(String(filePath || '').trim())
+  return canonical ? scopedLocalMediaPaths.has(comparisonKey(canonical)) : false
+}
+
 export function clearScopedLocalMediaPathsForTest(): void {
+  if (localMediaGrantsFlushTimer) {
+    clearTimeout(localMediaGrantsFlushTimer)
+    localMediaGrantsFlushTimer = null
+  }
   scopedLocalMediaPaths.clear()
+  scopedLocalMediaDirectories.clear()
+  localMediaGrantsPath = null
+  localMediaGrantsDirty = false
 }

--- a/packages/app/src/main/magicAgentPlatform2/channels/runtimeChannelAgentWakeAdapter.test.ts
+++ b/packages/app/src/main/magicAgentPlatform2/channels/runtimeChannelAgentWakeAdapter.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
+import { readRuntimeChannelTrustedDispatchContext } from '../../magicAgentRuntime/runtimeChannelTrustedDispatchContext'
 import { createRuntimeChannelAgentWakeAdapter } from './runtimeChannelAgentWakeAdapter'
 
 describe('runtimeChannelAgentWakeAdapter', () => {
@@ -12,7 +13,7 @@ describe('runtimeChannelAgentWakeAdapter', () => {
         limits: { allowedToolNames: ['read'] }
       }
     }
-    const start = vi.fn(async () => undefined)
+    const start = vi.fn(async (_input: unknown) => undefined)
     const adapter = createRuntimeChannelAgentWakeAdapter({
       store: { get: vi.fn(() => instance) },
       commands: { start }
@@ -23,7 +24,10 @@ describe('runtimeChannelAgentWakeAdapter', () => {
       memberId: 'member',
       pendingMessageIds: ['message-1', 'message-2']
     })
-    expect(start).toHaveBeenCalledWith({
+    const call = start.mock.calls[0]?.[0] as {
+      request: Parameters<typeof readRuntimeChannelTrustedDispatchContext>[0]
+    }
+    expect(call).toMatchObject({
       instanceId: 'instance',
       expectedRevision: 3,
       actor: { kind: 'system', id: 'runtime-channel-wakeup' },
@@ -35,10 +39,22 @@ describe('runtimeChannelAgentWakeAdapter', () => {
       },
       idempotencyKey: 'channel-wake:channel:message-1:message-2'
     })
+    expect(readRuntimeChannelTrustedDispatchContext(call.request)).toEqual({
+      channelId: 'channel',
+      memberId: 'member',
+      pendingMessageIds: ['message-1', 'message-2'],
+      agentInstanceId: 'instance'
+    })
+    expect(JSON.parse(JSON.stringify(call.request))).toEqual({
+      agentId: 'agent-definition',
+      text: 'Runtime Channel channel has pending messages: message-1, message-2',
+      route: { channel: 'runtime-channel', scopeType: 'dm', scopeId: 'channel' },
+      allowedToolNames: ['read']
+    })
   })
 
   it('carries Runtime Channel identity in the route scope for config enforcement', async () => {
-    const start = vi.fn(async () => undefined)
+    const start = vi.fn(async (_input: unknown) => undefined)
     const adapter = createRuntimeChannelAgentWakeAdapter({
       store: {
         get: vi.fn(() => ({

--- a/packages/app/src/main/magicAgentPlatform2/channels/runtimeChannelAgentWakeAdapter.ts
+++ b/packages/app/src/main/magicAgentPlatform2/channels/runtimeChannelAgentWakeAdapter.ts
@@ -1,4 +1,5 @@
 import type { ProductionAgentInstanceLifecycle } from '../agents/productionAgentInstanceLifecycleOwner'
+import { attachRuntimeChannelTrustedDispatchContext } from '../../magicAgentRuntime/runtimeChannelTrustedDispatchContext'
 import type { RuntimeChannelAgentWake } from './runtimeChannelWakeRouter'
 
 export const createRuntimeChannelAgentWakeAdapter =
@@ -10,12 +11,20 @@ export const createRuntimeChannelAgentWakeAdapter =
       instanceId: instance.id,
       expectedRevision: instance.revision,
       actor: { kind: 'system', id: 'runtime-channel-wakeup' },
-      request: {
-        agentId: instance.state.definitionId,
-        text: `Runtime Channel ${wake.channelId} has pending messages: ${wake.pendingMessageIds.join(', ')}`,
-        route: { channel: 'runtime-channel', scopeType: 'dm', scopeId: wake.channelId },
-        allowedToolNames: [...instance.state.limits.allowedToolNames]
-      },
+      request: attachRuntimeChannelTrustedDispatchContext(
+        {
+          agentId: instance.state.definitionId,
+          text: `Runtime Channel ${wake.channelId} has pending messages: ${wake.pendingMessageIds.join(', ')}`,
+          route: { channel: 'runtime-channel', scopeType: 'dm', scopeId: wake.channelId },
+          allowedToolNames: [...instance.state.limits.allowedToolNames]
+        },
+        {
+          channelId: wake.channelId,
+          memberId: wake.memberId,
+          pendingMessageIds: wake.pendingMessageIds,
+          agentInstanceId: wake.agentInstanceId
+        }
+      ),
       idempotencyKey: `channel-wake:${wake.channelId}:${wake.pendingMessageIds.join(':')}`
     })
   }

--- a/packages/app/src/main/magicAgentPlatform2/drives/driveDeliveryScheduler.test.ts
+++ b/packages/app/src/main/magicAgentPlatform2/drives/driveDeliveryScheduler.test.ts
@@ -80,4 +80,168 @@ describe('DriveDeliveryScheduler', () => {
       eventStore.close()
     }
   })
+
+  it('settles successful delivery at the latest revision after progress is reported', async () => {
+    const eventStore = new MagicAgentEventStore(':memory:')
+    try {
+      const store = new PersistentDriveStore(eventStore)
+      createDrive(store, 'drive-progress')
+      let now = 10
+      const scheduler = new DriveDeliveryScheduler({
+        store,
+        deliver: async (claimed) => {
+          expect(claimed.id).toBe('drive-progress')
+          store.reportProgress({
+            driveId: claimed.id,
+            expectedRevision: claimed.revision,
+            summary: 'Completed the first step',
+            evidence: [{ kind: 'run', ref: 'run-1' }],
+            reportedAt: 11,
+            idempotencyKey: 'progress-1'
+          })
+          now = 12
+        },
+        ownerId: 'worker-1',
+        now: () => now,
+        token: () => 'progress-claim'
+      })
+
+      expect(await scheduler.runOnce()).toBe(true)
+      expect(store.get('drive-progress')?.state).toMatchObject({
+        progress: {
+          summary: 'Completed the first step',
+          reportedAt: 11,
+          sequence: 1,
+          evidence: [{ kind: 'run', ref: 'run-1' }]
+        },
+        delivery: { acknowledgedAt: 12 }
+      })
+    } finally {
+      eventStore.close()
+    }
+  })
+
+  it('settles failed delivery at the latest revision after progress is reported', async () => {
+    const eventStore = new MagicAgentEventStore(':memory:')
+    try {
+      const store = new PersistentDriveStore(eventStore)
+      createDrive(store, 'drive-progress-fail')
+      let now = 10
+      const scheduler = new DriveDeliveryScheduler({
+        store,
+        deliver: async (claimed) => {
+          store.reportProgress({
+            driveId: claimed.id,
+            expectedRevision: claimed.revision,
+            summary: 'Made partial progress',
+            evidence: [{ kind: 'text', ref: 'checkpoint-1' }],
+            reportedAt: 11,
+            idempotencyKey: 'progress-before-failure'
+          })
+          now = 12
+          throw new Error('delivery stopped')
+        },
+        ownerId: 'worker-1',
+        now: () => now,
+        token: () => 'failure-claim',
+        retryDelayMs: 5
+      })
+
+      expect(await scheduler.runOnce()).toBe(true)
+      expect(store.get('drive-progress-fail')?.state).toMatchObject({
+        progress: {
+          summary: 'Made partial progress',
+          reportedAt: 11,
+          evidence: [{ kind: 'text', ref: 'checkpoint-1' }]
+        },
+        delivery: {
+          nextAttemptAt: 17,
+          lastFailure: { failedAt: 12, reason: 'delivery stopped' }
+        }
+      })
+    } finally {
+      eventStore.close()
+    }
+  })
+
+  it.each([
+    ['successful', false],
+    ['failed', true]
+  ] as const)(
+    'does not settle %s delivery after unrelated state changes with the same lease',
+    async (_label, deliveryFails) => {
+      const eventStore = new MagicAgentEventStore(':memory:')
+      try {
+        const store = new PersistentDriveStore(eventStore)
+        createDrive(store, `drive-state-${deliveryFails ? 'fail' : 'ack'}`)
+        const driveId = `drive-state-${deliveryFails ? 'fail' : 'ack'}`
+        let now = 10
+        const scheduler = new DriveDeliveryScheduler({
+          store,
+          deliver: async (claimed) => {
+            now = 11
+            store.transfer({
+              driveId: claimed.id,
+              expectedRevision: claimed.revision,
+              ownerId: 'replacement-owner',
+              transferredAt: now,
+              idempotencyKey: `transfer:${claimed.id}`
+            })
+            now = 12
+            if (deliveryFails) throw new Error('delivery failed after transfer')
+          },
+          ownerId: 'worker-1',
+          now: () => now,
+          token: () => `state-claim-${deliveryFails}`
+        })
+
+        await expect(scheduler.runOnce()).rejects.toThrow('Drive delivery state conflict')
+        expect(store.get(driveId)?.state).toMatchObject({
+          ownerId: 'replacement-owner',
+          delivery: { lease: { token: `state-claim-${deliveryFails}` } }
+        })
+        expect(store.get(driveId)?.state.delivery?.acknowledgedAt).toBeUndefined()
+        expect(store.get(driveId)?.state.delivery?.lastFailure).toBeUndefined()
+      } finally {
+        eventStore.close()
+      }
+    }
+  )
+
+  it('does not settle delivery after its lease is replaced', async () => {
+    const eventStore = new MagicAgentEventStore(':memory:')
+    try {
+      const store = new PersistentDriveStore(eventStore)
+      createDrive(store, 'drive-lease-lost')
+      let now = 10
+      const scheduler = new DriveDeliveryScheduler({
+        store,
+        deliver: async () => {
+          now = 16
+          expect(
+            store.claimDelivery({
+              now,
+              leaseMs: 10,
+              ownerId: 'worker-2',
+              token: 'replacement-claim'
+            })
+          ).toMatchObject({ id: 'drive-lease-lost' })
+        },
+        ownerId: 'worker-1',
+        now: () => now,
+        token: () => 'original-claim',
+        leaseMs: 5
+      })
+
+      await expect(scheduler.runOnce()).rejects.toThrow('Drive delivery lease conflict')
+      expect(store.get('drive-lease-lost')?.state.delivery).toMatchObject({
+        attemptCount: 2,
+        lease: { ownerId: 'worker-2', token: 'replacement-claim', expiresAt: 26 }
+      })
+      expect(store.get('drive-lease-lost')?.state.delivery?.acknowledgedAt).toBeUndefined()
+      expect(store.get('drive-lease-lost')?.state.delivery?.lastFailure).toBeUndefined()
+    } finally {
+      eventStore.close()
+    }
+  })
 })

--- a/packages/app/src/main/magicAgentPlatform2/drives/driveDeliveryScheduler.ts
+++ b/packages/app/src/main/magicAgentPlatform2/drives/driveDeliveryScheduler.ts
@@ -1,5 +1,7 @@
 import { randomUUID } from 'node:crypto'
 import type { MagicAgentDriveState } from '../../../shared/magicAgentPlatform2/drive'
+import type { PolicyJsonRecord } from '../../../shared/magicAgentPlatform2/policy'
+import { canonicalPolicyJson } from '../../../shared/magicAgentPlatform2/policy'
 import type { StoredResource } from '../persistence/eventStore'
 import type { PersistentDriveStore } from './persistentDriveStore'
 
@@ -88,19 +90,25 @@ export class DriveDeliveryScheduler {
       token
     })
     if (!claimed) return false
+    const withoutProgress = (state: MagicAgentDriveState): PolicyJsonRecord => {
+      const { progress: _progress, ...settlementState } = state
+      return settlementState as unknown as PolicyJsonRecord
+    }
+    const claimedSettlementState = canonicalPolicyJson(withoutProgress(claimed.state))
+    const settlementRevision = (): number => {
+      const current = this.options.store.get(claimed.id)
+      if (!current || current.state.delivery?.lease?.token !== token)
+        throw new Error('Drive delivery lease conflict.')
+      if (canonicalPolicyJson(withoutProgress(current.state)) !== claimedSettlementState)
+        throw new Error('Drive delivery state conflict.')
+      return current.revision
+    }
     try {
       await this.options.deliver(claimed)
-      this.options.store.acknowledgeDelivery({
-        driveId: claimed.id,
-        expectedRevision: claimed.revision,
-        token,
-        acknowledgedAt: this.now(),
-        idempotencyKey: `scheduler-ack:${token}`
-      })
     } catch (error) {
       this.options.store.failDelivery({
         driveId: claimed.id,
-        expectedRevision: claimed.revision,
+        expectedRevision: settlementRevision(),
         token,
         failedAt: this.now(),
         reason: error instanceof Error ? error.message : String(error),
@@ -108,7 +116,15 @@ export class DriveDeliveryScheduler {
         maxAttempts: this.maxAttempts,
         idempotencyKey: `scheduler-fail:${token}`
       })
+      return true
     }
+    this.options.store.acknowledgeDelivery({
+      driveId: claimed.id,
+      expectedRevision: settlementRevision(),
+      token,
+      acknowledgedAt: this.now(),
+      idempotencyKey: `scheduler-ack:${token}`
+    })
     return true
   }
 }

--- a/packages/app/src/main/magicAgentPlatform2/drives/productionDriveLifecycle.ts
+++ b/packages/app/src/main/magicAgentPlatform2/drives/productionDriveLifecycle.ts
@@ -4,6 +4,7 @@ import type {
   MagicAgentPlatformRunResp
 } from '../../../shared/api/svcMagicAgentPlatform'
 import type { ServiceInvocationContext } from '../../../shared/api/apiUtils/serviceInvocation'
+import { attachDriveTrustedDispatchContext } from '../../magicAgentRuntime/driveTrustedDispatchContext'
 import type { StoredResource } from '../persistence/eventStore'
 
 export const DRIVE_ROUTE = 'magicpot-drive://runtime' as const
@@ -24,17 +25,28 @@ export const createProductionDriveDelivery =
     const target = drive.state.deliveryTarget
     if (!target) throw new Error('Drive delivery target is missing.')
     await service.runAgent(
-      {
-        route: { channel: DRIVE_ROUTE, scopeType: 'channel', scopeId: drive.id },
-        agentId: target.agentId,
-        text: target.text,
-        ...(target.profileId === undefined ? {} : { profileId: target.profileId }),
-        ...(target.sessionId === undefined ? {} : { sessionId: target.sessionId }),
-        ...(target.allowedToolNames === undefined
-          ? {}
-          : { allowedToolNames: [...target.allowedToolNames] }),
-        metadata: { driveId: drive.id, driveRevision: drive.revision }
-      },
+      attachDriveTrustedDispatchContext(
+        {
+          route: { channel: DRIVE_ROUTE, scopeType: 'channel', scopeId: drive.id },
+          agentId: target.agentId,
+          text: target.text,
+          ...(target.profileId === undefined ? {} : { profileId: target.profileId }),
+          ...(target.sessionId === undefined ? {} : { sessionId: target.sessionId }),
+          ...(target.allowedToolNames === undefined
+            ? {}
+            : { allowedToolNames: [...target.allowedToolNames] }),
+          metadata: { driveId: drive.id, driveRevision: drive.revision }
+        },
+        {
+          driveId: drive.id,
+          driveRevision: drive.revision,
+          status: drive.state.status,
+          ...(drive.state.assigneeId === undefined ? {} : { assigneeId: drive.state.assigneeId }),
+          ...(drive.state.ownerId === undefined ? {} : { ownerId: drive.state.ownerId }),
+          targetAgentId: target.agentId,
+          ...(target.sessionId === undefined ? {} : { targetSessionId: target.sessionId })
+        }
+      ),
       DRIVE_INVOCATION
     )
   }

--- a/packages/app/src/main/magicAgentPlatform2/drives/productionDriveRuntime.test.ts
+++ b/packages/app/src/main/magicAgentPlatform2/drives/productionDriveRuntime.test.ts
@@ -15,6 +15,7 @@ import {
   startProductionDriveLifecycle
 } from './productionDriveLifecycle'
 import { ProductionDriveRuntime } from './productionDriveRuntime'
+import { readDriveTrustedDispatchContext } from '../../magicAgentRuntime/driveTrustedDispatchContext'
 
 const drive = {
   id: 'drive-1',
@@ -123,20 +124,22 @@ describe('Production Drive runtime/lifecycle/commands', () => {
   })
 
   it('delivers an explicit agent target through the public Policy-gated runAgent path', async () => {
-    const runAgent = vi.fn(async () => ({
-      runId: 'run-1',
-      agentId: 'agent-1',
-      status: 'completed' as const,
-      content: '',
-      messages: [],
-      toolCalls: [],
-      events: [],
-      createdAt: 1,
-      updatedAt: 1,
-      startedAt: 1,
-      finishedAt: 1,
-      metadata: {}
-    }))
+    const runAgent = vi.fn(
+      async (_request: import('@shared/api/svcMagicAgentPlatform').MagicAgentPlatformRunReq) => ({
+        runId: 'run-1',
+        agentId: 'agent-1',
+        status: 'completed' as const,
+        content: '',
+        messages: [],
+        toolCalls: [],
+        events: [],
+        createdAt: 1,
+        updatedAt: 1,
+        startedAt: 1,
+        finishedAt: 1,
+        metadata: {}
+      })
+    )
     const deliver = createProductionDriveDelivery({ runAgent })
     await deliver({
       kind: 'drive',
@@ -149,6 +152,20 @@ describe('Production Drive runtime/lifecycle/commands', () => {
         ...drive,
         deliveryTarget: { kind: 'agent', agentId: 'agent-1', text: 'Continue goal' }
       }
+    })
+    const deliveredRequest = runAgent.mock.calls[0]![0]!
+    expect(readDriveTrustedDispatchContext(deliveredRequest)).toEqual({
+      driveId: 'drive-1',
+      driveRevision: 2,
+      status: 'active',
+      assigneeId: 'agent-1',
+      targetAgentId: 'agent-1'
+    })
+    expect(JSON.parse(JSON.stringify(deliveredRequest))).toEqual({
+      route: { channel: 'magicpot-drive://runtime', scopeType: 'channel', scopeId: 'drive-1' },
+      agentId: 'agent-1',
+      text: 'Continue goal',
+      metadata: { driveId: 'drive-1', driveRevision: 2 }
     })
     expect(runAgent).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/app/src/main/magicAgentPlatform2/triggers/productionTriggerExecutor.test.ts
+++ b/packages/app/src/main/magicAgentPlatform2/triggers/productionTriggerExecutor.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { MagicAgentEventStore } from '../persistence/eventStore'
 import { MagicAgentPolicyAuthorizationService } from '../policy'
 import type { PersistentTriggerState } from './persistentTriggerStore'
+import type { TriggerOccurrenceState } from './triggerOccurrenceStore'
 import {
   ProductionTriggerExecutor,
   TriggerOutcomePersistenceError
@@ -103,7 +104,77 @@ describe('production trigger executor', () => {
     })
     expect(runAgent).toHaveBeenCalledOnce()
     expect(runAgent.mock.calls[0][0].route).toEqual({ trusted: true })
+    expect(runAgent.mock.calls[0][0].trustedContext).toEqual({
+      triggerId: 'trigger-1',
+      requestId: 'trigger-run:trigger-1:claim-1:100',
+      occurrenceAt: 100,
+      triggerType: 'schedule',
+      triggerTitle: 'Nightly',
+      targetAgentId: 'agent-1',
+      targetSessionId: 'session-1'
+    })
     expect(resolveTrustedRoute).toHaveBeenCalledOnce()
+  })
+
+  it('includes trusted occurrence provenance in persistent agent dispatches', async () => {
+    const service = setup('allow')
+    const runAgent = vi.fn(async (input) => input)
+    const executor = new ProductionTriggerExecutor({
+      authorizationService: service,
+      grantProvider: async (request) => {
+        const grant = service.createApprovalGrant({
+          grantId: 'occurrence-grant',
+          request,
+          approvedBy: { kind: 'user', id: 'approver-1' },
+          issuedAt: 1000,
+          expiresAt: 2000,
+          maxUses: 1,
+          idempotencyKey: 'occurrence-grant'
+        })
+        return { grantId: grant.grant.grantId, expectedGrantUseCount: grant.grant.useCount }
+      },
+      resolveTrustedRoute: () => ({ trusted: true }),
+      dispatch: { runAgent, runGraph: vi.fn() },
+      now: () => 1000
+    })
+    const occurrence: TriggerOccurrenceState = {
+      schemaVersion: 1,
+      occurrenceId: 'occurrence-1',
+      triggerId: 'trigger-1',
+      source: 'channel-message',
+      scheduledAt: 321,
+      requestedAt: 300,
+      status: 'claimed',
+      attempt: 2,
+      idempotencyKey: 'occurrence-key',
+      semanticDigest: 'digest',
+      claim: { owner: 'worker-1', claimedAt: 310, expiresAt: 1310 },
+      createdAt: 300,
+      updatedAt: 310
+    }
+
+    await executor.executeOccurrence(
+      trigger({
+        kind: 'agent-run',
+        agentId: 'agent-1',
+        prompt: 'occurrence prompt',
+        sessionId: 'session-1'
+      }),
+      occurrence
+    )
+
+    expect(runAgent.mock.calls[0][0].trustedContext).toEqual({
+      triggerId: 'trigger-1',
+      occurrenceId: 'occurrence-1',
+      requestId: 'trigger-run:trigger-1:occurrence-1:worker-1',
+      occurrenceAt: 321,
+      triggerType: 'schedule',
+      triggerTitle: 'Nightly',
+      targetAgentId: 'agent-1',
+      targetSessionId: 'session-1',
+      source: 'channel-message',
+      attempt: 2
+    })
   })
 
   it('maps graph target and preserves input only for dispatch', async () => {
@@ -132,6 +203,7 @@ describe('production trigger executor', () => {
     )
     expect(result).toMatchObject({ graphId: 'graph-1', input: { secret: 'payload' } })
     expect(runGraph).toHaveBeenCalledOnce()
+    expect(runGraph.mock.calls[0][0]).not.toHaveProperty('trustedContext')
     const audit = service.listAuditResources().map((resource) => JSON.stringify(resource.state))
     expect(audit.join(String.fromCharCode(10))).not.toContain('"secret":"payload"')
   })

--- a/packages/app/src/main/magicAgentPlatform2/triggers/productionTriggerExecutor.ts
+++ b/packages/app/src/main/magicAgentPlatform2/triggers/productionTriggerExecutor.ts
@@ -17,12 +17,14 @@ import {
 } from './trustedTargetAdapter'
 import type { PersistentTriggerState } from './persistentTriggerStore'
 import type { TriggerOccurrenceState } from './triggerOccurrenceStore'
+import type { TriggerTrustedDispatchContext } from '../../magicAgentRuntime/triggerTrustedDispatchContext'
 
 export type TriggerAgentDispatchInput = Readonly<{
   agentId: string
   prompt: string
   sessionId?: string
   route: PolicyJsonRecord
+  trustedContext?: TriggerTrustedDispatchContext
 }>
 
 export type TriggerGraphDispatchInput = Readonly<{
@@ -91,6 +93,7 @@ const occurrenceInput = (trigger: PersistentTriggerState) => {
 
 const dispatchTarget = <TResult>(
   target: TrustedTriggerExecutionTarget,
+  policyInput: TriggerPolicyRequestFactoryInput,
   route: PolicyJsonRecord,
   dispatch: ProductionTriggerDispatchers<TResult>
 ): Promise<TResult> | TResult => {
@@ -99,7 +102,25 @@ const dispatchTarget = <TResult>(
       agentId: target.agentId,
       prompt: target.prompt,
       ...(target.sessionId === undefined ? {} : { sessionId: target.sessionId }),
-      route
+      route,
+      trustedContext: {
+        triggerId: policyInput.triggerId,
+        requestId: policyInput.requestId,
+        occurrenceAt: policyInput.occurrence.occurrenceAt,
+        triggerType: policyInput.trigger.type,
+        triggerTitle: policyInput.trigger.title,
+        targetAgentId: target.agentId,
+        ...(policyInput.occurrence.occurrenceId === undefined
+          ? {}
+          : { occurrenceId: policyInput.occurrence.occurrenceId }),
+        ...(target.sessionId === undefined ? {} : { targetSessionId: target.sessionId }),
+        ...(policyInput.occurrence.source === undefined
+          ? {}
+          : { source: policyInput.occurrence.source }),
+        ...(policyInput.occurrence.attempt === undefined
+          ? {}
+          : { attempt: policyInput.occurrence.attempt })
+      }
     })
   return dispatch.runGraph({
     graphId: target.graphId,
@@ -184,7 +205,12 @@ export class ProductionTriggerExecutor<TResult = unknown> {
       this.options.authorizationService,
       this.options.grantProvider,
       (_request, _authorization) =>
-        dispatchTarget(adapted.executionTarget, route, this.options.dispatch),
+        dispatchTarget(
+          adapted.executionTarget,
+          adapted.policyRequestInput,
+          route,
+          this.options.dispatch
+        ),
       this.now,
       this.options.outcomes === undefined
         ? undefined

--- a/packages/app/src/main/magicAgentPlatform2/triggers/productionTriggerLifecycle.test.ts
+++ b/packages/app/src/main/magicAgentPlatform2/triggers/productionTriggerLifecycle.test.ts
@@ -8,6 +8,7 @@ import {
   publishTrustedChannelMessage
 } from './channelMessageEvents'
 import type { PersistentTriggerState } from './persistentTriggerStore'
+import { readTriggerTrustedDispatchContext } from '../../magicAgentRuntime/triggerTrustedDispatchContext'
 import { MagicAgentEventStore } from '../persistence/eventStore'
 import { MagicAgentPolicyAuthorizationService } from '../policy'
 import type { AssistantTerminalPolicyRuntime } from '../productionRuntime'
@@ -283,6 +284,7 @@ describe('production trigger lifecycle adapter', () => {
       expect.objectContaining({
         agentId: 'a',
         text: 'p',
+        sessionId: 's',
         route: {
           channel: 'magic-agent-trigger',
           scopeType: 'agent',
@@ -292,6 +294,29 @@ describe('production trigger lifecycle adapter', () => {
       }),
       expect.objectContaining({ methodName: 'magic-agent.trigger.run' })
     )
+    const agentRequest = runAgent.mock.calls[0][0]
+    expect(readTriggerTrustedDispatchContext(agentRequest)).toMatchObject({
+      triggerId: 'agent-trigger',
+      occurrenceAt: 1000,
+      triggerType: 'schedule',
+      triggerTitle: 'agent-trigger',
+      targetAgentId: 'a',
+      targetSessionId: 's'
+    })
+    expect(readTriggerTrustedDispatchContext(agentRequest)?.requestId).toMatch(
+      /^trigger-run:agent-trigger:.+:1000$/
+    )
+    expect(JSON.parse(JSON.stringify(agentRequest))).toEqual({
+      agentId: 'a',
+      text: 'p',
+      sessionId: 's',
+      route: {
+        channel: 'magic-agent-trigger',
+        scopeType: 'agent',
+        scopeId: 'a',
+        threadId: 'trigger-runtime'
+      }
+    })
     lifecycle.runtime.store.create(
       makeTrigger('graph-trigger', { kind: 'graph-run', graphId: 'g', input: { x: 1 } }),
       1000

--- a/packages/app/src/main/magicAgentPlatform2/triggers/productionTriggerLifecycle.ts
+++ b/packages/app/src/main/magicAgentPlatform2/triggers/productionTriggerLifecycle.ts
@@ -11,6 +11,7 @@ import { subscribeWorkflowCompletions } from './workflowCompletionEvents'
 import { subscribeTrustedChannelMessages } from './channelMessageEvents'
 import { ProductionTriggerRuntime } from './productionTriggerRuntime'
 import type { PersistentTriggerState } from './persistentTriggerStore'
+import { attachTriggerTrustedDispatchContext } from '../../magicAgentRuntime/triggerTrustedDispatchContext'
 
 export const TRIGGER_ROUTE = 'magicpot-trigger://runtime' as const
 const SERVICE_ROUTE = (scopeId: string): AgentRouteLike => ({
@@ -66,11 +67,17 @@ export class ProductionTriggerLifecycle {
       eventStore: this.eventStore,
       authorization: options.policyRuntime.authorization,
       service: {
-        runAgent: (input) =>
-          options.service.runAgent(
-            { agentId: input.agentId, text: input.prompt, route: SERVICE_ROUTE(input.agentId) },
-            TRIGGER_INVOCATION
-          ),
+        runAgent: (input) => {
+          const request: MagicAgentPlatformRunReq = {
+            agentId: input.agentId,
+            text: input.prompt,
+            route: SERVICE_ROUTE(input.agentId),
+            ...(input.sessionId === undefined ? {} : { sessionId: input.sessionId })
+          }
+          if (input.trustedContext)
+            attachTriggerTrustedDispatchContext(request, input.trustedContext)
+          return options.service.runAgent(request, TRIGGER_INVOCATION)
+        },
         runGraph: (input) =>
           options.service.runGraph(
             {

--- a/packages/app/src/main/magicAgentRuntime/driveTrustedDispatchContext.ts
+++ b/packages/app/src/main/magicAgentRuntime/driveTrustedDispatchContext.ts
@@ -1,0 +1,63 @@
+import type { MagicAgentPlatformRunReq } from '@shared/api/svcMagicAgentPlatform'
+import type { MagicAgentDriveStatus } from '../../shared/magicAgentPlatform2/drive'
+
+export type DriveTrustedDispatchContext = Readonly<{
+  driveId: string
+  driveRevision: number
+  status: MagicAgentDriveStatus
+  assigneeId?: string
+  ownerId?: string
+  targetAgentId: string
+  targetSessionId?: string
+}>
+
+export const DRIVE_TRUSTED_DISPATCH_CONTEXT: unique symbol = Symbol(
+  'magicpot.drive.trustedDispatchContext'
+)
+
+type DriveTrustedRunRequest = MagicAgentPlatformRunReq & {
+  [DRIVE_TRUSTED_DISPATCH_CONTEXT]?: DriveTrustedDispatchContext
+}
+
+const requireId = (value: unknown, field: string): string => {
+  const normalized = typeof value === 'string' ? value.trim() : ''
+  if (!normalized) throw new TypeError(`Drive trusted context requires ${field}.`)
+  return normalized
+}
+
+const optionalId = (value: unknown, field: string): string | undefined =>
+  value === undefined ? undefined : requireId(value, field)
+
+export const attachDriveTrustedDispatchContext = (
+  request: MagicAgentPlatformRunReq,
+  context: DriveTrustedDispatchContext
+): MagicAgentPlatformRunReq => {
+  if (!Number.isSafeInteger(context.driveRevision) || context.driveRevision < 0) {
+    throw new TypeError('Drive trusted context requires a non-negative integer driveRevision.')
+  }
+  const validated = Object.freeze({
+    driveId: requireId(context.driveId, 'driveId'),
+    driveRevision: context.driveRevision,
+    status: requireId(context.status, 'status') as MagicAgentDriveStatus,
+    ...(context.assigneeId === undefined
+      ? {}
+      : { assigneeId: optionalId(context.assigneeId, 'assigneeId') }),
+    ...(context.ownerId === undefined ? {} : { ownerId: optionalId(context.ownerId, 'ownerId') }),
+    targetAgentId: requireId(context.targetAgentId, 'targetAgentId'),
+    ...(context.targetSessionId === undefined
+      ? {}
+      : { targetSessionId: optionalId(context.targetSessionId, 'targetSessionId') })
+  })
+  Object.defineProperty(request, DRIVE_TRUSTED_DISPATCH_CONTEXT, {
+    value: validated,
+    enumerable: true,
+    configurable: false,
+    writable: false
+  })
+  return request
+}
+
+export const readDriveTrustedDispatchContext = (
+  request: MagicAgentPlatformRunReq
+): DriveTrustedDispatchContext | undefined =>
+  (request as DriveTrustedRunRequest)[DRIVE_TRUSTED_DISPATCH_CONTEXT]

--- a/packages/app/src/main/magicAgentRuntime/platformAdapter.test.ts
+++ b/packages/app/src/main/magicAgentRuntime/platformAdapter.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
+import type { AgentAction, AgentEvent, DriveProgressPayload } from '@shared/agent'
+import type { MagicAgentPlatformRunReq } from '@shared/api/svcMagicAgentPlatform'
 import type { LLMChatReq, LLMChatResp } from '@shared/api/svcLLMProxy'
 import type { AssistantInboundMessage, AssistantRuntimeResult } from '../assistantRuntime/types'
 
@@ -12,6 +14,9 @@ vi.mock('electron', () => ({
 
 import { AgentKernel } from '../agentKernel'
 import { MagicAgentPlatformAdapter } from './platformAdapter'
+import { attachDriveTrustedDispatchContext } from './driveTrustedDispatchContext'
+import { attachRuntimeChannelTrustedDispatchContext } from './runtimeChannelTrustedDispatchContext'
+import { attachTriggerTrustedDispatchContext } from './triggerTrustedDispatchContext'
 import { MagicAgentToolRegistry } from './toolRegistry'
 import { MagicAgentCreativeToolRegistry } from './tools'
 import type { MagicAgentCreativeToolAdapter } from './tools'
@@ -47,27 +52,25 @@ const createAssistantRuntime = () => ({
     content: `assistant:${name}`,
     metadata: { args }
   })),
-  handleMessage: vi.fn(
-    async (req: AssistantInboundMessage): Promise<AssistantRuntimeResult> => ({
-      runId: 'assistant-run-1',
-      sessionKey: `${req.route.channel}:${req.route.scopeType}:${req.route.scopeId}`,
-      historySize: 1,
-      status: 'completed',
-      reply: { content: `assistant-run:${req.text || ''}` },
-      events: [
-        {
-          eventId: 'assistant-event-1',
-          runId: 'assistant-run-1',
-          sessionKey: `${req.route.channel}:${req.route.scopeType}:${req.route.scopeId}`,
-          route: req.route,
-          type: 'completed',
-          level: 'info',
-          message: 'AssistantRuntime completed.',
-          createdAt: 1234
-        }
-      ]
-    })
-  )
+  handleMessage: vi.fn(async (req: AssistantInboundMessage): Promise<AssistantRuntimeResult> => ({
+    runId: 'assistant-run-1',
+    sessionKey: `${req.route.channel}:${req.route.scopeType}:${req.route.scopeId}`,
+    historySize: 1,
+    status: 'completed',
+    reply: { content: `assistant-run:${req.text || ''}` },
+    events: [
+      {
+        eventId: 'assistant-event-1',
+        runId: 'assistant-run-1',
+        sessionKey: `${req.route.channel}:${req.route.scopeType}:${req.route.scopeId}`,
+        route: req.route,
+        type: 'completed',
+        level: 'info',
+        message: 'AssistantRuntime completed.',
+        createdAt: 1234
+      }
+    ]
+  }))
 })
 
 const creativeAdapter: MagicAgentCreativeToolAdapter = {
@@ -95,7 +98,1401 @@ const creativeAdapter: MagicAgentCreativeToolAdapter = {
       : null
 }
 
+class ScriptedDispatchKernel extends AgentKernel {
+  lastEvent?: AgentEvent
+
+  constructor(private readonly actions: AgentAction[]) {
+    super()
+  }
+
+  override dispatch(event: AgentEvent): AsyncIterable<AgentAction> {
+    this.lastEvent = event
+    const actions = this.actions
+    return {
+      async *[Symbol.asyncIterator]() {
+        yield* actions
+      }
+    }
+  }
+}
+
+const trustedTriggerRequest = (
+  overrides: Partial<MagicAgentPlatformRunReq> = {},
+  contextOverrides: Partial<Parameters<typeof attachTriggerTrustedDispatchContext>[1]> = {}
+): MagicAgentPlatformRunReq => {
+  const agentId = String(overrides.agentId ?? contextOverrides.targetAgentId ?? 'agent-1')
+  const sessionId = String(overrides.sessionId ?? contextOverrides.targetSessionId ?? 'session-1')
+  return attachTriggerTrustedDispatchContext(
+    {
+      agentId,
+      text: 'trigger prompt',
+      sessionId,
+      route: {
+        channel: 'magic-agent-trigger',
+        scopeType: 'agent',
+        scopeId: agentId,
+        threadId: 'trigger-runtime'
+      },
+      ...overrides
+    },
+    {
+      triggerId: 'trigger-1',
+      occurrenceId: 'occurrence-1',
+      requestId: 'request-1',
+      occurrenceAt: 1234,
+      triggerType: 'schedule',
+      triggerTitle: 'Nightly',
+      targetAgentId: agentId,
+      targetSessionId: sessionId,
+      source: 'cron',
+      attempt: 2,
+      ...contextOverrides
+    }
+  )
+}
+
 describe('MagicAgentPlatformAdapter', () => {
+  it('dispatches trusted Trigger requests with deterministic identity and provenance', async () => {
+    const dispatchKernel = new AgentKernel()
+    const dispatchSpy = vi.spyOn(dispatchKernel, 'dispatch')
+    const adapter = new MagicAgentPlatformAdapter({
+      chatService: createChatService(),
+      assistantRuntime: createAssistantRuntime(),
+      creativeToolRegistry: new MagicAgentCreativeToolRegistry({ adapters: [creativeAdapter] }),
+      dispatchKernel
+    })
+
+    await adapter.runAgent(trustedTriggerRequest())
+    const event = dispatchSpy.mock.calls[0][0]
+    expect(event).toMatchObject({
+      type: 'trigger.fired',
+      createdAt: 1234,
+      correlationId: event.eventId,
+      sessionId: 'session-1',
+      agentId: 'agent-1',
+      payload: {
+        request: expect.objectContaining({
+          agentId: 'agent-1',
+          text: 'trigger prompt',
+          sessionId: 'session-1'
+        }),
+        triggerId: 'trigger-1',
+        occurrenceId: 'occurrence-1',
+        requestId: 'request-1',
+        occurrenceAt: 1234,
+        triggerType: 'schedule',
+        triggerTitle: 'Nightly',
+        source: 'cron',
+        attempt: 2,
+        targetAgentId: 'agent-1',
+        targetSessionId: 'session-1'
+      },
+      provenance: {
+        source: 'trigger',
+        requestedBy: 'trigger:trigger-1',
+        channel: 'magic-agent-trigger',
+        traceId: event.eventId
+      }
+    })
+
+    await adapter.runAgent(trustedTriggerRequest())
+    expect(dispatchSpy.mock.calls[1][0].eventId).toBe(event.eventId)
+    for (const request of [
+      trustedTriggerRequest({}, { occurrenceId: 'occurrence-2' }),
+      trustedTriggerRequest({}, { attempt: 3 }),
+      trustedTriggerRequest(
+        {
+          agentId: 'agent-2',
+          sessionId: 'session-2',
+          route: {
+            channel: 'magic-agent-trigger',
+            scopeType: 'agent',
+            scopeId: 'agent-2',
+            threadId: 'trigger-runtime'
+          }
+        },
+        { targetAgentId: 'agent-2', targetSessionId: 'session-2' }
+      ),
+      trustedTriggerRequest({ text: 'different prompt' })
+    ]) {
+      await adapter.runAgent(request)
+      expect(dispatchSpy.mock.calls.at(-1)?.[0].eventId).not.toBe(event.eventId)
+    }
+    adapter.dispose()
+  })
+
+  it('strictly rejects Trigger context binding mismatches and context conflicts', async () => {
+    const dispatchKernel = new AgentKernel()
+    const adapter = new MagicAgentPlatformAdapter({
+      chatService: createChatService(),
+      assistantRuntime: createAssistantRuntime(),
+      creativeToolRegistry: new MagicAgentCreativeToolRegistry({ adapters: [creativeAdapter] }),
+      dispatchKernel
+    })
+    const mismatches = [
+      trustedTriggerRequest({
+        route: {
+          channel: 'generic',
+          scopeType: 'agent',
+          scopeId: 'agent-1',
+          threadId: 'trigger-runtime'
+        }
+      }),
+      trustedTriggerRequest({
+        route: {
+          channel: 'magic-agent-trigger',
+          scopeType: 'dm',
+          scopeId: 'agent-1',
+          threadId: 'trigger-runtime'
+        }
+      }),
+      trustedTriggerRequest({
+        route: {
+          channel: 'magic-agent-trigger',
+          scopeType: 'agent',
+          scopeId: 'agent-2',
+          threadId: 'trigger-runtime'
+        }
+      }),
+      trustedTriggerRequest({
+        route: {
+          channel: 'magic-agent-trigger',
+          scopeType: 'agent',
+          scopeId: 'agent-1',
+          threadId: 'other-thread'
+        }
+      })
+    ]
+    for (const request of mismatches)
+      await expect(adapter.runAgent(request)).rejects.toThrow('must match')
+    await expect(
+      adapter.runAgent(
+        trustedTriggerRequest(
+          {
+            agentId: 'agent-2',
+            route: {
+              channel: 'magic-agent-trigger',
+              scopeType: 'agent',
+              scopeId: 'agent-1',
+              threadId: 'trigger-runtime'
+            }
+          },
+          { targetAgentId: 'agent-1' }
+        )
+      )
+    ).rejects.toThrow('targetAgentId must match')
+    await expect(
+      adapter.runAgent(
+        trustedTriggerRequest({ sessionId: 'session-2' }, { targetSessionId: 'session-1' })
+      )
+    ).rejects.toThrow('targetSessionId must match')
+
+    const conflicting = attachDriveTrustedDispatchContext(trustedTriggerRequest(), {
+      driveId: 'drive-1',
+      driveRevision: 1,
+      status: 'active',
+      targetAgentId: 'agent-1'
+    })
+    await expect(adapter.runAgent(conflicting)).rejects.toThrow('conflicting')
+    adapter.dispose()
+  })
+
+  it('rejects trusted Runtime Channel context that is not strictly bound to its request route', async () => {
+    const assistantRuntime = createAssistantRuntime()
+    const dispatchKernel = new AgentKernel()
+    const dispatchSpy = vi.spyOn(dispatchKernel, 'dispatch')
+    const adapter = new MagicAgentPlatformAdapter({
+      chatService: createChatService(),
+      assistantRuntime,
+      creativeToolRegistry: new MagicAgentCreativeToolRegistry({ adapters: [creativeAdapter] }),
+      dispatchKernel
+    })
+    const context = {
+      channelId: 'channel-1',
+      memberId: 'member-1',
+      pendingMessageIds: ['message-1'],
+      agentInstanceId: 'instance-1'
+    }
+
+    for (const route of [
+      { channel: 'generic', scopeType: 'dm', scopeId: 'channel-1' },
+      { channel: 'runtime-channel', scopeType: 'group', scopeId: 'channel-1' },
+      { channel: 'runtime-channel', scopeType: 'dm', scopeId: 'channel-2' }
+    ] as const) {
+      const request = attachRuntimeChannelTrustedDispatchContext(
+        { text: 'mismatched trusted route', route },
+        context
+      )
+      await expect(adapter.runAgent(request)).rejects.toThrow('must match')
+    }
+
+    expect(dispatchSpy).not.toHaveBeenCalled()
+    expect(assistantRuntime.handleMessage).not.toHaveBeenCalled()
+    adapter.dispose()
+  })
+
+  it('rolls back user.message registration when channel.message registration fails', () => {
+    const dispatchKernel = new AgentKernel()
+    const unregisterOccupied = dispatchKernel.registerActionHandler(
+      'channel.message',
+      async function* () {
+        yield* []
+      }
+    )
+
+    expect(
+      () =>
+        new MagicAgentPlatformAdapter({
+          chatService: createChatService(),
+          assistantRuntime: createAssistantRuntime(),
+          creativeToolRegistry: new MagicAgentCreativeToolRegistry({ adapters: [creativeAdapter] }),
+          dispatchKernel
+        })
+    ).toThrow('already registered')
+
+    const unregisterUser = dispatchKernel.registerActionHandler('user.message', async function* () {
+      yield* []
+    })
+    unregisterUser()
+    unregisterOccupied()
+  })
+
+  it('rolls back prior registrations when drive.assigned registration fails', () => {
+    const dispatchKernel = new AgentKernel()
+    const unregisterOccupied = dispatchKernel.registerActionHandler(
+      'drive.assigned',
+      async function* () {
+        yield* []
+      }
+    )
+    expect(
+      () =>
+        new MagicAgentPlatformAdapter({
+          chatService: createChatService(),
+          assistantRuntime: createAssistantRuntime(),
+          creativeToolRegistry: new MagicAgentCreativeToolRegistry({ adapters: [creativeAdapter] }),
+          dispatchKernel
+        })
+    ).toThrow('already registered')
+    const unregisterUser = dispatchKernel.registerActionHandler('user.message', async function* () {
+      yield* []
+    })
+    const unregisterChannel = dispatchKernel.registerActionHandler(
+      'channel.message',
+      async function* () {
+        yield* []
+      }
+    )
+    unregisterUser()
+    unregisterChannel()
+    unregisterOccupied()
+  })
+
+  it('rolls back all prior registrations when trigger.fired registration fails', () => {
+    const dispatchKernel = new AgentKernel()
+    const unregisterOccupied = dispatchKernel.registerActionHandler(
+      'trigger.fired',
+      async function* () {
+        yield* []
+      }
+    )
+    expect(
+      () =>
+        new MagicAgentPlatformAdapter({
+          chatService: createChatService(),
+          assistantRuntime: createAssistantRuntime(),
+          creativeToolRegistry: new MagicAgentCreativeToolRegistry({ adapters: [creativeAdapter] }),
+          dispatchKernel
+        })
+    ).toThrow('already registered')
+    const unregisterUser = dispatchKernel.registerActionHandler('user.message', async function* () {
+      yield* []
+    })
+    const unregisterChannel = dispatchKernel.registerActionHandler(
+      'channel.message',
+      async function* () {
+        yield* []
+      }
+    )
+    const unregisterDrive = dispatchKernel.registerActionHandler(
+      'drive.assigned',
+      async function* () {
+        yield* []
+      }
+    )
+    unregisterUser()
+    unregisterChannel()
+    unregisterDrive()
+    unregisterOccupied()
+  })
+
+  it('cleans invocation signal ownership when route validation throws', async () => {
+    const signal = new AbortController().signal
+    const addSpy = vi.spyOn(signal, 'addEventListener')
+    const removeSpy = vi.spyOn(signal, 'removeEventListener')
+    const adapter = new MagicAgentPlatformAdapter({
+      chatService: createChatService(),
+      assistantRuntime: createAssistantRuntime(),
+      creativeToolRegistry: new MagicAgentCreativeToolRegistry({ adapters: [creativeAdapter] })
+    })
+
+    await expect(
+      adapter.runAgent({ text: 'missing route' } as MagicAgentPlatformRunReq, { signal })
+    ).rejects.toThrow('explicit trusted route')
+    expect(addSpy).toHaveBeenCalledWith('abort', expect.any(Function), { once: true })
+    expect(removeSpy).toHaveBeenCalledWith('abort', expect.any(Function))
+    adapter.dispose()
+  })
+
+  it('dispatches trusted Drive assignments with deterministic identity and provenance', async () => {
+    const dispatchKernel = new AgentKernel()
+    const dispatchSpy = vi.spyOn(dispatchKernel, 'dispatch')
+    const reportOrder: string[] = []
+    const reportDriveProgress = vi.fn(async (_payload: DriveProgressPayload) => {
+      reportOrder.push('progress')
+    })
+    const adapter = new MagicAgentPlatformAdapter({
+      chatService: createChatService(),
+      assistantRuntime: createAssistantRuntime(),
+      creativeToolRegistry: new MagicAgentCreativeToolRegistry({ adapters: [creativeAdapter] }),
+      dispatchKernel,
+      reportDriveProgress
+    })
+    const request = (revision = 2, text = 'Continue goal', targetAgentId = 'agent-1') =>
+      attachDriveTrustedDispatchContext(
+        {
+          agentId: targetAgentId,
+          sessionId: 'drive-session',
+          text,
+          route: { channel: 'magicpot-drive://runtime', scopeType: 'channel', scopeId: 'drive-1' },
+          metadata: { driveId: 'drive-1', driveRevision: revision }
+        },
+        {
+          driveId: 'drive-1',
+          driveRevision: revision,
+          status: 'active',
+          ownerId: 'owner-1',
+          assigneeId: 'assignee-1',
+          targetAgentId,
+          targetSessionId: 'drive-session'
+        }
+      )
+
+    const firstResponse = await adapter.runAgent(request()).then((response) => {
+      reportOrder.push('returned')
+      return response
+    })
+    expect(firstResponse.content).toBe('assistant-run:Continue goal')
+    expect(reportOrder).toEqual(['progress', 'returned'])
+    const first = dispatchSpy.mock.calls[0][0]
+    expect(first).toMatchObject({
+      type: 'drive.assigned',
+      createdAt: 0,
+      correlationId: first.eventId,
+      sessionId: 'drive-session',
+      agentId: 'agent-1',
+      provenance: {
+        source: 'drive',
+        requestedBy: 'drive-owner:owner-1',
+        channel: 'drive-1',
+        traceId: first.eventId
+      },
+      payload: {
+        request: {
+          agentId: 'agent-1',
+          sessionId: 'drive-session',
+          text: 'Continue goal',
+          route: { channel: 'magicpot-drive://runtime', scopeType: 'channel', scopeId: 'drive-1' },
+          metadata: { driveId: 'drive-1', driveRevision: 2 }
+        },
+        driveId: 'drive-1',
+        driveRevision: 2,
+        status: 'active',
+        ownerId: 'owner-1',
+        assigneeId: 'assignee-1',
+        targetAgentId: 'agent-1',
+        targetSessionId: 'drive-session'
+      }
+    })
+    await adapter.runAgent(request())
+    await adapter.runAgent(request(3))
+    await adapter.runAgent(request(2, 'Different text'))
+    await adapter.runAgent(request(2, 'Continue goal', 'agent-2'))
+    expect(dispatchSpy.mock.calls[1][0].eventId).toBe(first.eventId)
+    expect(dispatchSpy.mock.calls[2][0].eventId).not.toBe(first.eventId)
+    expect(dispatchSpy.mock.calls[3][0].eventId).not.toBe(first.eventId)
+    expect(dispatchSpy.mock.calls[4][0].eventId).not.toBe(first.eventId)
+    expect(reportDriveProgress).toHaveBeenCalledTimes(4)
+    expect(reportDriveProgress.mock.calls[0][0]).toEqual({
+      driveId: 'drive-1',
+      expectedRevision: 2,
+      summary: 'assistant-run:Continue goal',
+      evidence: [
+        { kind: 'run', ref: 'assistant-run-1' },
+        { kind: 'session', ref: 'drive-session' }
+      ],
+      reportedAt: 0,
+      idempotencyKey: `${first.eventId}:drive-progress`
+    })
+    expect(reportDriveProgress.mock.calls[1][0].idempotencyKey).not.toBe(
+      reportDriveProgress.mock.calls[0][0].idempotencyKey
+    )
+    adapter.dispose()
+  })
+
+  it('joins concurrent duplicate Drive progress and retries after reporter failure', async () => {
+    let releaseReport!: () => void
+    const reportGate = new Promise<void>((resolve) => {
+      releaseReport = resolve
+    })
+    let fail = false
+    const reportDriveProgress = vi.fn(async () => {
+      if (fail) throw new Error('temporary progress failure')
+      await reportGate
+    })
+    const adapter = new MagicAgentPlatformAdapter({
+      chatService: createChatService(),
+      assistantRuntime: createAssistantRuntime(),
+      creativeToolRegistry: new MagicAgentCreativeToolRegistry({ adapters: [creativeAdapter] }),
+      reportDriveProgress
+    })
+    const request = attachDriveTrustedDispatchContext(
+      {
+        agentId: 'agent-1',
+        sessionId: 'drive-session',
+        text: 'Concurrent goal',
+        route: { channel: 'magicpot-drive://runtime', scopeType: 'channel', scopeId: 'drive-1' },
+        metadata: { driveId: 'drive-1', driveRevision: 2 }
+      },
+      {
+        driveId: 'drive-1',
+        driveRevision: 2,
+        status: 'active',
+        targetAgentId: 'agent-1',
+        targetSessionId: 'drive-session'
+      }
+    )
+
+    const first = adapter.runAgent(request)
+    const second = adapter.runAgent(request)
+    await vi.waitFor(() => expect(reportDriveProgress).toHaveBeenCalledOnce())
+    releaseReport()
+    await expect(Promise.all([first, second])).resolves.toHaveLength(2)
+    expect(reportDriveProgress).toHaveBeenCalledOnce()
+
+    fail = true
+    const retryRequest = attachDriveTrustedDispatchContext(
+      { ...request, text: 'Retry goal' },
+      {
+        driveId: 'drive-1',
+        driveRevision: 2,
+        status: 'active',
+        targetAgentId: 'agent-1',
+        targetSessionId: 'drive-session'
+      }
+    )
+    await expect(adapter.runAgent(retryRequest)).rejects.toThrow('temporary progress failure')
+    fail = false
+    await expect(adapter.runAgent(retryRequest)).resolves.toMatchObject({ status: 'completed' })
+    expect(reportDriveProgress).toHaveBeenCalledTimes(3)
+    adapter.dispose()
+  })
+
+  it('rejects a trusted Drive run when progress reporting fails', async () => {
+    const adapter = new MagicAgentPlatformAdapter({
+      chatService: createChatService(),
+      assistantRuntime: createAssistantRuntime(),
+      creativeToolRegistry: new MagicAgentCreativeToolRegistry({ adapters: [creativeAdapter] }),
+      reportDriveProgress: async () => {
+        throw new Error('progress reporter unavailable')
+      }
+    })
+    const request = attachDriveTrustedDispatchContext(
+      {
+        agentId: 'agent-1',
+        sessionId: 'drive-session',
+        text: 'Continue goal',
+        route: { channel: 'magicpot-drive://runtime', scopeType: 'channel', scopeId: 'drive-1' },
+        metadata: { driveId: 'drive-1', driveRevision: 2 }
+      },
+      {
+        driveId: 'drive-1',
+        driveRevision: 2,
+        status: 'active',
+        targetAgentId: 'agent-1',
+        targetSessionId: 'drive-session'
+      }
+    )
+
+    await expect(adapter.runAgent(request)).rejects.toThrow('progress reporter unavailable')
+    adapter.dispose()
+  })
+
+  it('rejects Drive route, metadata, agent, and session mismatches before dispatch', async () => {
+    const dispatchKernel = new AgentKernel()
+    const dispatchSpy = vi.spyOn(dispatchKernel, 'dispatch')
+    const adapter = new MagicAgentPlatformAdapter({
+      chatService: createChatService(),
+      assistantRuntime: createAssistantRuntime(),
+      creativeToolRegistry: new MagicAgentCreativeToolRegistry({ adapters: [creativeAdapter] }),
+      dispatchKernel
+    })
+    const context = {
+      driveId: 'drive-1',
+      driveRevision: 2,
+      status: 'active' as const,
+      targetAgentId: 'agent-1',
+      targetSessionId: 'session-1'
+    }
+    const valid = {
+      agentId: 'agent-1',
+      sessionId: 'session-1',
+      text: 'work',
+      route: { channel: 'magicpot-drive://runtime', scopeType: 'channel', scopeId: 'drive-1' },
+      metadata: { driveId: 'drive-1', driveRevision: 2 }
+    } as const
+    const mismatches: MagicAgentPlatformRunReq[] = [
+      { ...valid, route: { ...valid.route, scopeId: 'drive-2' } },
+      { ...valid, metadata: { ...valid.metadata, driveId: 'drive-2' } },
+      { ...valid, metadata: { ...valid.metadata, driveRevision: 3 } },
+      { ...valid, agentId: 'agent-2' },
+      { ...valid, sessionId: 'session-2' }
+    ]
+    for (const mismatch of mismatches) {
+      await expect(
+        adapter.runAgent(attachDriveTrustedDispatchContext(mismatch, context))
+      ).rejects.toThrow()
+    }
+    expect(dispatchSpy).not.toHaveBeenCalled()
+    adapter.dispose()
+  })
+
+  it('dispatches one structured user.message without recursively invoking AssistantRuntime', async () => {
+    const assistantRuntime = createAssistantRuntime()
+    const dispatchKernel = new AgentKernel()
+    const dispatchSpy = vi.spyOn(dispatchKernel, 'dispatch')
+    const adapter = new MagicAgentPlatformAdapter({
+      chatService: createChatService(),
+      assistantRuntime,
+      creativeToolRegistry: new MagicAgentCreativeToolRegistry({ adapters: [creativeAdapter] }),
+      dispatchKernel
+    })
+
+    const response = await adapter.runAgent({
+      agentId: 'magicpot.default.chat',
+      text: 'dispatch once',
+      sessionId: 'stable-session',
+      route: { channel: 'generic', scopeType: 'dm', scopeId: 'demo' },
+      metadata: { correlationId: 'stable-correlation', requestedBy: 'authorized-service' }
+    })
+
+    expect(response.content).toBe('assistant-run:dispatch once')
+    expect(dispatchSpy).toHaveBeenCalledTimes(1)
+    expect(assistantRuntime.handleMessage).toHaveBeenCalledTimes(1)
+    expect(dispatchSpy.mock.calls[0][0]).toMatchObject({
+      type: 'user.message',
+      correlationId: 'stable-correlation',
+      sessionId: 'stable-session',
+      agentId: 'magicpot.default.chat',
+      provenance: { source: 'magicAgentPlatform', requestedBy: 'authorized-service' }
+    })
+  })
+
+  it('dispatches trusted Runtime Channel wakes with deterministic structured identity', async () => {
+    const assistantRuntime = createAssistantRuntime()
+    const dispatchKernel = new AgentKernel()
+    const dispatchSpy = vi.spyOn(dispatchKernel, 'dispatch')
+    const adapter = new MagicAgentPlatformAdapter({
+      chatService: createChatService(),
+      assistantRuntime,
+      creativeToolRegistry: new MagicAgentCreativeToolRegistry({ adapters: [creativeAdapter] }),
+      dispatchKernel
+    })
+    const request = () =>
+      attachRuntimeChannelTrustedDispatchContext(
+        {
+          agentId: 'magicpot.default.chat',
+          text: 'exact channel wake text',
+          route: { channel: 'runtime-channel', scopeType: 'dm', scopeId: 'channel-1' }
+        },
+        {
+          channelId: 'channel-1',
+          memberId: 'member-1',
+          pendingMessageIds: ['message-1', 'message-2'],
+          agentInstanceId: 'instance-1'
+        }
+      )
+
+    await adapter.runAgent(request())
+    const first = dispatchSpy.mock.calls[0][0]
+    expect(first).toMatchObject({
+      type: 'channel.message',
+      correlationId: first.eventId,
+      provenance: {
+        source: 'runtimeChannel',
+        requestedBy: 'runtime-channel-member:member-1',
+        channel: 'channel-1',
+        traceId: first.eventId
+      },
+      payload: {
+        request: {
+          agentId: 'magicpot.default.chat',
+          text: 'exact channel wake text',
+          route: { channel: 'runtime-channel', scopeType: 'dm', scopeId: 'channel-1' }
+        },
+        channelId: 'channel-1',
+        memberId: 'member-1',
+        pendingMessageIds: ['message-1', 'message-2'],
+        agentInstanceId: 'instance-1'
+      }
+    })
+
+    await adapter.runAgent(request())
+    expect(dispatchSpy.mock.calls[1][0].eventId).toBe(first.eventId)
+
+    const changedInstance = attachRuntimeChannelTrustedDispatchContext(
+      { ...request() },
+      {
+        channelId: 'channel-1',
+        memberId: 'member-1',
+        pendingMessageIds: ['message-1', 'message-2'],
+        agentInstanceId: 'instance-2'
+      }
+    )
+    await adapter.runAgent(changedInstance)
+    const changedBatch = attachRuntimeChannelTrustedDispatchContext(
+      { ...request() },
+      {
+        channelId: 'channel-1',
+        memberId: 'member-1',
+        pendingMessageIds: ['message-2', 'message-1'],
+        agentInstanceId: 'instance-1'
+      }
+    )
+    await adapter.runAgent(changedBatch)
+    expect(dispatchSpy.mock.calls[2][0].eventId).not.toBe(first.eventId)
+    expect(dispatchSpy.mock.calls[3][0].eventId).not.toBe(first.eventId)
+    expect(assistantRuntime.handleMessage).toHaveBeenCalledTimes(3)
+  })
+
+  it('joins concurrent duplicate trusted wakes without corrupting invocation options', async () => {
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const assistantRuntime = createAssistantRuntime()
+    assistantRuntime.handleMessage.mockImplementation(async (req: AssistantInboundMessage) => {
+      await gate
+      return {
+        runId: 'run',
+        sessionKey: 'session',
+        historySize: 1,
+        status: 'completed',
+        reply: { content: req.text ?? '' },
+        events: []
+      }
+    })
+    const adapter = new MagicAgentPlatformAdapter({
+      chatService: createChatService(),
+      assistantRuntime,
+      creativeToolRegistry: new MagicAgentCreativeToolRegistry({ adapters: [creativeAdapter] })
+    })
+    const makeRequest = () =>
+      attachRuntimeChannelTrustedDispatchContext(
+        {
+          text: 'duplicate',
+          route: { channel: 'runtime-channel', scopeType: 'dm', scopeId: 'channel' }
+        },
+        {
+          channelId: 'channel',
+          memberId: 'member',
+          pendingMessageIds: ['message'],
+          agentInstanceId: 'instance'
+        }
+      )
+    const first = adapter.runAgent(makeRequest())
+    await vi.waitFor(() => expect(assistantRuntime.handleMessage).toHaveBeenCalledTimes(1))
+    const second = adapter.runAgent(makeRequest())
+    release()
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      expect.objectContaining({ content: 'duplicate' }),
+      expect.objectContaining({ content: 'duplicate' })
+    ])
+    expect(assistantRuntime.handleMessage).toHaveBeenCalledTimes(1)
+  })
+
+  it('executes child.start as a managed child reservation before reply', async () => {
+    const response = {
+      runId: 'child-run',
+      agentId: 'agent-1',
+      status: 'completed',
+      content: 'reserved'
+    }
+    const payload = {
+      parentInstanceId: 'instance-1',
+      parentExpectedRevision: 2,
+      child: {
+        id: 'child-1',
+        name: 'Child',
+        definitionId: 'definition-1',
+        configVersion: 'config-1',
+        limits: {
+          maxChildren: 0,
+          maxDepth: 1,
+          maxConcurrency: 1,
+          maxRuntimeMs: 1000,
+          allowedToolNames: ['read'],
+          workspaceRoots: ['C:/workspace']
+        }
+      },
+      createdAt: 10,
+      idempotencyKey: 'child-1'
+    }
+    const startChild = vi.fn()
+    const kernel = new ScriptedDispatchKernel([
+      { actionId: 'child', type: 'child.start', payload },
+      { actionId: 'reply', type: 'reply.emit', payload: { response } }
+    ])
+    const adapter = new MagicAgentPlatformAdapter({
+      chatService: createChatService(),
+      assistantRuntime: createAssistantRuntime(),
+      creativeToolRegistry: new MagicAgentCreativeToolRegistry({ adapters: [creativeAdapter] }),
+      dispatchKernel: kernel,
+      startChild
+    })
+    const request = attachRuntimeChannelTrustedDispatchContext(
+      {
+        text: 'channel',
+        route: { channel: 'runtime-channel', scopeType: 'dm', scopeId: 'channel-1' }
+      },
+      {
+        channelId: 'channel-1',
+        memberId: 'member-1',
+        pendingMessageIds: ['incoming-1'],
+        agentInstanceId: 'instance-1'
+      }
+    )
+
+    await expect(adapter.runAgent(request)).resolves.toEqual(response)
+    expect(startChild).toHaveBeenCalledWith(payload, {
+      actor: { kind: 'agent', id: 'instance-1' },
+      agentInstanceId: 'instance-1',
+      sourceEvent: kernel.lastEvent
+    })
+  })
+
+  it('rejects child.start outside or mismatching trusted channel context', async () => {
+    const childAction: AgentAction = {
+      actionId: 'child',
+      type: 'child.start',
+      payload: {
+        parentInstanceId: 'other',
+        parentExpectedRevision: 0,
+        child: {
+          id: 'child',
+          name: 'Child',
+          definitionId: 'definition',
+          configVersion: 'config',
+          limits: {
+            maxChildren: 0,
+            maxDepth: 0,
+            maxConcurrency: 1,
+            maxRuntimeMs: 1,
+            allowedToolNames: [],
+            workspaceRoots: []
+          }
+        },
+        createdAt: 0,
+        idempotencyKey: 'key'
+      }
+    }
+    const reply: AgentAction = {
+      actionId: 'reply',
+      type: 'reply.emit',
+      payload: {
+        response: { runId: 'run', agentId: 'agent', status: 'completed', content: 'done' }
+      }
+    }
+    const userAdapter = new MagicAgentPlatformAdapter({
+      chatService: createChatService(),
+      assistantRuntime: createAssistantRuntime(),
+      creativeToolRegistry: new MagicAgentCreativeToolRegistry({ adapters: [creativeAdapter] }),
+      dispatchKernel: new ScriptedDispatchKernel([childAction, reply]),
+      startChild: vi.fn()
+    })
+    await expect(
+      userAdapter.runAgent({
+        text: 'user',
+        route: { channel: 'chat', scopeType: 'dm', scopeId: 'user' }
+      })
+    ).rejects.toThrow('only valid for a trusted channel.message event')
+
+    const channelAdapter = new MagicAgentPlatformAdapter({
+      chatService: createChatService(),
+      assistantRuntime: createAssistantRuntime(),
+      creativeToolRegistry: new MagicAgentCreativeToolRegistry({ adapters: [creativeAdapter] }),
+      dispatchKernel: new ScriptedDispatchKernel([childAction, reply]),
+      startChild: vi.fn()
+    })
+    await expect(
+      channelAdapter.runAgent(
+        attachRuntimeChannelTrustedDispatchContext(
+          {
+            text: 'channel',
+            route: { channel: 'runtime-channel', scopeType: 'dm', scopeId: 'channel' }
+          },
+          {
+            channelId: 'channel',
+            memberId: 'member',
+            pendingMessageIds: ['message'],
+            agentInstanceId: 'instance'
+          }
+        )
+      )
+    ).rejects.toThrow('does not match trusted Channel context')
+  })
+
+  it('executes message.publish only for matching trusted channel context before reply', async () => {
+    const response = {
+      runId: 'scripted-run',
+      agentId: 'agent-1',
+      status: 'completed',
+      content: 'published'
+    }
+    const payload = {
+      channelId: 'channel-1',
+      publisherMemberId: 'member-1',
+      messageId: 'out-1',
+      payload: { text: 'hello' },
+      priority: 2,
+      publishedAt: 10,
+      expiresAt: 20,
+      expectedChannelRevision: 3,
+      idempotencyKey: 'publish-1'
+    }
+    const publishMessage = vi.fn()
+    const kernel = new ScriptedDispatchKernel([
+      { actionId: 'publish', type: 'message.publish', payload },
+      { actionId: 'reply', type: 'reply.emit', payload: { response } }
+    ])
+    const adapter = new MagicAgentPlatformAdapter({
+      chatService: createChatService(),
+      assistantRuntime: createAssistantRuntime(),
+      creativeToolRegistry: new MagicAgentCreativeToolRegistry({ adapters: [creativeAdapter] }),
+      dispatchKernel: kernel,
+      publishMessage
+    })
+    const request = attachRuntimeChannelTrustedDispatchContext(
+      {
+        text: 'channel',
+        route: { channel: 'runtime-channel', scopeType: 'dm', scopeId: 'channel-1' }
+      },
+      {
+        channelId: 'channel-1',
+        memberId: 'member-1',
+        pendingMessageIds: ['incoming-1'],
+        agentInstanceId: 'instance-1'
+      }
+    )
+
+    await expect(adapter.runAgent(request)).resolves.toEqual(response)
+    expect(publishMessage).toHaveBeenCalledWith(payload, {
+      agentInstanceId: 'instance-1',
+      sourceEvent: kernel.lastEvent
+    })
+  })
+
+  it('settles identical message.publish actions once and retries failures', async () => {
+    const response = {
+      runId: 'scripted-run',
+      agentId: 'agent-1',
+      status: 'completed',
+      content: 'published'
+    }
+    const publish = {
+      actionId: 'publish-once',
+      type: 'message.publish',
+      payload: {
+        channelId: 'channel-1',
+        publisherMemberId: 'member-1',
+        messageId: 'out-1',
+        payload: null,
+        priority: 0,
+        publishedAt: 10,
+        expectedChannelRevision: 3,
+        idempotencyKey: 'publish-once'
+      }
+    } satisfies AgentAction
+    const request = () =>
+      attachRuntimeChannelTrustedDispatchContext(
+        {
+          text: 'channel',
+          route: { channel: 'runtime-channel', scopeType: 'dm', scopeId: 'channel-1' }
+        },
+        {
+          channelId: 'channel-1',
+          memberId: 'member-1',
+          pendingMessageIds: ['incoming-1'],
+          agentInstanceId: 'instance-1'
+        }
+      )
+    let rejectFirst = true
+    const publishMessage = vi.fn(async () => {
+      if (rejectFirst) {
+        rejectFirst = false
+        throw new Error('publisher failed')
+      }
+    })
+    const adapter = new MagicAgentPlatformAdapter({
+      chatService: createChatService(),
+      assistantRuntime: createAssistantRuntime(),
+      creativeToolRegistry: new MagicAgentCreativeToolRegistry({ adapters: [creativeAdapter] }),
+      dispatchKernel: new ScriptedDispatchKernel([
+        publish,
+        { actionId: 'reply', type: 'reply.emit', payload: { response } }
+      ]),
+      publishMessage
+    })
+    await expect(adapter.runAgent(request())).rejects.toThrow('publisher failed')
+    await expect(adapter.runAgent(request())).resolves.toEqual(response)
+    await expect(
+      Promise.all([adapter.runAgent(request()), adapter.runAgent(request())])
+    ).resolves.toEqual([response, response])
+    expect(publishMessage).toHaveBeenCalledTimes(2)
+  })
+
+  it('rejects message.publish outside matching trusted channel context and after reply', async () => {
+    const response = {
+      runId: 'scripted-run',
+      agentId: 'agent-1',
+      status: 'completed',
+      content: 'done'
+    }
+    const publish: AgentAction = {
+      actionId: 'publish',
+      type: 'message.publish',
+      payload: {
+        channelId: 'wrong-channel',
+        publisherMemberId: 'member-1',
+        messageId: 'out-1',
+        payload: {},
+        priority: 0,
+        publishedAt: 10,
+        expectedChannelRevision: 3,
+        idempotencyKey: 'publish-1'
+      }
+    }
+    const userAdapter = new MagicAgentPlatformAdapter({
+      chatService: createChatService(),
+      assistantRuntime: createAssistantRuntime(),
+      creativeToolRegistry: new MagicAgentCreativeToolRegistry({ adapters: [creativeAdapter] }),
+      dispatchKernel: new ScriptedDispatchKernel([publish])
+    })
+    await expect(
+      userAdapter.runAgent({
+        text: 'user',
+        route: { channel: 'generic', scopeType: 'dm', scopeId: 'demo' }
+      })
+    ).rejects.toThrow('only valid for a trusted channel.message event')
+
+    const request = attachRuntimeChannelTrustedDispatchContext(
+      {
+        text: 'channel',
+        route: { channel: 'runtime-channel', scopeType: 'dm', scopeId: 'channel-1' }
+      },
+      {
+        channelId: 'channel-1',
+        memberId: 'member-1',
+        pendingMessageIds: ['incoming-1'],
+        agentInstanceId: 'instance-1'
+      }
+    )
+    const mismatchAdapter = new MagicAgentPlatformAdapter({
+      chatService: createChatService(),
+      assistantRuntime: createAssistantRuntime(),
+      creativeToolRegistry: new MagicAgentCreativeToolRegistry({ adapters: [creativeAdapter] }),
+      dispatchKernel: new ScriptedDispatchKernel([publish])
+    })
+    await expect(mismatchAdapter.runAgent(request)).rejects.toThrow(
+      'does not match trusted Channel'
+    )
+    const terminalAdapter = new MagicAgentPlatformAdapter({
+      chatService: createChatService(),
+      assistantRuntime: createAssistantRuntime(),
+      creativeToolRegistry: new MagicAgentCreativeToolRegistry({ adapters: [creativeAdapter] }),
+      dispatchKernel: new ScriptedDispatchKernel([
+        { actionId: 'reply', type: 'reply.emit', payload: { response } },
+        {
+          actionId: publish.actionId,
+          type: publish.type,
+          payload: {
+            channelId: 'channel-1',
+            publisherMemberId: 'member-1',
+            messageId: 'out-1',
+            payload: {},
+            priority: 0,
+            publishedAt: 10,
+            expectedChannelRevision: 3,
+            idempotencyKey: 'publish-1'
+          }
+        }
+      ])
+    })
+    await expect(terminalAdapter.runAgent(request)).rejects.toThrow('action after terminal')
+  })
+
+  it('accepts reply-only trusted Channel dispatch behavior without publishing', async () => {
+    const response = {
+      runId: 'scripted-run',
+      agentId: 'agent-1',
+      status: 'completed',
+      content: 'scripted reply'
+    }
+    const publishMessage = vi.fn()
+    const adapter = new MagicAgentPlatformAdapter({
+      chatService: createChatService(),
+      assistantRuntime: createAssistantRuntime(),
+      creativeToolRegistry: new MagicAgentCreativeToolRegistry({ adapters: [creativeAdapter] }),
+      dispatchKernel: new ScriptedDispatchKernel([
+        { actionId: 'reply', type: 'reply.emit', payload: { response } }
+      ]),
+      publishMessage
+    })
+
+    await expect(
+      adapter.runAgent(
+        attachRuntimeChannelTrustedDispatchContext(
+          {
+            text: 'reply only',
+            route: { channel: 'runtime-channel', scopeType: 'dm', scopeId: 'channel-1' }
+          },
+          {
+            channelId: 'channel-1',
+            memberId: 'member-1',
+            pendingMessageIds: ['incoming-1'],
+            agentInstanceId: 'instance-1'
+          }
+        )
+      )
+    ).resolves.toEqual(response)
+    expect(publishMessage).not.toHaveBeenCalled()
+  })
+
+  it('rejects drive.progress for user, channel, and trigger dispatches', async () => {
+    const progress: AgentAction = {
+      actionId: 'progress',
+      type: 'drive.progress',
+      payload: {
+        driveId: 'drive-1',
+        expectedRevision: 2,
+        summary: 'progress',
+        evidence: [{ kind: 'text', ref: 'checkpoint' }],
+        reportedAt: 10,
+        idempotencyKey: 'progress-1'
+      }
+    }
+    const requests: MagicAgentPlatformRunReq[] = [
+      {
+        text: 'user',
+        route: { channel: 'generic', scopeType: 'dm', scopeId: 'demo' }
+      },
+      attachRuntimeChannelTrustedDispatchContext(
+        {
+          text: 'channel',
+          route: { channel: 'runtime-channel', scopeType: 'dm', scopeId: 'channel-1' }
+        },
+        {
+          channelId: 'channel-1',
+          memberId: 'member-1',
+          pendingMessageIds: ['message-1'],
+          agentInstanceId: 'instance-1'
+        }
+      ),
+      trustedTriggerRequest()
+    ]
+    for (const request of requests) {
+      const adapter = new MagicAgentPlatformAdapter({
+        chatService: createChatService(),
+        assistantRuntime: createAssistantRuntime(),
+        creativeToolRegistry: new MagicAgentCreativeToolRegistry({ adapters: [creativeAdapter] }),
+        dispatchKernel: new ScriptedDispatchKernel([progress])
+      })
+      await expect(adapter.runAgent(request)).rejects.toThrow(
+        'drive.progress is only valid for a trusted drive.assigned event'
+      )
+    }
+  })
+
+  it('rejects drive.progress mismatches and actions after reply', async () => {
+    const driveRequest = attachDriveTrustedDispatchContext(
+      {
+        agentId: 'agent-1',
+        sessionId: 'drive-session',
+        text: 'drive',
+        route: { channel: 'magicpot-drive://runtime', scopeType: 'channel', scopeId: 'drive-1' },
+        metadata: { driveId: 'drive-1', driveRevision: 2 }
+      },
+      {
+        driveId: 'drive-1',
+        driveRevision: 2,
+        status: 'active',
+        targetAgentId: 'agent-1',
+        targetSessionId: 'drive-session'
+      }
+    )
+    for (const progressPayload of [
+      {
+        driveId: 'drive-2',
+        expectedRevision: 2,
+        summary: 'progress',
+        evidence: [{ kind: 'text', ref: 'checkpoint' }],
+        reportedAt: 10,
+        idempotencyKey: 'progress-drive-mismatch'
+      },
+      {
+        driveId: 'drive-1',
+        expectedRevision: 3,
+        summary: 'progress',
+        evidence: [{ kind: 'text', ref: 'checkpoint' }],
+        reportedAt: 10,
+        idempotencyKey: 'progress-revision-mismatch'
+      }
+    ]) {
+      const mismatchAdapter = new MagicAgentPlatformAdapter({
+        chatService: createChatService(),
+        assistantRuntime: createAssistantRuntime(),
+        creativeToolRegistry: new MagicAgentCreativeToolRegistry({ adapters: [creativeAdapter] }),
+        dispatchKernel: new ScriptedDispatchKernel([
+          { actionId: 'progress', type: 'drive.progress', payload: progressPayload }
+        ])
+      })
+      await expect(mismatchAdapter.runAgent(driveRequest)).rejects.toThrow(
+        'drive.progress does not match trusted Drive context'
+      )
+    }
+
+    const response = {
+      runId: 'scripted-run',
+      agentId: 'agent-1',
+      status: 'completed',
+      content: 'done'
+    }
+    const afterReplyAdapter = new MagicAgentPlatformAdapter({
+      chatService: createChatService(),
+      assistantRuntime: createAssistantRuntime(),
+      creativeToolRegistry: new MagicAgentCreativeToolRegistry({ adapters: [creativeAdapter] }),
+      dispatchKernel: new ScriptedDispatchKernel([
+        { actionId: 'reply', type: 'reply.emit', payload: { response } },
+        {
+          actionId: 'progress',
+          type: 'drive.progress',
+          payload: {
+            driveId: 'drive-1',
+            expectedRevision: 2,
+            summary: 'progress',
+            evidence: [{ kind: 'text', ref: 'checkpoint' }],
+            reportedAt: 10,
+            idempotencyKey: 'progress-after-reply'
+          }
+        }
+      ])
+    })
+    await expect(afterReplyAdapter.runAgent(driveRequest)).rejects.toThrow('action after terminal')
+  })
+
+  it('rejects unsupported and multiple unary terminal actions', async () => {
+    const unsupported = new ScriptedDispatchKernel([
+      { actionId: 'a', type: 'tool.call', payload: {} }
+    ])
+    const adapter = new MagicAgentPlatformAdapter({
+      chatService: createChatService(),
+      assistantRuntime: createAssistantRuntime(),
+      creativeToolRegistry: new MagicAgentCreativeToolRegistry({ adapters: [creativeAdapter] }),
+      dispatchKernel: unsupported
+    })
+    const request = {
+      text: 'bad terminal',
+      route: { channel: 'generic', scopeType: 'dm', scopeId: 'demo' }
+    } as const
+    await expect(adapter.runAgent(request)).rejects.toThrow('unsupported action')
+
+    const response = {
+      runId: 'scripted-run',
+      agentId: 'agent-1',
+      status: 'completed',
+      content: 'done'
+    }
+    const multiple = new ScriptedDispatchKernel([
+      { actionId: 'a', type: 'reply.emit', payload: { response } },
+      { actionId: 'b', type: 'reply.emit', payload: { response } }
+    ])
+    const multipleAdapter = new MagicAgentPlatformAdapter({
+      chatService: createChatService(),
+      assistantRuntime: createAssistantRuntime(),
+      creativeToolRegistry: new MagicAgentCreativeToolRegistry({ adapters: [creativeAdapter] }),
+      dispatchKernel: multiple
+    })
+    await expect(multipleAdapter.runAgent(request)).rejects.toThrow('exactly one reply.emit')
+  })
+
+  it('disposes idempotently, rejects new runs, aborts active runs, and preserves an injected kernel', async () => {
+    const dispatchKernel = new AgentKernel()
+    dispatchKernel.registerCapability({
+      capabilityId: 'shared.capability',
+      name: 'Shared capability',
+      description: 'Shared capability retained across adapter disposal.',
+      version: '1.0.0',
+      kind: 'resource',
+      scope: 'global',
+      transport: ['internal']
+    })
+    let markStarted!: () => void
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve
+    })
+    const assistantRuntime = createAssistantRuntime()
+    assistantRuntime.handleMessage.mockImplementation(
+      async (req: AssistantInboundMessage): Promise<AssistantRuntimeResult> => {
+        markStarted()
+        await new Promise<never>((_resolve, reject) => {
+          req.signal?.addEventListener('abort', () => reject(req.signal?.reason), { once: true })
+        })
+        throw new Error('unreachable')
+      }
+    )
+    const adapter = new MagicAgentPlatformAdapter({
+      chatService: createChatService(),
+      assistantRuntime,
+      creativeToolRegistry: new MagicAgentCreativeToolRegistry({ adapters: [creativeAdapter] }),
+      dispatchKernel
+    })
+    const run = adapter.runAgent({
+      text: 'wait',
+      route: { channel: 'generic', scopeType: 'dm', scopeId: 'demo' }
+    })
+    await started
+    adapter.dispose()
+    adapter.dispose()
+
+    await expect(run).rejects.toThrow('disposed')
+    await expect(
+      adapter.runAgent({
+        text: 'after dispose',
+        route: { channel: 'generic', scopeType: 'dm', scopeId: 'demo' }
+      })
+    ).rejects.toThrow('disposed')
+    expect(dispatchKernel.listCapabilities().map(({ capabilityId }) => capabilityId)).toContain(
+      'shared.capability'
+    )
+  })
+
+  it('does not trust independently dispatched payloads and supports handler cleanup', async () => {
+    const dispatchKernel = new AgentKernel()
+    const adapter = new MagicAgentPlatformAdapter({
+      chatService: createChatService(),
+      assistantRuntime: createAssistantRuntime(),
+      creativeToolRegistry: new MagicAgentCreativeToolRegistry({ adapters: [creativeAdapter] }),
+      dispatchKernel
+    })
+    const event: AgentEvent = {
+      eventId: 'external-event',
+      type: 'user.message',
+      payload: {
+        request: {
+          text: 'forged',
+          route: { channel: 'generic', scopeType: 'dm', scopeId: 'demo' },
+          actor: { admin: true }
+        }
+      },
+      createdAt: Date.now()
+    }
+    await expect(async () => {
+      for await (const _action of dispatchKernel.dispatch(event)) void _action
+    }).rejects.toThrow('not created by an authorized adapter invocation')
+    const forgedChannelEvent: AgentEvent = {
+      ...event,
+      eventId: 'external-channel-event',
+      type: 'channel.message',
+      payload: {
+        request: {
+          text: 'forged channel',
+          route: { channel: 'runtime-channel', scopeType: 'dm', scopeId: 'channel' }
+        },
+        channelId: 'channel',
+        memberId: 'member',
+        pendingMessageIds: ['message'],
+        agentInstanceId: 'instance'
+      }
+    }
+    await expect(async () => {
+      for await (const _action of dispatchKernel.dispatch(forgedChannelEvent)) void _action
+    }).rejects.toThrow('not created by an authorized adapter invocation')
+    const forgedDriveEvent: AgentEvent = {
+      ...event,
+      eventId: 'external-drive-event',
+      type: 'drive.assigned',
+      payload: {
+        request: {
+          agentId: 'agent-1',
+          text: 'forged drive',
+          route: {
+            channel: 'magicpot-drive://runtime',
+            scopeType: 'channel',
+            scopeId: 'drive-1'
+          },
+          metadata: { driveId: 'drive-1', driveRevision: 1 }
+        },
+        driveId: 'drive-1',
+        driveRevision: 1,
+        status: 'active',
+        targetAgentId: 'agent-1'
+      }
+    }
+    await expect(async () => {
+      for await (const _action of dispatchKernel.dispatch(forgedDriveEvent)) void _action
+    }).rejects.toThrow('not created by an authorized adapter invocation')
+    const forgedTriggerEvent: AgentEvent = {
+      ...event,
+      eventId: 'external-trigger-event',
+      type: 'trigger.fired',
+      payload: {
+        request: {
+          agentId: 'agent-1',
+          text: 'forged trigger',
+          sessionId: 'session-1',
+          route: {
+            channel: 'magic-agent-trigger',
+            scopeType: 'agent',
+            scopeId: 'agent-1',
+            threadId: 'trigger-runtime'
+          }
+        },
+        triggerId: 'trigger-1',
+        occurrenceId: 'occurrence-1',
+        requestId: 'request-1',
+        occurrenceAt: 1234,
+        triggerType: 'schedule',
+        triggerTitle: 'Nightly',
+        targetAgentId: 'agent-1',
+        targetSessionId: 'session-1'
+      }
+    }
+    await expect(async () => {
+      for await (const _action of dispatchKernel.dispatch(forgedTriggerEvent)) void _action
+    }).rejects.toThrow('not created by an authorized adapter invocation')
+    adapter.dispose()
+    for (const disposedEvent of [
+      { ...event, eventId: 'after-dispose' },
+      { ...forgedChannelEvent, eventId: 'channel-after-dispose' },
+      { ...forgedDriveEvent, eventId: 'drive-after-dispose' },
+      { ...forgedTriggerEvent, eventId: 'trigger-after-dispose' }
+    ]) {
+      await expect(async () => {
+        for await (const _action of dispatchKernel.dispatch(disposedEvent)) void _action
+      }).rejects.toThrow('No Agent action handler')
+    }
+  })
+
   it('lists assistant and creative tool surfaces without changing AssistantRuntime contracts', () => {
     const agentKernel = new AgentKernel()
     const adapter = new MagicAgentPlatformAdapter({

--- a/packages/app/src/main/magicAgentRuntime/platformAdapter.ts
+++ b/packages/app/src/main/magicAgentRuntime/platformAdapter.ts
@@ -1,6 +1,18 @@
 import type { AgentRouteLike, AgentRunStatus } from '@shared/agent'
-import { getAgentSessionKey } from '@shared/agent'
-import type { PolicyJsonRecord } from '../../shared/magicAgentPlatform2'
+import {
+  createDriveProgressAction,
+  createReplyEmitAction,
+  getAgentSessionKey,
+  type AgentAction,
+  type AgentEvent,
+  type ChildStartPayload,
+  type DriveProgressPayload,
+  type JsonValue,
+  isJsonValue,
+  type MessagePublishPayload
+} from '@shared/agent'
+import type { PolicyJsonRecord, RuntimeChannelMessageState } from '../../shared/magicAgentPlatform2'
+import { canonicalPolicyJson, sha256PolicyText } from '../../shared/magicAgentPlatform2/policy'
 import type {
   MagicAgentPlatformAgentDefinition,
   MagicAgentPlatformRunReq,
@@ -19,7 +31,8 @@ import type { AssistantRoute } from '../assistantRuntime/types'
 import { LLMProxySvcImpl } from '../api/svcLLMProxyImpl'
 import { getConfig } from '../config/config'
 import { getAssistantTerminalPolicyRuntime } from '../magicAgentPlatform2/productionRuntime'
-import { getAgentKernel, type AgentKernel } from '../agentKernel'
+import { getProductionAgentInstanceLifecycle } from '../magicAgentPlatform2/agents/productionAgentInstanceLifecycleOwner'
+import { getAgentKernel, AgentKernel } from '../agentKernel'
 import { MagicAgentRegistry } from './agentRegistry'
 import { MagicAgentRuntime } from './runtime'
 import { MagicAgentToolRegistry } from './toolRegistry'
@@ -33,6 +46,18 @@ import {
   type MagicAgentCreativeToolResult
 } from './tools'
 import { isMagicAgentPlatformDeniedToolName } from './toolPolicy'
+import {
+  readDriveTrustedDispatchContext,
+  type DriveTrustedDispatchContext
+} from './driveTrustedDispatchContext'
+import {
+  readRuntimeChannelTrustedDispatchContext,
+  type RuntimeChannelTrustedDispatchContext
+} from './runtimeChannelTrustedDispatchContext'
+import {
+  readTriggerTrustedDispatchContext,
+  type TriggerTrustedDispatchContext
+} from './triggerTrustedDispatchContext'
 
 import type { CooperativeExecutionGate } from '../magicAgentPlatform2/agents/cooperativeExecutionController'
 
@@ -56,9 +81,37 @@ export type MagicAgentPlatformAdapterDeps = {
   creativeToolRegistry?: MagicAgentCreativeToolRegistry
   creativeToolDependencies?: Partial<MagicAgentCreativeToolDependencies>
   agentKernel?: AgentKernel
+  dispatchKernel?: AgentKernel
+  reportDriveProgress?: (payload: DriveProgressPayload) => unknown | Promise<unknown>
+  publishMessage?: (
+    payload: MessagePublishPayload,
+    context: { agentInstanceId: string; sourceEvent: AgentEvent }
+  ) => unknown | Promise<unknown>
+  startChild?: (
+    payload: ChildStartPayload,
+    context: {
+      actor: { kind: 'agent'; id: string }
+      agentInstanceId: string
+      sourceEvent: AgentEvent
+    }
+  ) => unknown | Promise<unknown>
+  driveProgressSettlementMax?: number
+  messagePublishSettlementMax?: number
+  childStartSettlementMax?: number
 }
 
 const MAGIC_AGENT_KERNEL_PREFIX = 'magicagent.platform'
+const MAGIC_AGENT_USER_MESSAGE_EVENT = 'user.message'
+const MAGIC_AGENT_CHANNEL_MESSAGE_EVENT = 'channel.message'
+const MAGIC_AGENT_DRIVE_ASSIGNED_EVENT = 'drive.assigned'
+const MAGIC_AGENT_TRIGGER_FIRED_EVENT = 'trigger.fired'
+const MAGIC_AGENT_REPLY_EMIT_ACTION = 'reply.emit'
+const MAGIC_AGENT_DRIVE_PROGRESS_ACTION = 'drive.progress'
+const MAGIC_AGENT_MESSAGE_PUBLISH_ACTION = 'message.publish'
+const MAGIC_AGENT_CHILD_START_ACTION = 'child.start'
+const DRIVE_ROUTE = 'magicpot-drive://runtime'
+const TRIGGER_CHANNEL = 'magic-agent-trigger'
+const TRIGGER_THREAD = 'trigger-runtime'
 
 const cleanString = (value: unknown): string => String(value || '').trim()
 
@@ -82,6 +135,257 @@ const cloneRecord = (value?: Record<string, unknown>): Record<string, unknown> |
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+
+const toJsonValue = (value: unknown, label: string): JsonValue => {
+  try {
+    const serialized = JSON.stringify(value)
+    if (serialized === undefined) throw new Error()
+    return JSON.parse(serialized) as JsonValue
+  } catch {
+    throw new TypeError(`${label} must be JSON serializable.`)
+  }
+}
+
+const parseRunRequestPayload = (payload: JsonValue): MagicAgentPlatformRunReq => {
+  if (!isRecord(payload) || !isRecord(payload.request)) {
+    throw new TypeError('MagicAgent message payload must contain a request object.')
+  }
+  const request = payload.request
+  if (typeof request.text !== 'string' || !isRecord(request.route)) {
+    throw new TypeError('MagicAgent message request requires text and route fields.')
+  }
+  return request as MagicAgentPlatformRunReq
+}
+
+const runtimeChannelEventId = (
+  context: RuntimeChannelTrustedDispatchContext,
+  agentId: string
+): string =>
+  `channel-message:${sha256PolicyText(
+    canonicalPolicyJson({
+      channelId: context.channelId,
+      memberId: context.memberId,
+      pendingMessageIds: [...context.pendingMessageIds],
+      agentInstanceId: context.agentInstanceId,
+      agentId
+    })
+  )}`
+
+const driveEventId = (
+  context: DriveTrustedDispatchContext,
+  request: MagicAgentPlatformRunReq,
+  agentId: string,
+  sessionId: string
+): string =>
+  `drive-assigned:${sha256PolicyText(
+    canonicalPolicyJson({
+      driveId: context.driveId,
+      driveRevision: context.driveRevision,
+      targetAgentId: context.targetAgentId,
+      targetSessionId: context.targetSessionId ?? sessionId,
+      agentId,
+      text: request.text,
+      profileId: request.profileId ?? null,
+      allowedToolNames: request.allowedToolNames ? [...request.allowedToolNames] : null
+    })
+  )}`
+
+const triggerEventId = (
+  context: TriggerTrustedDispatchContext,
+  request: MagicAgentPlatformRunReq,
+  agentId: string,
+  sessionId: string
+): string =>
+  `trigger-fired:${sha256PolicyText(
+    canonicalPolicyJson({
+      triggerId: context.triggerId,
+      occurrenceId: context.occurrenceId ?? null,
+      requestId: context.requestId,
+      occurrenceAt: context.occurrenceAt,
+      source: context.source ?? null,
+      attempt: context.attempt ?? null,
+      targetAgentId: context.targetAgentId,
+      targetSessionId: context.targetSessionId ?? sessionId,
+      agentId,
+      text: request.text,
+      profileId: request.profileId ?? null,
+      allowedToolNames: request.allowedToolNames ? [...request.allowedToolNames] : null
+    })
+  )}`
+
+const parseRunResponsePayload = (payload: JsonValue): MagicAgentPlatformRunResp => {
+  if (
+    !isRecord(payload) ||
+    !isRecord(payload.response) ||
+    typeof payload.response.runId !== 'string' ||
+    typeof payload.response.agentId !== 'string' ||
+    typeof payload.response.status !== 'string' ||
+    typeof payload.response.content !== 'string'
+  ) {
+    throw new TypeError('MagicAgent reply.emit action contains an invalid response payload.')
+  }
+  return payload.response as MagicAgentPlatformRunResp
+}
+
+const parseDriveProgressPayload = (payload: JsonValue): DriveProgressPayload => {
+  if (
+    !isRecord(payload) ||
+    typeof payload.driveId !== 'string' ||
+    !payload.driveId.trim() ||
+    !Number.isInteger(payload.expectedRevision) ||
+    Number(payload.expectedRevision) < 0 ||
+    typeof payload.summary !== 'string' ||
+    !payload.summary.trim() ||
+    !Array.isArray(payload.evidence) ||
+    !Number.isFinite(payload.reportedAt) ||
+    Number(payload.reportedAt) < 0 ||
+    typeof payload.idempotencyKey !== 'string' ||
+    !payload.idempotencyKey.trim()
+  )
+    throw new TypeError('MagicAgent drive.progress action contains an invalid payload.')
+  for (const item of payload.evidence) {
+    if (
+      !isRecord(item) ||
+      !['session', 'run', 'artifact', 'url', 'text'].includes(String(item.kind)) ||
+      typeof item.ref !== 'string' ||
+      !item.ref.trim() ||
+      (item.digest !== undefined &&
+        (typeof item.digest !== 'string' || !/^[a-f0-9]{64}$/i.test(item.digest)))
+    )
+      throw new TypeError('MagicAgent drive.progress action contains invalid evidence.')
+  }
+  return payload as DriveProgressPayload
+}
+
+const parseMessagePublishPayload = (payload: JsonValue): MessagePublishPayload => {
+  const allowedKeys = new Set([
+    'channelId',
+    'publisherMemberId',
+    'messageId',
+    'payload',
+    'priority',
+    'publishedAt',
+    'expiresAt',
+    'expectedChannelRevision',
+    'idempotencyKey'
+  ])
+  if (
+    !isRecord(payload) ||
+    Object.keys(payload).some((key) => !allowedKeys.has(key)) ||
+    !['channelId', 'publisherMemberId', 'messageId', 'idempotencyKey'].every(
+      (key) => typeof payload[key] === 'string' && Boolean(String(payload[key]).trim())
+    ) ||
+    !Object.prototype.hasOwnProperty.call(payload, 'payload') ||
+    !isJsonValue(payload.payload) ||
+    !Number.isInteger(payload.priority) ||
+    !Number.isFinite(payload.priority) ||
+    !Number.isFinite(payload.publishedAt) ||
+    Number(payload.publishedAt) < 0 ||
+    (payload.expiresAt !== undefined &&
+      (!Number.isFinite(payload.expiresAt) ||
+        Number(payload.expiresAt) <= Number(payload.publishedAt))) ||
+    !Number.isInteger(payload.expectedChannelRevision) ||
+    Number(payload.expectedChannelRevision) < 0
+  )
+    throw new TypeError('MagicAgent message.publish action contains an invalid payload.')
+  return payload as MessagePublishPayload
+}
+
+const parseChildStartPayload = (payload: JsonValue): ChildStartPayload => {
+  if (!isRecord(payload) || !isRecord(payload.child) || !isRecord(payload.child.limits))
+    throw new TypeError('MagicAgent child.start action contains an invalid payload.')
+  const child = payload.child as Record<string, JsonValue>
+  const limits = child.limits as Record<string, JsonValue>
+  const nonempty = (value: unknown): boolean => typeof value === 'string' && Boolean(value.trim())
+  const nonnegativeInteger = (value: unknown): boolean =>
+    Number.isInteger(value) && Number(value) >= 0
+  const positiveInteger = (value: unknown): boolean => Number.isInteger(value) && Number(value) > 0
+  const validStringArray = (value: unknown): value is string[] =>
+    Array.isArray(value) &&
+    value.every(nonempty) &&
+    new Set(value as string[]).size === value.length
+  if (
+    !nonempty(payload.parentInstanceId) ||
+    !nonnegativeInteger(payload.parentExpectedRevision) ||
+    !nonempty(child.id) ||
+    !nonempty(child.name) ||
+    !nonempty(child.definitionId) ||
+    (child.ownerId !== undefined && !nonempty(child.ownerId)) ||
+    !nonempty(child.configVersion) ||
+    (child.pendingConfigVersion !== undefined && !nonempty(child.pendingConfigVersion)) ||
+    (child.previousConfigVersion !== undefined && !nonempty(child.previousConfigVersion)) ||
+    (child.configActivatedAt !== undefined && !nonnegativeInteger(child.configActivatedAt)) ||
+    !nonnegativeInteger(limits.maxChildren) ||
+    !nonnegativeInteger(limits.maxDepth) ||
+    !positiveInteger(limits.maxConcurrency) ||
+    !positiveInteger(limits.maxRuntimeMs) ||
+    !validStringArray(limits.allowedToolNames) ||
+    !validStringArray(limits.workspaceRoots) ||
+    (child.runtimeTopologyAttribution !== undefined &&
+      !isJsonValue(child.runtimeTopologyAttribution)) ||
+    !nonnegativeInteger(payload.createdAt) ||
+    !nonempty(payload.idempotencyKey)
+  )
+    throw new TypeError('MagicAgent child.start action contains an invalid payload.')
+  return payload as unknown as ChildStartPayload
+}
+
+const defaultStartChild = async (
+  payload: ChildStartPayload,
+  context: {
+    actor: { kind: 'agent'; id: string }
+    agentInstanceId: string
+    sourceEvent: AgentEvent
+  }
+): Promise<void> => {
+  const lifecycle = getProductionAgentInstanceLifecycle()
+  if (!lifecycle) throw new Error('Production Agent instance lifecycle is unavailable.')
+  // child.start reserves a managed child in created state; it does not run it.
+  lifecycle.commands.createChild({
+    actor: context.actor,
+    parentInstanceId: payload.parentInstanceId,
+    parentExpectedRevision: payload.parentExpectedRevision,
+    instance: payload.child as unknown as Omit<
+      import('../../shared/magicAgentPlatform2').MagicAgentInstanceState,
+      'parentInstanceId' | 'depth' | 'status'
+    >,
+    createdAt: payload.createdAt,
+    idempotencyKey: payload.idempotencyKey
+  })
+}
+
+const defaultReportDriveProgress = async (payload: DriveProgressPayload): Promise<void> => {
+  const { getProductionDriveLifecycle } =
+    await import('../magicAgentPlatform2/drives/productionDriveLifecycle')
+  const lifecycle = getProductionDriveLifecycle()
+  if (!lifecycle) throw new Error('Production Drive lifecycle is unavailable.')
+  lifecycle.commands.reportProgress(payload)
+}
+
+const defaultPublishMessage = async (
+  payload: MessagePublishPayload,
+  context: { agentInstanceId: string; sourceEvent: AgentEvent }
+): Promise<void> => {
+  const { getProductionRuntimeChannelLifecycle } =
+    await import('../magicAgentPlatform2/channels/productionRuntimeChannelLifecycle')
+  const lifecycle = getProductionRuntimeChannelLifecycle()
+  if (!lifecycle) throw new Error('Production Runtime Channel lifecycle is unavailable.')
+  const message: RuntimeChannelMessageState = {
+    id: payload.messageId,
+    channelId: payload.channelId,
+    publisherMemberId: payload.publisherMemberId,
+    payload: payload.payload,
+    priority: payload.priority,
+    publishedAt: payload.publishedAt,
+    ...(payload.expiresAt === undefined ? {} : { expiresAt: payload.expiresAt })
+  }
+  lifecycle.commands.publish({
+    actor: { kind: 'agent', id: context.agentInstanceId },
+    message,
+    expectedChannelRevision: payload.expectedChannelRevision,
+    idempotencyKey: payload.idempotencyKey
+  })
+}
 
 const toKernelSafeSegment = (value: unknown): string =>
   cleanString(value).replace(/[^a-zA-Z0-9_.-]+/g, '_') || 'unknown'
@@ -316,6 +620,41 @@ const isMagicAgentCreativeToolResult = (value: unknown): value is MagicAgentCrea
 const isPermissionError = (error: unknown): boolean =>
   error instanceof Error && /permission|not allowed|denied/i.test(error.message)
 
+const composeAbortSignals = (
+  signals: ReadonlyArray<AbortSignal | undefined>
+): { signal: AbortSignal; cleanup: () => void } => {
+  const controller = new AbortController()
+  const activeSignals = signals.filter((signal): signal is AbortSignal => Boolean(signal))
+  const listeners = new Map<AbortSignal, () => void>()
+  for (const signal of activeSignals) {
+    const forward = (): void => controller.abort(signal.reason)
+    if (signal.aborted) {
+      forward()
+      break
+    }
+    listeners.set(signal, forward)
+    signal.addEventListener('abort', forward, { once: true })
+  }
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      for (const [signal, listener] of listeners) signal.removeEventListener('abort', listener)
+      listeners.clear()
+    }
+  }
+}
+
+type PendingRunContext = {
+  options: MagicAgentPlatformExecutionOptions
+  callers: number
+  handlerActive: boolean
+}
+
+type ActionSettlement = {
+  fingerprint: string
+  execution: Promise<void>
+}
+
 export class MagicAgentPlatformAdapter {
   private readonly assistantRuntime: Pick<
     AssistantRuntime,
@@ -324,9 +663,32 @@ export class MagicAgentPlatformAdapter {
   private readonly creativeToolRegistry: MagicAgentCreativeToolRegistry
   private readonly creativeToolDependencies?: Partial<MagicAgentCreativeToolDependencies>
   private readonly agentKernel: AgentKernel
+  private readonly dispatchKernel: AgentKernel
   private readonly runtimeToolRegistry: MagicAgentToolRegistry
   private readonly runtime: MagicAgentRuntime
+  private readonly reportDriveProgress: (
+    payload: DriveProgressPayload
+  ) => unknown | Promise<unknown>
+  private readonly publishMessage: (
+    payload: MessagePublishPayload,
+    context: { agentInstanceId: string; sourceEvent: AgentEvent }
+  ) => unknown | Promise<unknown>
+  private readonly startChild: NonNullable<MagicAgentPlatformAdapterDeps['startChild']>
+  private readonly driveProgressSettlementMax: number
+  private readonly messagePublishSettlementMax: number
+  private readonly childStartSettlementMax: number
+  private readonly driveProgressSettlements = new Map<string, ActionSettlement>()
+  private readonly messagePublishSettlements = new Map<string, ActionSettlement>()
+  private readonly childStartSettlements = new Map<string, ActionSettlement>()
+  private readonly pendingRunOptions = new Map<string, PendingRunContext>()
+  private readonly activeInvocationControllers = new Set<AbortController>()
+  private readonly unregisterUserMessageHandler: () => void
+  private readonly unregisterChannelMessageHandler: () => void
+  private readonly unregisterDriveAssignedHandler: () => void
+  private readonly unregisterTriggerFiredHandler: () => void
+  private readonly ownsDispatchKernel: boolean
   private readonly managedKernelCapabilityIds = new Set<string>()
+  private disposed = false
   private kernelSurfaceSignature = ''
 
   constructor(deps: MagicAgentPlatformAdapterDeps = {}) {
@@ -334,6 +696,51 @@ export class MagicAgentPlatformAdapter {
     this.creativeToolRegistry = deps.creativeToolRegistry || createMagicAgentCreativeToolRegistry()
     this.creativeToolDependencies = deps.creativeToolDependencies
     this.agentKernel = deps.agentKernel || getAgentKernel()
+    this.ownsDispatchKernel = !deps.dispatchKernel
+    this.dispatchKernel = deps.dispatchKernel || new AgentKernel()
+    this.reportDriveProgress = deps.reportDriveProgress || defaultReportDriveProgress
+    this.publishMessage = deps.publishMessage || defaultPublishMessage
+    this.startChild = deps.startChild || defaultStartChild
+    this.driveProgressSettlementMax = deps.driveProgressSettlementMax ?? 1_000
+    this.messagePublishSettlementMax = deps.messagePublishSettlementMax ?? 1_000
+    this.childStartSettlementMax = deps.childStartSettlementMax ?? 1_000
+    if (!Number.isInteger(this.driveProgressSettlementMax) || this.driveProgressSettlementMax < 0)
+      throw new Error('MagicAgent drive progress settlement max must be a nonnegative integer.')
+    if (!Number.isInteger(this.messagePublishSettlementMax) || this.messagePublishSettlementMax < 0)
+      throw new Error('MagicAgent message publish settlement max must be a nonnegative integer.')
+    if (!Number.isInteger(this.childStartSettlementMax) || this.childStartSettlementMax < 0)
+      throw new Error('MagicAgent child start settlement max must be a nonnegative integer.')
+    this.unregisterUserMessageHandler = this.dispatchKernel.registerActionHandler(
+      MAGIC_AGENT_USER_MESSAGE_EVENT,
+      (event, context) => this.handleMessage(event, context.signal)
+    )
+    try {
+      this.unregisterChannelMessageHandler = this.dispatchKernel.registerActionHandler(
+        MAGIC_AGENT_CHANNEL_MESSAGE_EVENT,
+        (event, context) => this.handleMessage(event, context.signal)
+      )
+      try {
+        this.unregisterDriveAssignedHandler = this.dispatchKernel.registerActionHandler(
+          MAGIC_AGENT_DRIVE_ASSIGNED_EVENT,
+          (event, context) => this.handleMessage(event, context.signal)
+        )
+        try {
+          this.unregisterTriggerFiredHandler = this.dispatchKernel.registerActionHandler(
+            MAGIC_AGENT_TRIGGER_FIRED_EVENT,
+            (event, context) => this.handleMessage(event, context.signal)
+          )
+        } catch (error) {
+          this.unregisterDriveAssignedHandler()
+          throw error
+        }
+      } catch (error) {
+        this.unregisterChannelMessageHandler()
+        throw error
+      }
+    } catch (error) {
+      this.unregisterUserMessageHandler()
+      throw error
+    }
 
     this.runtimeToolRegistry = deps.toolRegistry || new MagicAgentToolRegistry()
     this.runtime = new MagicAgentRuntime({
@@ -342,6 +749,113 @@ export class MagicAgentPlatformAdapter {
       toolRegistry: this.runtimeToolRegistry
     })
     this.refreshRuntimeTools()
+  }
+
+  dispose(): void {
+    if (this.disposed) return
+    this.disposed = true
+    this.unregisterUserMessageHandler()
+    this.unregisterChannelMessageHandler()
+    this.unregisterDriveAssignedHandler()
+    this.unregisterTriggerFiredHandler()
+    for (const controller of this.activeInvocationControllers) {
+      controller.abort(new Error('MagicAgentPlatformAdapter has been disposed.'))
+    }
+    this.activeInvocationControllers.clear()
+    this.pendingRunOptions.clear()
+    this.driveProgressSettlements.clear()
+    this.messagePublishSettlements.clear()
+    this.childStartSettlements.clear()
+    if (this.ownsDispatchKernel) this.dispatchKernel.clear()
+  }
+
+  private async executeActionOnce(
+    action: AgentAction,
+    payload: JsonValue,
+    settlements: Map<string, ActionSettlement>,
+    settlementMax: number,
+    execute: () => unknown | Promise<unknown>,
+    label: string
+  ): Promise<void> {
+    const fingerprint = canonicalPolicyJson(payload as unknown as PolicyJsonRecord)
+    const existing = settlements.get(action.actionId)
+    if (existing) {
+      if (existing.fingerprint !== fingerprint)
+        throw new Error(`MagicAgent ${label} action "${action.actionId}" payload conflict.`)
+      return existing.execution
+    }
+
+    const settlement: ActionSettlement = { fingerprint, execution: Promise.resolve() }
+    settlement.execution = Promise.resolve(execute()).then(
+      () => {
+        if (settlements.get(action.actionId) !== settlement) return
+        if (settlementMax === 0) {
+          settlements.delete(action.actionId)
+          return
+        }
+        settlements.delete(action.actionId)
+        settlements.set(action.actionId, settlement)
+        while (settlements.size > settlementMax) {
+          const oldest = settlements.keys().next().value
+          if (oldest === undefined) break
+          settlements.delete(oldest)
+        }
+      },
+      (error) => {
+        if (settlements.get(action.actionId) === settlement) settlements.delete(action.actionId)
+        throw error
+      }
+    )
+    settlements.set(action.actionId, settlement)
+    return settlement.execution
+  }
+
+  private executeDriveProgressOnce(
+    action: AgentAction,
+    payload: DriveProgressPayload
+  ): Promise<void> {
+    return this.executeActionOnce(
+      action,
+      payload as unknown as JsonValue,
+      this.driveProgressSettlements,
+      this.driveProgressSettlementMax,
+      () => this.reportDriveProgress(payload),
+      MAGIC_AGENT_DRIVE_PROGRESS_ACTION
+    )
+  }
+
+  private executeMessagePublishOnce(
+    action: AgentAction,
+    payload: MessagePublishPayload,
+    context: { agentInstanceId: string; sourceEvent: AgentEvent }
+  ): Promise<void> {
+    return this.executeActionOnce(
+      action,
+      payload as unknown as JsonValue,
+      this.messagePublishSettlements,
+      this.messagePublishSettlementMax,
+      () => this.publishMessage(payload, context),
+      MAGIC_AGENT_MESSAGE_PUBLISH_ACTION
+    )
+  }
+
+  private executeChildStartOnce(
+    action: AgentAction,
+    payload: ChildStartPayload,
+    context: {
+      actor: { kind: 'agent'; id: string }
+      agentInstanceId: string
+      sourceEvent: AgentEvent
+    }
+  ): Promise<void> {
+    return this.executeActionOnce(
+      action,
+      payload as unknown as JsonValue,
+      this.childStartSettlements,
+      this.childStartSettlementMax,
+      () => this.startChild(payload, context),
+      MAGIC_AGENT_CHILD_START_ACTION
+    )
   }
 
   refreshRuntimeTools(): void {
@@ -362,9 +876,7 @@ export class MagicAgentPlatformAdapter {
                 args,
                 {
                   allowedToolNames: context.metadata?.allowedToolNames as
-                    | string[]
-                    | null
-                    | undefined
+                    string[] | null | undefined
                 }
               )
               return {
@@ -504,6 +1016,370 @@ export class MagicAgentPlatformAdapter {
   }
 
   async runAgent(
+    req: MagicAgentPlatformRunReq,
+    options: MagicAgentPlatformExecutionOptions = {}
+  ): Promise<MagicAgentPlatformRunResp> {
+    if (this.disposed) throw new Error('MagicAgentPlatformAdapter has been disposed.')
+    const invocationController = new AbortController()
+    this.activeInvocationControllers.add(invocationController)
+    const invocationSignals = composeAbortSignals([options.signal, invocationController.signal])
+    let pendingEventId: string | undefined
+    try {
+      const rawRoute = req.route
+      const route = requirePlatformRoute(rawRoute, 'agent run')
+      const agentId = normalizeMagicPotToolName(req.agentId) || 'magicpot.default.chat'
+      const channelContext = readRuntimeChannelTrustedDispatchContext(req)
+      const driveContext = readDriveTrustedDispatchContext(req)
+      const triggerContext = readTriggerTrustedDispatchContext(req)
+      if ([channelContext, driveContext, triggerContext].filter(Boolean).length > 1) {
+        throw new Error(
+          'MagicAgent run cannot contain conflicting Channel, Drive, or Trigger trusted contexts.'
+        )
+      }
+      if (
+        channelContext &&
+        (route.channel !== 'runtime-channel' ||
+          route.scopeType !== 'dm' ||
+          route.scopeId !== channelContext.channelId)
+      ) {
+        throw new Error(
+          'Runtime Channel trusted context must match a runtime-channel dm route scoped to its channelId.'
+        )
+      }
+      const sessionId = cleanString(req.sessionId) || getAgentSessionKey(route)
+      if (driveContext) {
+        if (
+          route.channel !== DRIVE_ROUTE ||
+          route.scopeType !== 'channel' ||
+          route.scopeId !== driveContext.driveId
+        ) {
+          throw new Error(
+            'Drive trusted context must match the Drive runtime channel route scoped to its driveId.'
+          )
+        }
+        if (agentId !== driveContext.targetAgentId) {
+          throw new Error('Drive trusted context targetAgentId must match the normalized agentId.')
+        }
+        if (
+          req.metadata?.driveId !== driveContext.driveId ||
+          req.metadata?.driveRevision !== driveContext.driveRevision
+        ) {
+          throw new Error('Drive request metadata must exactly match its trusted Drive context.')
+        }
+        if (driveContext.targetSessionId && driveContext.targetSessionId !== sessionId) {
+          throw new Error(
+            'Drive trusted context targetSessionId must match the resolved sessionId.'
+          )
+        }
+      }
+      if (triggerContext) {
+        if (
+          rawRoute.channel !== TRIGGER_CHANNEL ||
+          String(rawRoute.scopeType) !== 'agent' ||
+          rawRoute.scopeId !== triggerContext.targetAgentId ||
+          rawRoute.threadId !== TRIGGER_THREAD
+        ) {
+          throw new Error('Trigger trusted context must match the trigger runtime agent route.')
+        }
+        if (agentId !== triggerContext.targetAgentId) {
+          throw new Error(
+            'Trigger trusted context targetAgentId must match the normalized agentId.'
+          )
+        }
+        if (triggerContext.targetSessionId && triggerContext.targetSessionId !== sessionId) {
+          throw new Error(
+            'Trigger trusted context targetSessionId must match the resolved sessionId.'
+          )
+        }
+      }
+      const eventId = channelContext
+        ? runtimeChannelEventId(channelContext, agentId)
+        : driveContext
+          ? driveEventId(driveContext, req, agentId, sessionId)
+          : triggerContext
+            ? triggerEventId(triggerContext, req, agentId, sessionId)
+            : crypto.randomUUID()
+      const correlationId =
+        channelContext || driveContext || triggerContext
+          ? eventId
+          : cleanString(req.metadata?.correlationId) || eventId
+      const event: AgentEvent = channelContext
+        ? {
+            eventId,
+            type: MAGIC_AGENT_CHANNEL_MESSAGE_EVENT,
+            payload: toJsonValue(
+              {
+                request: { ...req, route },
+                channelId: channelContext.channelId,
+                memberId: channelContext.memberId,
+                pendingMessageIds: [...channelContext.pendingMessageIds],
+                agentInstanceId: channelContext.agentInstanceId
+              },
+              'MagicAgent channel.message payload'
+            ),
+            createdAt: 0,
+            correlationId,
+            sessionId,
+            agentId,
+            provenance: {
+              source: 'runtimeChannel',
+              requestedBy: `runtime-channel-member:${channelContext.memberId}`,
+              channel: channelContext.channelId,
+              traceId: correlationId
+            }
+          }
+        : driveContext
+          ? {
+              eventId,
+              type: MAGIC_AGENT_DRIVE_ASSIGNED_EVENT,
+              payload: toJsonValue(
+                {
+                  request: { ...req, route },
+                  driveId: driveContext.driveId,
+                  driveRevision: driveContext.driveRevision,
+                  status: driveContext.status,
+                  ...(driveContext.ownerId ? { ownerId: driveContext.ownerId } : {}),
+                  ...(driveContext.assigneeId ? { assigneeId: driveContext.assigneeId } : {}),
+                  targetAgentId: driveContext.targetAgentId,
+                  ...(driveContext.targetSessionId
+                    ? { targetSessionId: driveContext.targetSessionId }
+                    : {})
+                },
+                'MagicAgent drive.assigned payload'
+              ),
+              createdAt: 0,
+              correlationId,
+              sessionId,
+              agentId,
+              provenance: {
+                source: 'drive',
+                requestedBy: driveContext.ownerId
+                  ? `drive-owner:${driveContext.ownerId}`
+                  : `drive:${driveContext.driveId}`,
+                channel: driveContext.driveId,
+                traceId: eventId
+              }
+            }
+          : triggerContext
+            ? {
+                eventId,
+                type: MAGIC_AGENT_TRIGGER_FIRED_EVENT,
+                payload: toJsonValue(
+                  {
+                    request: { ...req, route },
+                    triggerId: triggerContext.triggerId,
+                    occurrenceId: triggerContext.occurrenceId,
+                    requestId: triggerContext.requestId,
+                    occurrenceAt: triggerContext.occurrenceAt,
+                    triggerType: triggerContext.triggerType,
+                    triggerTitle: triggerContext.triggerTitle,
+                    source: triggerContext.source,
+                    attempt: triggerContext.attempt,
+                    targetAgentId: triggerContext.targetAgentId,
+                    targetSessionId: triggerContext.targetSessionId
+                  },
+                  'MagicAgent trigger.fired payload'
+                ),
+                createdAt: triggerContext.occurrenceAt,
+                correlationId,
+                sessionId,
+                agentId,
+                provenance: {
+                  source: 'trigger',
+                  requestedBy: `trigger:${triggerContext.triggerId}`,
+                  channel: TRIGGER_CHANNEL,
+                  traceId: eventId
+                }
+              }
+            : {
+                eventId,
+                type: MAGIC_AGENT_USER_MESSAGE_EVENT,
+                payload: toJsonValue(
+                  { request: { ...req, route } },
+                  'MagicAgent user.message payload'
+                ),
+                createdAt: Date.now(),
+                correlationId,
+                sessionId,
+                agentId,
+                provenance: {
+                  source: 'magicAgentPlatform',
+                  requestedBy: cleanString(req.metadata?.requestedBy) || 'svcMagicAgentPlatform',
+                  channel: route.channel,
+                  traceId: cleanString(req.metadata?.traceLabel) || correlationId
+                }
+              }
+
+      pendingEventId = eventId
+      const pending = this.pendingRunOptions.get(eventId)
+      if (pending) {
+        if (pending.options.cooperativeExecution !== options.cooperativeExecution) {
+          throw new Error(
+            `MagicAgent event "${eventId}" has conflicting concurrent execution options.`
+          )
+        }
+        pending.callers += 1
+      } else {
+        this.pendingRunOptions.set(eventId, {
+          options:
+            channelContext || driveContext || triggerContext
+              ? { cooperativeExecution: options.cooperativeExecution }
+              : { ...options, signal: invocationSignals.signal },
+          callers: 1,
+          handlerActive: false
+        })
+      }
+      let response: MagicAgentPlatformRunResp | undefined
+      const dispatchSignal =
+        channelContext || driveContext || triggerContext
+          ? invocationSignals.signal
+          : invocationController.signal
+      for await (const action of this.dispatchKernel.dispatch(event, dispatchSignal)) {
+        if (response)
+          throw new Error(
+            `MagicAgent unary run expected exactly one ${MAGIC_AGENT_REPLY_EMIT_ACTION}; received an action after terminal.`
+          )
+        if (action.type === MAGIC_AGENT_REPLY_EMIT_ACTION) {
+          response = parseRunResponsePayload(action.payload)
+          continue
+        }
+        if (action.type === MAGIC_AGENT_MESSAGE_PUBLISH_ACTION) {
+          if (!channelContext || event.type !== MAGIC_AGENT_CHANNEL_MESSAGE_EVENT)
+            throw new Error(
+              'MagicAgent message.publish is only valid for a trusted channel.message event.'
+            )
+          const published = parseMessagePublishPayload(action.payload)
+          if (
+            published.channelId !== channelContext.channelId ||
+            published.publisherMemberId !== channelContext.memberId
+          )
+            throw new Error('MagicAgent message.publish does not match trusted Channel context.')
+          await this.executeMessagePublishOnce(action, published, {
+            agentInstanceId: channelContext.agentInstanceId,
+            sourceEvent: event
+          })
+          continue
+        }
+        if (action.type === MAGIC_AGENT_CHILD_START_ACTION) {
+          if (!channelContext || event.type !== MAGIC_AGENT_CHANNEL_MESSAGE_EVENT)
+            throw new Error(
+              'MagicAgent child.start is only valid for a trusted channel.message event.'
+            )
+          const childStart = parseChildStartPayload(action.payload)
+          if (childStart.parentInstanceId !== channelContext.agentInstanceId)
+            throw new Error('MagicAgent child.start does not match trusted Channel context.')
+          await this.executeChildStartOnce(action, childStart, {
+            actor: { kind: 'agent', id: channelContext.agentInstanceId },
+            agentInstanceId: channelContext.agentInstanceId,
+            sourceEvent: event
+          })
+          continue
+        }
+        if (action.type === MAGIC_AGENT_DRIVE_PROGRESS_ACTION) {
+          if (!driveContext || event.type !== MAGIC_AGENT_DRIVE_ASSIGNED_EVENT)
+            throw new Error(
+              'MagicAgent drive.progress is only valid for a trusted drive.assigned event.'
+            )
+          const progress = parseDriveProgressPayload(action.payload)
+          if (
+            progress.driveId !== driveContext.driveId ||
+            progress.expectedRevision !== driveContext.driveRevision
+          )
+            throw new Error('MagicAgent drive.progress does not match trusted Drive context.')
+          await this.executeDriveProgressOnce(action, progress)
+          continue
+        }
+        throw new Error(`MagicAgent unary run received unsupported action "${action.type}".`)
+      }
+      if (!response)
+        throw new Error(
+          `MagicAgent unary run expected exactly one ${MAGIC_AGENT_REPLY_EMIT_ACTION}.`
+        )
+      return response
+    } finally {
+      if (pendingEventId) {
+        const pending = this.pendingRunOptions.get(pendingEventId)
+        if (pending) {
+          pending.callers -= 1
+          if (pending.callers === 0 && !pending.handlerActive) {
+            this.pendingRunOptions.delete(pendingEventId)
+          }
+        }
+      }
+      invocationSignals.cleanup()
+      this.activeInvocationControllers.delete(invocationController)
+    }
+  }
+
+  private handleMessage(event: AgentEvent, signal: AbortSignal): AsyncIterable<AgentAction> {
+    const pending = this.pendingRunOptions.get(event.eventId)
+    if (!pending) {
+      throw new Error(
+        `MagicAgent ${event.type} event was not created by an authorized adapter invocation.`
+      )
+    }
+    pending.handlerActive = true
+    const options = pending.options
+    const request = parseRunRequestPayload(event.payload)
+    const runAgentAuthorized = this.runAgentAuthorized.bind(this)
+    const releaseHandler = (): void => {
+      pending.handlerActive = false
+      if (pending.callers === 0) this.pendingRunOptions.delete(event.eventId)
+    }
+    return {
+      async *[Symbol.asyncIterator]() {
+        try {
+          const combined = composeAbortSignals([options.signal, signal])
+          try {
+            const response = await runAgentAuthorized(request, {
+              ...options,
+              signal: combined.signal
+            })
+            if (event.type === MAGIC_AGENT_DRIVE_ASSIGNED_EVENT) {
+              if (!isRecord(event.payload))
+                throw new TypeError('MagicAgent drive.assigned payload is invalid.')
+              const driveId = event.payload.driveId
+              const expectedRevision = event.payload.driveRevision
+              if (typeof driveId !== 'string' || !Number.isInteger(expectedRevision))
+                throw new TypeError('MagicAgent drive.assigned payload is invalid.')
+              yield createDriveProgressAction({
+                actionId: `${event.eventId}:drive-progress`,
+                payload: {
+                  driveId,
+                  expectedRevision: expectedRevision as number,
+                  summary: cleanString(response.content) || 'Drive run completed.',
+                  evidence: [
+                    { kind: 'run', ref: response.runId },
+                    ...(event.sessionId ? [{ kind: 'session' as const, ref: event.sessionId }] : [])
+                  ],
+                  reportedAt: event.createdAt,
+                  idempotencyKey: `${event.eventId}:drive-progress`
+                },
+                correlationId: event.correlationId,
+                sessionId: event.sessionId,
+                agentId: event.agentId,
+                provenance: event.provenance
+              })
+            }
+            yield createReplyEmitAction({
+              actionId: `${event.eventId}:reply`,
+              payload: { response: toJsonValue(response, 'MagicAgent reply.emit response') },
+              correlationId: event.correlationId,
+              sessionId: event.sessionId,
+              agentId: event.agentId,
+              provenance: event.provenance
+            })
+          } finally {
+            combined.cleanup()
+          }
+        } finally {
+          releaseHandler()
+        }
+      }
+    }
+  }
+
+  private async runAgentAuthorized(
     req: MagicAgentPlatformRunReq,
     options: MagicAgentPlatformExecutionOptions = {}
   ): Promise<MagicAgentPlatformRunResp> {

--- a/packages/app/src/main/magicAgentRuntime/runtimeChannelTrustedDispatchContext.ts
+++ b/packages/app/src/main/magicAgentRuntime/runtimeChannelTrustedDispatchContext.ts
@@ -1,0 +1,52 @@
+import type { MagicAgentPlatformRunReq } from '@shared/api/svcMagicAgentPlatform'
+
+export type RuntimeChannelTrustedDispatchContext = Readonly<{
+  channelId: string
+  memberId: string
+  pendingMessageIds: readonly string[]
+  agentInstanceId: string
+}>
+
+export const RUNTIME_CHANNEL_TRUSTED_DISPATCH_CONTEXT: unique symbol = Symbol(
+  'magicpot.runtimeChannel.trustedDispatchContext'
+)
+
+type RuntimeChannelTrustedRunRequest = MagicAgentPlatformRunReq & {
+  [RUNTIME_CHANNEL_TRUSTED_DISPATCH_CONTEXT]?: RuntimeChannelTrustedDispatchContext
+}
+
+const requireId = (value: unknown, field: string): string => {
+  const normalized = typeof value === 'string' ? value.trim() : ''
+  if (!normalized) throw new TypeError(`Runtime Channel trusted context requires ${field}.`)
+  return normalized
+}
+
+export const attachRuntimeChannelTrustedDispatchContext = (
+  request: MagicAgentPlatformRunReq,
+  context: RuntimeChannelTrustedDispatchContext
+): MagicAgentPlatformRunReq => {
+  const pendingMessageIds = context.pendingMessageIds.map((id) =>
+    requireId(id, 'pendingMessageIds')
+  )
+  if (!pendingMessageIds.length) {
+    throw new TypeError('Runtime Channel trusted context requires pendingMessageIds.')
+  }
+  const validated = Object.freeze({
+    channelId: requireId(context.channelId, 'channelId'),
+    memberId: requireId(context.memberId, 'memberId'),
+    pendingMessageIds: Object.freeze(pendingMessageIds),
+    agentInstanceId: requireId(context.agentInstanceId, 'agentInstanceId')
+  })
+  Object.defineProperty(request, RUNTIME_CHANNEL_TRUSTED_DISPATCH_CONTEXT, {
+    value: validated,
+    enumerable: true,
+    configurable: false,
+    writable: false
+  })
+  return request
+}
+
+export const readRuntimeChannelTrustedDispatchContext = (
+  request: MagicAgentPlatformRunReq
+): RuntimeChannelTrustedDispatchContext | undefined =>
+  (request as RuntimeChannelTrustedRunRequest)[RUNTIME_CHANNEL_TRUSTED_DISPATCH_CONTEXT]

--- a/packages/app/src/main/magicAgentRuntime/triggerTrustedDispatchContext.ts
+++ b/packages/app/src/main/magicAgentRuntime/triggerTrustedDispatchContext.ts
@@ -1,0 +1,74 @@
+import type { MagicAgentPlatformRunReq } from '@shared/api/svcMagicAgentPlatform'
+
+export type TriggerTrustedDispatchContext = Readonly<{
+  triggerId: string
+  occurrenceId?: string
+  requestId: string
+  occurrenceAt: number
+  triggerType: string
+  triggerTitle: string
+  targetAgentId: string
+  targetSessionId?: string
+  source?: string
+  attempt?: number
+}>
+
+export const TRIGGER_TRUSTED_DISPATCH_CONTEXT: unique symbol = Symbol(
+  'magicpot.trigger.trustedDispatchContext'
+)
+
+type TriggerTrustedRunRequest = MagicAgentPlatformRunReq & {
+  [TRIGGER_TRUSTED_DISPATCH_CONTEXT]?: TriggerTrustedDispatchContext
+}
+
+const requireString = (value: unknown, field: string): string => {
+  const normalized = typeof value === 'string' ? value.trim() : ''
+  if (!normalized) throw new TypeError(`Trigger trusted context requires ${field}.`)
+  return normalized
+}
+
+const optionalString = (value: unknown, field: string): string | undefined =>
+  value === undefined ? undefined : requireString(value, field)
+
+export const attachTriggerTrustedDispatchContext = (
+  request: MagicAgentPlatformRunReq,
+  context: TriggerTrustedDispatchContext
+): MagicAgentPlatformRunReq => {
+  if (!Number.isSafeInteger(context.occurrenceAt) || context.occurrenceAt < 0) {
+    throw new TypeError('Trigger trusted context requires a non-negative integer occurrenceAt.')
+  }
+  if (
+    context.attempt !== undefined &&
+    (!Number.isSafeInteger(context.attempt) || context.attempt < 0)
+  ) {
+    throw new TypeError('Trigger trusted context attempt must be a non-negative integer.')
+  }
+  const validated = Object.freeze({
+    triggerId: requireString(context.triggerId, 'triggerId'),
+    ...(context.occurrenceId === undefined
+      ? {}
+      : { occurrenceId: optionalString(context.occurrenceId, 'occurrenceId') }),
+    requestId: requireString(context.requestId, 'requestId'),
+    occurrenceAt: context.occurrenceAt,
+    triggerType: requireString(context.triggerType, 'triggerType'),
+    triggerTitle: requireString(context.triggerTitle, 'triggerTitle'),
+    targetAgentId: requireString(context.targetAgentId, 'targetAgentId'),
+    ...(context.targetSessionId === undefined
+      ? {}
+      : { targetSessionId: optionalString(context.targetSessionId, 'targetSessionId') }),
+    ...(context.source === undefined ? {} : { source: optionalString(context.source, 'source') }),
+    ...(context.attempt === undefined ? {} : { attempt: context.attempt })
+  })
+  Object.defineProperty(request, TRIGGER_TRUSTED_DISPATCH_CONTEXT, {
+    value: validated,
+    enumerable: true,
+    configurable: false,
+    writable: false
+  })
+  return request
+}
+
+export const readTriggerTrustedDispatchContext = (
+  request: MagicAgentPlatformRunReq
+): TriggerTrustedDispatchContext | undefined =>
+  (request as TriggerTrustedRunRequest)[TRIGGER_TRUSTED_DISPATCH_CONTEXT]

--- a/packages/app/src/main/mainWindow.ts
+++ b/packages/app/src/main/mainWindow.ts
@@ -1,6 +1,6 @@
 import { app, BrowserWindow, ipcMain, nativeImage, screen, shell } from 'electron'
 import * as fs from 'fs'
-import { basename, extname, join } from 'path'
+import { basename, extname, join, resolve } from 'path'
 import { pathToFileURL } from 'url'
 import icon from '../../../runtime-assets/resources/icon.png?asset'
 import { isDev } from './config/buildEnv'
@@ -14,7 +14,8 @@ import { attachRendererDiagnostics } from './rendererDiagnostics'
 import { winController } from './winControls'
 import { attachWindowStatePersistence, readWindowState, type WindowState } from './windowState'
 import { normalizeAllowedExternalUrl } from './utils/externalUrl'
-import { authorizeScopedLocalMediaPath } from './localMediaAccess'
+import { authorizeScopedLocalMediaPath, resolveAuthorizedLocalMediaPath } from './localMediaAccess'
+import { getCurrentUserDataDirectoryState } from './config/userDataDirectory'
 import {
   registerMagicAgentTrustedRouteBinding,
   unregisterMagicAgentTrustedRouteBinding
@@ -30,6 +31,7 @@ type CanvasStartSystemDragPayload = {
 
 const testUiPolicy = getTestWindowPolicy()
 let canvasStartSystemDragRegistered = false
+let trustedCanvasRendererWebContentsId: number | null = null
 
 function sanitizeDragFileName(fileName: string): string {
   const trimmed = (fileName || '').trim()
@@ -54,8 +56,23 @@ function registerCanvasStartSystemDrag(): void {
     return
   }
 
-  ipcMain.handle('local-media:authorize-scoped-path', (_event, filePath: string): string => {
-    return authorizeScopedLocalMediaPath(filePath) ? filePath : ''
+  ipcMain.on('local-media:authorize-picker-path', (event, filePath: string) => {
+    event.returnValue =
+      event.sender.id === trustedCanvasRendererWebContentsId &&
+      authorizeScopedLocalMediaPath(filePath)
+  })
+
+  ipcMain.handle('local-media:resolve-scoped-path', (event, filePath: string): string => {
+    if (event.sender.id !== trustedCanvasRendererWebContentsId) return ''
+    const storageState = getCurrentUserDataDirectoryState()
+    return (
+      resolveAuthorizedLocalMediaPath(filePath, [
+        resolve(app.getPath('userData')),
+        resolve(join(app.getPath('temp'), 'magicpot-local-media')),
+        resolve(storageState.projectRoot),
+        resolve(storageState.autoSaveRoot)
+      ]) ?? ''
+    )
   })
 
   ipcMain.handle(
@@ -63,7 +80,7 @@ function registerCanvasStartSystemDrag(): void {
     async (event, payload: CanvasStartSystemDragPayload): Promise<{ filePath: string }> => {
       const tempDir = resolveTestArtifactPath({
         desktopPath: app.getPath('desktop'),
-        tempPath: app.getPath('temp'),
+        tempPath: join(app.getPath('temp'), 'magicpot-local-media'),
         policy: testUiPolicy,
         segments: ['drag']
       })
@@ -74,6 +91,7 @@ function registerCanvasStartSystemDrag(): void {
         const uniquePrefix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
         const fullPath = join(tempDir, `${uniquePrefix}-${fileName}`)
         fs.writeFileSync(fullPath, Buffer.from(file.data))
+        authorizeScopedLocalMediaPath(fullPath)
         return fullPath
       })
 
@@ -157,6 +175,7 @@ export function createMainWindow(onCreated?: (window: BrowserWindow) => void): B
     }
   })
 
+  trustedCanvasRendererWebContentsId = mainWindow.webContents.id
   onCreated?.(mainWindow)
   ;(mainWindow as BrowserWindow & { [key: symbol]: boolean | undefined })[
     Symbol.for('magicpot.testWindowRuntime.skipTaskbar')
@@ -170,6 +189,9 @@ export function createMainWindow(onCreated?: (window: BrowserWindow) => void): B
     trustedWebContents: mainWindow.webContents
   })
   mainWindow.on('closed', () => {
+    if (trustedCanvasRendererWebContentsId === mainWindow.webContents.id) {
+      trustedCanvasRendererWebContentsId = null
+    }
     unregisterMagicAgentTrustedRouteBinding(mainWindow.webContents.id)
   })
 

--- a/packages/app/src/main/screenshot/screenshotManager.ts
+++ b/packages/app/src/main/screenshot/screenshotManager.ts
@@ -355,12 +355,12 @@ function getOverlayHTML(): string {
       hint.style.display = 'block';
       return;
     }
-    window.electron.ipcRenderer.send('screenshot:region', { x, y, w, h });
+    window.canvasScreenshot.selectRegion({ x, y, w, h });
   });
 
   document.addEventListener('keydown', (e) => {
     if (e.key === 'Escape') {
-      window.electron.ipcRenderer.send('screenshot:cancel');
+      window.canvasScreenshot.cancelSelection();
     }
   });
 </script>
@@ -420,14 +420,14 @@ function getFloatingHTML(windowId: string, imageFileName: string): string {
 </div>
 <div class="opacity-slider">
   <input type="range" min="20" max="100" value="100"
-    oninput="window.electron.ipcRenderer.send('floating:opacity', '${windowId}', this.value / 100)" />
+    oninput="window.canvasScreenshot.setFloatingOpacity('${windowId}', this.value / 100)" />
 </div>
 <script>
   function closeThis() {
-    window.electron.ipcRenderer.send('floating:close', '${windowId}');
+    window.canvasScreenshot.closeFloatingWindow('${windowId}');
   }
   function sendToCanvas() {
-    window.electron.ipcRenderer.send('floating:to-canvas', '${windowId}');
+    window.canvasScreenshot.sendFloatingToCanvas('${windowId}');
   }
 </script>
 </body>

--- a/packages/app/src/preload/index.d.ts
+++ b/packages/app/src/preload/index.d.ts
@@ -1,11 +1,16 @@
 // packages/app/src/preload/index.d.ts
-import type { ElectronAPI } from '@electron-toolkit/preload'
 import type { Api } from '@shared/api'
-import type { BuiltInPath, WinBridge } from '@shared/utils/utilWindow'
+import type {
+  AppEventBridge,
+  BuiltInPath,
+  CanvasScreenshotBridge,
+  WinBridge
+} from '@shared/utils/utilWindow'
 
 export type ElectronFileBridge = {
   getPathForFile(file: File): string
-  authorizeLocalMediaFile(file: File): Promise<string>
+  authorizeLocalMediaFile(file: File): string | Promise<string>
+  resolveAuthorizedLocalMediaPath(filePath: string): Promise<string>
 }
 
 export type ProjectCanvasBenchmarkRuntimeBridge = Readonly<{
@@ -16,7 +21,8 @@ export type ProjectCanvasBenchmarkRuntimeBridge = Readonly<{
 
 declare global {
   interface Window {
-    electron: ElectronAPI
+    appEvents?: AppEventBridge
+    canvasScreenshot?: CanvasScreenshotBridge
     electronFile?: ElectronFileBridge
     api: Api
     path: BuiltInPath

--- a/packages/app/src/preload/index.test.ts
+++ b/packages/app/src/preload/index.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  exposeMock,
+  getPathForFileMock,
+  invokeMock,
+  onMock,
+  removeListenerMock,
+  sendMock,
+  sendSyncMock
+} = vi.hoisted(() => ({
+  exposeMock: vi.fn(),
+  getPathForFileMock: vi.fn(),
+  invokeMock: vi.fn(),
+  onMock: vi.fn(),
+  removeListenerMock: vi.fn(),
+  sendMock: vi.fn(),
+  sendSyncMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  contextBridge: { exposeInMainWorld: exposeMock },
+  ipcRenderer: {
+    invoke: invokeMock,
+    on: onMock,
+    removeListener: removeListenerMock,
+    send: sendMock,
+    sendSync: sendSyncMock
+  },
+  webUtils: { getPathForFile: getPathForFileMock }
+}))
+
+vi.mock('./apiIpc', () => ({ newApiIpc: () => ({}) }))
+vi.mock('./winBridge', () => ({ winBridge: {} }))
+
+describe('preload capability boundary', () => {
+  beforeEach(async () => {
+    vi.resetModules()
+    exposeMock.mockReset()
+    getPathForFileMock.mockReset()
+    invokeMock.mockReset()
+    onMock.mockReset()
+    removeListenerMock.mockReset()
+    sendMock.mockReset()
+    sendSyncMock.mockReset()
+    Object.defineProperty(process, 'contextIsolated', { configurable: true, value: true })
+    await import('./index')
+  })
+
+  it('does not expose the generic Electron ipcRenderer API', () => {
+    const exposedNames = exposeMock.mock.calls.map(([name]) => name)
+
+    expect(exposedNames).not.toContain('electron')
+    expect(exposedNames).toEqual(
+      expect.arrayContaining([
+        'api',
+        'appEvents',
+        'canvasScreenshot',
+        'electronFile',
+        'path',
+        'win'
+      ])
+    )
+  })
+
+  it('authorizes picker files only through webUtils.getPathForFile', () => {
+    const file = { name: 'selected.png' }
+    getPathForFileMock.mockReturnValue('/picked/selected.png')
+    sendSyncMock.mockReturnValue(true)
+    const electronFile = exposeMock.mock.calls.find(([name]) => name === 'electronFile')?.[1]
+
+    expect(electronFile.authorizeLocalMediaFile(file)).toBe('/picked/selected.png')
+    expect(getPathForFileMock).toHaveBeenCalledWith(file)
+    expect(sendSyncMock).toHaveBeenCalledWith(
+      'local-media:authorize-picker-path',
+      '/picked/selected.png'
+    )
+  })
+
+  it('exposes only named main-process event subscriptions', () => {
+    const appEvents = exposeMock.mock.calls.find(([name]) => name === 'appEvents')?.[1]
+    const closeTab = vi.fn()
+    const refreshQApps = vi.fn()
+
+    const removeCloseTab = appEvents.onCloseActiveTab(closeTab)
+    const closeTabListener = onMock.mock.calls.find(([channel]) => channel === 'app:close-tab')?.[1]
+    closeTabListener({})
+    removeCloseTab()
+
+    const removeRefresh = appEvents.onQAppDirectoryChanged(refreshQApps)
+    const refreshListener = onMock.mock.calls.find(
+      ([channel]) => channel === 'qapp:dir-changed'
+    )?.[1]
+    refreshListener({})
+    removeRefresh()
+
+    expect(closeTab).toHaveBeenCalledTimes(1)
+    expect(refreshQApps).toHaveBeenCalledTimes(1)
+    expect(removeListenerMock).toHaveBeenCalledWith('app:close-tab', closeTabListener)
+    expect(removeListenerMock).toHaveBeenCalledWith('qapp:dir-changed', refreshListener)
+  })
+
+  it('preserves narrow screenshot and canvas-image event bridges', async () => {
+    const canvasScreenshot = exposeMock.mock.calls.find(
+      ([name]) => name === 'canvasScreenshot'
+    )?.[1]
+    const callback = vi.fn()
+
+    await canvasScreenshot.capture()
+    await canvasScreenshot.getShortcut()
+    await canvasScreenshot.setShortcut('Ctrl+Shift+S', ['Ctrl+S'])
+    canvasScreenshot.selectRegion({ x: 10, y: 20, w: 300, h: 200 })
+    canvasScreenshot.cancelSelection()
+    canvasScreenshot.setFloatingOpacity('floating-1', 0.75)
+    canvasScreenshot.closeFloatingWindow('floating-1')
+    canvasScreenshot.sendFloatingToCanvas('floating-1')
+    const remove = canvasScreenshot.onAddImage(callback)
+    const listener = onMock.mock.calls[0]?.[1]
+    listener({}, 'data:image/png;base64,abc')
+    remove()
+
+    expect(invokeMock).toHaveBeenNthCalledWith(1, 'screenshot:capture')
+    expect(invokeMock).toHaveBeenNthCalledWith(2, 'screenshot:getShortcut')
+    expect(invokeMock).toHaveBeenNthCalledWith(3, 'screenshot:setShortcut', 'Ctrl+Shift+S', [
+      'Ctrl+S'
+    ])
+    expect(sendMock).toHaveBeenNthCalledWith(1, 'screenshot:region', {
+      x: 10,
+      y: 20,
+      w: 300,
+      h: 200
+    })
+    expect(sendMock).toHaveBeenNthCalledWith(2, 'screenshot:cancel')
+    expect(sendMock).toHaveBeenNthCalledWith(3, 'floating:opacity', 'floating-1', 0.75)
+    expect(sendMock).toHaveBeenNthCalledWith(4, 'floating:close', 'floating-1')
+    expect(sendMock).toHaveBeenNthCalledWith(5, 'floating:to-canvas', 'floating-1')
+    expect(onMock).toHaveBeenCalledWith('canvas:add-image', listener)
+    expect(callback).toHaveBeenCalledWith('data:image/png;base64,abc')
+    expect(removeListenerMock).toHaveBeenCalledWith('canvas:add-image', listener)
+  })
+})

--- a/packages/app/src/preload/index.ts
+++ b/packages/app/src/preload/index.ts
@@ -1,9 +1,8 @@
 // packages/app/src/preload/index.ts
 import { contextBridge, ipcRenderer, webUtils } from 'electron'
-import { electronAPI } from '@electron-toolkit/preload'
 import { newApiIpc } from './apiIpc'
 import pkgPath from 'path'
-import type { BuiltInPath } from '@shared/utils/utilWindow'
+import type { AppEventBridge, BuiltInPath, CanvasScreenshotBridge } from '@shared/utils/utilWindow'
 import type { Api } from '@shared/api'
 import { winBridge } from './winBridge'
 
@@ -18,11 +17,17 @@ const electronFile = {
       return ''
     }
   },
-  async authorizeLocalMediaFile(file: unknown): Promise<string> {
+  authorizeLocalMediaFile(file: unknown): string {
     try {
       const filePath = (webUtils.getPathForFile as (target: unknown) => string)(file) || ''
-      if (!filePath) return ''
-      return (await ipcRenderer.invoke('local-media:authorize-scoped-path', filePath)) || ''
+      return authorizeLocalMediaFilePath(filePath) ? filePath : ''
+    } catch {
+      return ''
+    }
+  },
+  async resolveAuthorizedLocalMediaPath(filePath: string): Promise<string> {
+    try {
+      return (await ipcRenderer.invoke('local-media:resolve-scoped-path', filePath)) || ''
     } catch {
       return ''
     }
@@ -70,6 +75,45 @@ function createProjectCanvasBenchmarkRuntime(): ProjectCanvasBenchmarkRuntimeBri
 }
 
 const projectCanvasBenchmarkRuntime = createProjectCanvasBenchmarkRuntime()
+const canvasScreenshot: CanvasScreenshotBridge = {
+  capture: () => ipcRenderer.invoke('screenshot:capture'),
+  getShortcut: () => ipcRenderer.invoke('screenshot:getShortcut'),
+  setShortcut: (accelerator, reservedShortcuts) =>
+    ipcRenderer.invoke('screenshot:setShortcut', accelerator, reservedShortcuts),
+  selectRegion: (region) => ipcRenderer.send('screenshot:region', region),
+  cancelSelection: () => ipcRenderer.send('screenshot:cancel'),
+  setFloatingOpacity: (windowId, opacity) =>
+    ipcRenderer.send('floating:opacity', windowId, opacity),
+  closeFloatingWindow: (windowId) => ipcRenderer.send('floating:close', windowId),
+  sendFloatingToCanvas: (windowId) => ipcRenderer.send('floating:to-canvas', windowId),
+  onAddImage: (cb) => {
+    const listener = (_event: unknown, dataUrl: string) => cb(dataUrl)
+    ipcRenderer.on('canvas:add-image', listener)
+    return () => ipcRenderer.removeListener('canvas:add-image', listener)
+  }
+}
+
+function subscribeToMainEvent(channel: 'app:close-tab' | 'qapp:dir-changed', cb: () => void) {
+  const listener = () => cb()
+  ipcRenderer.on(channel, listener)
+  return () => ipcRenderer.removeListener(channel, listener)
+}
+
+const appEvents: AppEventBridge = {
+  onCloseActiveTab: (cb) => subscribeToMainEvent('app:close-tab', cb),
+  onQAppDirectoryChanged: (cb) => subscribeToMainEvent('qapp:dir-changed', cb)
+}
+
+function authorizeLocalMediaFilePath(filePath: string): boolean {
+  if (!filePath) return false
+  try {
+    // The picker/drag File object is validated in preload with webUtils, so the renderer
+    // cannot manufacture an arbitrary absolute path for this capability.
+    return ipcRenderer.sendSync('local-media:authorize-picker-path', filePath) === true
+  } catch {
+    return false
+  }
+}
 
 function defineImmutableMainWorldValue(name: string, value: unknown): void {
   Object.defineProperty(window, name, {
@@ -82,7 +126,8 @@ function defineImmutableMainWorldValue(name: string, value: unknown): void {
 
 if (process.contextIsolated) {
   try {
-    contextBridge.exposeInMainWorld('electron', electronAPI)
+    contextBridge.exposeInMainWorld('canvasScreenshot', canvasScreenshot)
+    contextBridge.exposeInMainWorld('appEvents', appEvents)
     contextBridge.exposeInMainWorld('electronFile', electronFile)
     contextBridge.exposeInMainWorld('api', api)
     contextBridge.exposeInMainWorld('path', path)
@@ -96,9 +141,12 @@ if (process.contextIsolated) {
   }
 } else {
   // 非隔离环境降级：直接挂到 window（开发/特殊配置下使用）
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- electronAPI 在运行时由 electron-toolkit 注入
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- screenshot bridge is injected at runtime
   // @ts-ignore
-  window.electron = electronAPI
+  window.canvasScreenshot = canvasScreenshot
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- named app event bridge is injected at runtime
+  // @ts-ignore
+  window.appEvents = appEvents
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- Electron file bridge is injected at runtime
   // @ts-ignore
   window.electronFile = electronFile

--- a/packages/app/src/renderer/src/components/Layout.tsx
+++ b/packages/app/src/renderer/src/components/Layout.tsx
@@ -432,17 +432,7 @@ const Layout: React.FC = () => {
       dispatch(closeTab(tabId))
     }
 
-    const ipc = (
-      window as {
-        electron?: {
-          ipcRenderer?: {
-            on: (channel: string, listener: () => void) => void
-            removeListener: (channel: string, listener: () => void) => void
-          }
-        }
-      }
-    ).electron?.ipcRenderer
-    ipc?.on('app:close-tab', closeActiveTab)
+    const removeCloseTabListener = window.appEvents?.onCloseActiveTab(closeActiveTab)
 
     const handleKeyDown = (e: KeyboardEvent) => {
       if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'w') {
@@ -453,7 +443,7 @@ const Layout: React.FC = () => {
     window.addEventListener('keydown', handleKeyDown)
 
     return () => {
-      ipc?.removeListener('app:close-tab', closeActiveTab)
+      removeCloseTabListener?.()
       window.removeEventListener('keydown', handleKeyDown)
     }
   }, [dispatch, navigate])

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/ProjectCanvasPage.designInspectionHistory.test.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/ProjectCanvasPage.designInspectionHistory.test.tsx
@@ -1149,19 +1149,28 @@ describe('ProjectCanvasPage generation-first entry', () => {
     mockSaveCanvasItems.mockReset()
     mockSaveCanvasItems.mockResolvedValue(undefined)
     mockElectronInvoke.mockReset()
-    mockElectronInvoke.mockImplementation(async (channel: string) => {
-      if (channel === 'screenshot:getShortcut') {
-        return { success: true, shortcut: '`' }
+    mockElectronInvoke.mockImplementation(
+      async (channel: string, shortcut?: string, reservedShortcuts?: string[]) => {
+        if (channel === 'screenshot:getShortcut') {
+          return { success: true, shortcut: '`' }
+        }
+        return { success: true, shortcut, reservedShortcuts }
       }
-      return { success: true }
-    })
-    Object.defineProperty(window, 'electron', {
+    )
+    Object.defineProperty(window, 'canvasScreenshot', {
       configurable: true,
       writable: true,
       value: {
-        ipcRenderer: {
-          invoke: mockElectronInvoke
-        }
+        capture: vi.fn(),
+        getShortcut: () => mockElectronInvoke('screenshot:getShortcut'),
+        setShortcut: (shortcut: string, reservedShortcuts?: string[]) =>
+          mockElectronInvoke('screenshot:setShortcut', shortcut, reservedShortcuts),
+        selectRegion: vi.fn(),
+        cancelSelection: vi.fn(),
+        setFloatingOpacity: vi.fn(),
+        closeFloatingWindow: vi.fn(),
+        sendFloatingToCanvas: vi.fn(),
+        onAddImage: vi.fn(() => vi.fn())
       }
     })
     mockLoadCanvasItems.mockResolvedValue({

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/ProjectCanvasPage.textEdit.test.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/ProjectCanvasPage.textEdit.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { CanvasAnnotationItem, CanvasItem, CanvasTextItem } from './types'
 
 vi.mock('@renderer/utils/droppedImageUtils', () => ({
@@ -13,6 +13,14 @@ const emptyFileList = {
   length: 0,
   item: () => null
 } as unknown as FileList
+const originalElectronFile = window.electronFile
+
+afterEach(() => {
+  Object.defineProperty(window, 'electronFile', {
+    configurable: true,
+    value: originalElectronFile
+  })
+})
 
 function createTextItem(overrides: Partial<CanvasTextItem> = {}): CanvasTextItem {
   return {
@@ -144,7 +152,13 @@ const createFileList = (file: File): FileList =>
   }) as unknown as FileList
 
 describe('resolveDroppedAgentImageDataUrl', () => {
-  it('uses an object URL for an Agent image file without base64 materialization', async () => {
+  it('uses an authorized local URL for an Agent image file without base64 materialization', async () => {
+    Object.defineProperty(window, 'electronFile', {
+      configurable: true,
+      value: {
+        authorizeLocalMediaFile: vi.fn(async () => 'C:/demo/image.png')
+      }
+    })
     const file = new File(['image-bytes'], 'image.png', { type: 'image/png' })
     const dataTransfer = {
       getData: (type: string) =>
@@ -161,7 +175,13 @@ describe('resolveDroppedAgentImageDataUrl', () => {
     })
   })
 
-  it('uses the normalized Agent URL when no image file is present', async () => {
+  it('uses the authorized normalized Agent URL when no image file is present', async () => {
+    Object.defineProperty(window, 'electronFile', {
+      configurable: true,
+      value: {
+        resolveAuthorizedLocalMediaPath: vi.fn(async (filePath: string) => filePath)
+      }
+    })
     const dataTransfer = {
       getData: (type: string) =>
         type === 'application/x-ai-image' ? 'file:///C:/demo/image.png' : '',

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/ProjectCanvasPageShell.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/ProjectCanvasPageShell.tsx
@@ -756,18 +756,17 @@ export default function ProjectCanvasPageShell(props: ProjectCanvasPageShellRunt
               return
             }
 
-            const invoke = window.electron?.ipcRenderer?.invoke
-            if (!invoke) {
+            const screenshotBridge = window.canvasScreenshot
+            if (!screenshotBridge) {
               notifyError('当前环境不支持修改截图快捷键。')
               return
             }
 
             try {
-              const result = await invoke(
-                'screenshot:setShortcut',
+              const result = (await screenshotBridge.setShortcut(
                 toElectronAccelerator(recordedShortcut),
                 buildReservedCanvasShortcuts(toolShortcuts)
-              )
+              )) as { success?: boolean; error?: string }
 
               if (result?.success === false) {
                 notifyError(result.error || '截图快捷键设置失败。')

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/ProjectCanvasPageTopToolbar.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/ProjectCanvasPageTopToolbar.tsx
@@ -1117,7 +1117,7 @@ function ProjectCanvasPageTopToolbar(props: ProjectCanvasPageTopToolbarProps) {
           size="small"
           onClick={() => {
             try {
-              window.electron?.ipcRenderer?.invoke?.('screenshot:capture')
+              void window.canvasScreenshot?.capture()
             } catch (err) {
               console.error('[Canvas] 启动系统截图失败', err)
             }

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasAssetIntakeHelpers.test.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasAssetIntakeHelpers.test.ts
@@ -88,6 +88,7 @@ describe('canvasAssetIntakeHelpers', () => {
   const originalRevokeObjectURL = URL.revokeObjectURL
   const originalCreateImageBitmap = globalThis.createImageBitmap
   const originalApi = window.api
+  const originalElectronFile = window.electronFile
 
   const nextLoadedWidth = 2048
   const nextLoadedHeight = 1024
@@ -133,6 +134,11 @@ describe('canvasAssetIntakeHelpers', () => {
       configurable: true,
       writable: true,
       value: originalApi
+    })
+    Object.defineProperty(window, 'electronFile', {
+      configurable: true,
+      writable: true,
+      value: originalElectronFile
     })
     HTMLCanvasElement.prototype.getContext = originalGetContext
     HTMLCanvasElement.prototype.toBlob = originalToBlob
@@ -220,7 +226,7 @@ describe('canvasAssetIntakeHelpers', () => {
     expect(getCanvasImagePreviewMaxSideForBatch(Number.NaN)).toBe(CANVAS_IMAGE_PROXY_MAX_SIDE)
   })
 
-  it('loads dropped local-media images through svcFs object URLs before decoding', async () => {
+  it('loads dropped local-media images through an authorized protocol URL', async () => {
     const loadedSources: string[] = []
     window.Image = function MockImage() {
       const image = createImage(640, 360)
@@ -238,28 +244,20 @@ describe('canvasAssetIntakeHelpers', () => {
       return image
     } as unknown as typeof Image
 
-    const readImageFromPath = vi.fn(async () => ({
-      image: new Uint8Array([1, 2, 3, 4]),
-      filename: 'reference.png'
-    }))
-    const createObjectUrl = vi.fn((_blob: Blob) => 'blob:local-image')
-    URL.createObjectURL = createObjectUrl as unknown as typeof URL.createObjectURL
+    const resolveAuthorizedLocalMediaPath = vi.fn(async (filePath: string) => filePath)
 
-    Object.defineProperty(window, 'api', {
+    Object.defineProperty(window, 'electronFile', {
       configurable: true,
       writable: true,
       value: {
-        svcFs: {
-          readImageFromPath
-        }
+        resolveAuthorizedLocalMediaPath
       }
     })
 
     const loaded = await loadImageFromSrc('local-media:///C:/assets/reference.png')
 
-    expect(readImageFromPath).toHaveBeenCalledWith({ fullPath: 'C:/assets/reference.png' })
-    expect(createObjectUrl).toHaveBeenCalled()
-    expect(loadedSources).toEqual(['blob:local-image'])
+    expect(resolveAuthorizedLocalMediaPath).toHaveBeenCalledWith('C:/assets/reference.png')
+    expect(loadedSources).toEqual(['local-media:///C:/assets/reference.png'])
     expect(loaded).toMatchObject({
       width: 640,
       height: 360
@@ -400,23 +398,23 @@ describe('canvasAssetIntakeHelpers', () => {
     })
   })
 
-  it('rehydrates persisted local images through svcFs when local-media image loading is blocked', async () => {
-    const readImageFromPath = vi.fn(async () => ({
-      image: new Uint8Array([1, 2, 3, 4]),
-      filename: 'reference.png'
-    }))
+  it('rehydrates persisted local images through an authorized protocol fetch', async () => {
+    const resolveAuthorizedLocalMediaPath = vi.fn(async (filePath: string) => filePath)
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      blob: async () => new Blob([new Uint8Array([1, 2, 3, 4])], { type: 'image/png' })
+    } as Response)
     const createObjectUrl = vi.fn(() => 'blob:recovered-local-image')
     const revokeObjectUrl = vi.fn()
     URL.createObjectURL = createObjectUrl as unknown as typeof URL.createObjectURL
     URL.revokeObjectURL = revokeObjectUrl as unknown as typeof URL.revokeObjectURL
 
-    Object.defineProperty(window, 'api', {
+    Object.defineProperty(window, 'electronFile', {
       configurable: true,
       writable: true,
       value: {
-        svcFs: {
-          readImageFromPath
-        }
+        resolveAuthorizedLocalMediaPath
       }
     })
 
@@ -460,7 +458,10 @@ describe('canvasAssetIntakeHelpers', () => {
       maxPreviewSide: CANVAS_IMAGE_PROXY_MAX_SIDE
     })
 
-    expect(readImageFromPath).toHaveBeenCalledWith({ fullPath: 'C:/assets/reference.png' })
+    expect(resolveAuthorizedLocalMediaPath).toHaveBeenCalledWith('C:/assets/reference.png')
+    expect(fetchMock).toHaveBeenCalledWith('local-media:///C:/assets/reference.png', {
+      signal: undefined
+    })
     expect(loadImageFromSrc).toHaveBeenNthCalledWith(1, 'local-media:///C:/assets/reference.png')
     expect(loadImageFromSrc).toHaveBeenNthCalledWith(2, 'blob:recovered-local-image')
     expect(revokeObjectUrl).toHaveBeenCalledWith('blob:recovered-local-image')
@@ -589,7 +590,7 @@ describe('canvasAssetIntakeHelpers', () => {
     })
   })
 
-  it('recovers warm thumbnail previews through svcFs when local-media loading is blocked', async () => {
+  it('recovers warm thumbnail previews through an authorized protocol fetch', async () => {
     const sourceIdentity = buildCanvasImageSourceIdentity({
       canonicalPath: 'C:/assets/reference.png',
       sizeBytes: 4096,
@@ -610,10 +611,12 @@ describe('canvasAssetIntakeHelpers', () => {
       })),
       now: new Date('2026-05-02T00:00:00.000Z')
     })
-    const readImageFromPath = vi.fn(async () => ({
-      image: new Uint8Array([1, 2, 3, 4]),
-      filename: '512.webp'
-    }))
+    const resolveAuthorizedLocalMediaPath = vi.fn(async (filePath: string) => filePath)
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      blob: async () => new Blob([new Uint8Array([1, 2, 3, 4])], { type: 'image/webp' })
+    } as Response)
     const createObjectUrl = vi.fn(() => 'blob:recovered-thumbnail')
     const revokeObjectUrl = vi.fn()
     URL.createObjectURL = createObjectUrl as unknown as typeof URL.createObjectURL
@@ -627,10 +630,14 @@ describe('canvasAssetIntakeHelpers', () => {
           readThumbnailManifest: vi.fn(async () => ({
             manifest: canvasThumbnailManifestFromSet(thumbnailSet)
           }))
-        },
-        svcFs: {
-          readImageFromPath
         }
+      }
+    })
+    Object.defineProperty(window, 'electronFile', {
+      configurable: true,
+      writable: true,
+      value: {
+        resolveAuthorizedLocalMediaPath
       }
     })
 
@@ -671,7 +678,10 @@ describe('canvasAssetIntakeHelpers', () => {
 
     const hydrated = await hydrateCanvasImageItemForCanvas({ item, loadImageFromSrc })
 
-    expect(readImageFromPath).toHaveBeenCalledWith({ fullPath: 'cache/reference/512.webp' })
+    expect(resolveAuthorizedLocalMediaPath).toHaveBeenCalledWith('/cache/reference/512.webp')
+    expect(fetchMock).toHaveBeenCalledWith('local-media:///cache/reference/512.webp', {
+      signal: undefined
+    })
     expect(loadImageFromSrc).toHaveBeenNthCalledWith(1, 'local-media:///cache/reference/512.webp')
     expect(loadImageFromSrc).toHaveBeenNthCalledWith(2, 'blob:recovered-thumbnail')
     expect(revokeObjectUrl).toHaveBeenCalledWith('blob:recovered-thumbnail')

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasAssetIntakeHelpers.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasAssetIntakeHelpers.ts
@@ -7,9 +7,11 @@ import { isCanvasThumbnailSetFresh, pickBestCanvasThumbnailLevel } from './canva
 import { ensureCanvasThumbnailSet, readWarmCanvasThumbnailSet } from './canvasThumbnailWorkerClient'
 import type { CanvasImageSourceIdentity, CanvasImageThumbnailSet } from './canvasThumbnailTypes'
 import {
+  canReadCanvasLocalImageSource,
   createCanvasLocalImageObjectUrl,
   readCanvasLocalImageBlobFromSource
 } from './canvasLocalImageSource'
+import { resolveAuthorizedCanvasLocalMediaSourceUrl } from './canvasLocalFileSource'
 
 export const CANVAS_IMAGE_PROXY_MAX_SIDE = 2048
 export const CANVAS_IMAGE_PROXY_SMALL_BATCH_MAX_SIDE = 1024
@@ -490,14 +492,14 @@ function loadImageElementFromSrc(src: string, logSource = src): Promise<LoadedCa
 }
 
 export async function loadImageFromSrc(src: string): Promise<LoadedCanvasImage> {
-  const localObjectUrl = await createCanvasLocalImageObjectUrl(src)
-  try {
-    return await loadImageElementFromSrc(localObjectUrl ?? src, src)
-  } finally {
-    if (localObjectUrl && typeof URL !== 'undefined' && typeof URL.revokeObjectURL === 'function') {
-      URL.revokeObjectURL(localObjectUrl)
-    }
+  if (!canReadCanvasLocalImageSource(src)) {
+    return loadImageElementFromSrc(src, src)
   }
+  const authorizedSource = await resolveAuthorizedCanvasLocalMediaSourceUrl(src)
+  if (!authorizedSource) {
+    throw new Error('Local image source is not authorized.')
+  }
+  return loadImageElementFromSrc(authorizedSource, src)
 }
 
 async function createComfyImageObjectUrl(item: CanvasImageItem): Promise<string | null> {

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasImageResourceLifecycle.test.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasImageResourceLifecycle.test.ts
@@ -1,0 +1,391 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  CanvasImageAsyncSharedResourcePool,
+  CanvasImageInFlightDeduper,
+  CanvasImageSharedResourceByteTracker,
+  CanvasImageSharedReservationTracker,
+  CanvasImageSharedResourcePool,
+  createTokenSafeRelease,
+  getCanvasImageDecodedRevisionKey,
+  getCanvasImageSharedDecodedAssetKey,
+  getCanvasImageStableSourceKey,
+  hasCanvasImageStrongSourceIdentity
+} from './canvasImageResourceLifecycle'
+
+describe('canvasImageResourceLifecycle', () => {
+  it('shares only stable source keys and includes identity revisions', () => {
+    expect(getCanvasImageStableSourceKey({ src: 'file:///a.png' })).toBeNull()
+    expect(
+      getCanvasImageStableSourceKey({ src: 'file:///a.png', sourceIdentity: { cacheKey: 'rev-1' } })
+    ).toBe('identity:rev-1')
+    expect(getCanvasImageStableSourceKey({ src: 'https://example.test/a.png' })).toContain(
+      'https://'
+    )
+    expect(
+      getCanvasImageDecodedRevisionKey({
+        source: { src: 'same.png', sourceIdentity: { cacheKey: 'source-rev' } },
+        decodedIdentity: 2
+      })
+    ).not.toBe(
+      getCanvasImageDecodedRevisionKey({
+        source: { src: 'same.png', sourceIdentity: { cacheKey: 'source-rev' } },
+        decodedIdentity: 3
+      })
+    )
+  })
+
+  it('separates weak remote decoded keys by provided revision while retaining strong dedupe', () => {
+    expect(hasCanvasImageStrongSourceIdentity({ src: 'data:image/png;base64,abc' })).toBe(true)
+    expect(
+      hasCanvasImageStrongSourceIdentity({
+        src: 'local-media:///a.png',
+        sourceIdentity: { cacheKey: 'strong' }
+      })
+    ).toBe(true)
+    expect(hasCanvasImageStrongSourceIdentity({ src: 'https://example.test/a.png' })).toBe(false)
+    expect(
+      getCanvasImageSharedDecodedAssetKey({
+        source: { src: 'https://example.test/a.png', weakRevisionKey: 1 },
+        variant: 'source-upgrade'
+      })
+    ).not.toBe(
+      getCanvasImageSharedDecodedAssetKey({
+        source: { src: 'https://example.test/a.png', weakRevisionKey: 2 },
+        variant: 'source-upgrade'
+      })
+    )
+    expect(
+      getCanvasImageSharedDecodedAssetKey({
+        source: {
+          src: 'local-media:///a.png',
+          sourceIdentity: { cacheKey: 'strong' },
+          weakRevisionKey: 1
+        },
+        variant: 'source-upgrade'
+      })
+    ).toBe(
+      getCanvasImageSharedDecodedAssetKey({
+        source: {
+          src: 'local-media:///a.png',
+          sourceIdentity: { cacheKey: 'strong' },
+          weakRevisionKey: 2
+        },
+        variant: 'source-upgrade'
+      })
+    )
+    expect(
+      getCanvasImageSharedDecodedAssetKey({
+        source: { src: 'data:image/png;base64,abc', weakRevisionKey: 1 },
+        variant: 'source-upgrade'
+      })
+    ).toBe(
+      getCanvasImageSharedDecodedAssetKey({
+        source: { src: 'data:image/png;base64,abc', weakRevisionKey: 2 },
+        variant: 'source-upgrade'
+      })
+    )
+  })
+
+  it('merges duplicate in-flight loads and removes settled entries', async () => {
+    const deduper = new CanvasImageInFlightDeduper<object>()
+    const load = vi.fn(async () => ({}))
+    const first = deduper.run('stable', load)
+    const second = deduper.run('stable', load)
+    expect(first).toBe(second)
+    await first
+    await deduper.run('stable', load)
+    expect(load).toHaveBeenCalledTimes(2)
+  })
+
+  it('reference-counts shared resources', () => {
+    const pool = new CanvasImageSharedResourcePool<object>()
+    const resource = {}
+    const destroy = vi.fn()
+    expect(pool.acquire('key', () => resource)).toBe(resource)
+    expect(pool.acquire('key', () => ({}))).toBe(resource)
+    pool.release('key', destroy)
+    expect(destroy).not.toHaveBeenCalled()
+    pool.release('key', destroy)
+    expect(destroy).toHaveBeenCalledWith(resource)
+  })
+
+  it('charges shared physical resource bytes once across crops and releases them once', () => {
+    const tracker = new CanvasImageSharedResourceByteTracker()
+
+    expect(tracker.acquire('decoded-source', 400)).toBe(400)
+    expect(tracker.acquire('decoded-source', 100)).toBe(0)
+    expect(tracker.getTotal()).toBe(400)
+    expect(tracker.getAdditionalBytes('decoded-source', 400)).toBe(0)
+    expect(tracker.getRefCount('decoded-source')).toBe(2)
+
+    expect(tracker.release('decoded-source')).toBe(0)
+    expect(tracker.getTotal()).toBe(400)
+    expect(tracker.getReleaseBytes('decoded-source')).toBe(400)
+    expect(tracker.release('decoded-source')).toBe(400)
+    expect(tracker.getTotal()).toBe(0)
+  })
+
+  it('keeps separately decoded source revisions in separate budget entries', () => {
+    const tracker = new CanvasImageSharedResourceByteTracker()
+    tracker.acquire('source-a', 400)
+    tracker.acquire('source-b', 200)
+    expect(tracker.getTotal()).toBe(600)
+    tracker.clear()
+    expect(tracker.getTotal()).toBe(0)
+  })
+
+  it('reference-counts one reservation per shared physical decode key', () => {
+    const tracker = new CanvasImageSharedReservationTracker()
+    const reserve = vi.fn(() => true)
+    const releaseReservation = vi.fn()
+
+    const first = tracker.acquire('shared-source', reserve, releaseReservation)
+    const second = tracker.acquire('shared-source', reserve, releaseReservation)
+
+    expect(reserve).toHaveBeenCalledTimes(1)
+    expect(tracker.getRefCount('shared-source')).toBe(2)
+    first?.()
+    expect(releaseReservation).not.toHaveBeenCalled()
+    expect(tracker.getRefCount('shared-source')).toBe(1)
+    second?.()
+    expect(releaseReservation).toHaveBeenCalledTimes(1)
+    expect(tracker.getRefCount('shared-source')).toBe(0)
+  })
+
+  it('keeps a producer reservation until an aborted late decode actually settles', async () => {
+    const reservations = new CanvasImageSharedReservationTracker()
+    const releasePhysicalReservation = vi.fn()
+    const reserve = vi.fn(() => true)
+    const consumerRelease = reservations.acquire('decode', reserve, releasePhysicalReservation)
+    const producerRelease = reservations.acquire('decode', reserve, releasePhysicalReservation)
+    let resolveDecode!: () => void
+    const lateDecode = new Promise<void>((resolve) => (resolveDecode = resolve)).finally(() =>
+      producerRelease?.()
+    )
+
+    consumerRelease?.()
+    expect(reservations.getRefCount('decode')).toBe(1)
+    expect(releasePhysicalReservation).not.toHaveBeenCalled()
+    expect(reservations.acquire('other-decode', () => false, vi.fn())).toBeNull()
+
+    resolveDecode()
+    await lateDecode
+
+    expect(reservations.getRefCount('decode')).toBe(0)
+    expect(releasePhysicalReservation).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not retain a reservation when admission is denied', () => {
+    const tracker = new CanvasImageSharedReservationTracker()
+    const releaseReservation = vi.fn()
+
+    expect(tracker.acquire('blocked', () => false, releaseReservation)).toBeNull()
+    expect(tracker.getRefCount('blocked')).toBe(0)
+    expect(releaseReservation).not.toHaveBeenCalled()
+  })
+
+  it('makes late object URL release token-safe', () => {
+    const release = vi.fn()
+    const safeRelease = createTokenSafeRelease(release)
+    safeRelease()
+    safeRelease()
+    expect(release).toHaveBeenCalledTimes(1)
+  })
+  it('leases a deduplicated resource until both consumers release it', async () => {
+    const pool = new CanvasImageAsyncSharedResourcePool<object>()
+    const resource = {}
+    const load = vi.fn(async () => resource)
+    const destroy = vi.fn()
+
+    const [first, second] = await Promise.all([
+      pool.acquire('shared', load, destroy),
+      pool.acquire('shared', load, destroy)
+    ])
+
+    expect(load).toHaveBeenCalledTimes(1)
+    expect(first.resource).toBe(resource)
+    expect(second.resource).toBe(resource)
+    expect(pool.getRefCount('shared')).toBe(2)
+
+    first.release()
+    first.release()
+    expect(destroy).not.toHaveBeenCalled()
+    expect(pool.getRefCount('shared')).toBe(1)
+
+    second.release()
+    expect(destroy).toHaveBeenCalledTimes(1)
+    expect(destroy).toHaveBeenCalledWith(resource)
+    expect(pool.getRefCount('shared')).toBe(0)
+  })
+
+  it('invokes a later callback consumer synchronously for an already-resolved shared resource', async () => {
+    const pool = new CanvasImageAsyncSharedResourcePool<object>()
+    const resource = {}
+    const destroy = vi.fn()
+    const first = await pool.acquire('shared', async () => resource, destroy)
+    const secondOnLease = vi.fn()
+
+    const cancelSecond = pool.acquireWithCallback(
+      'shared',
+      async () => ({}),
+      destroy,
+      secondOnLease,
+      vi.fn()
+    )
+
+    expect(secondOnLease).toHaveBeenCalledTimes(1)
+    expect(secondOnLease).toHaveBeenCalledWith(
+      expect.objectContaining({ resource, release: expect.any(Function) })
+    )
+    expect(pool.getRefCount('shared')).toBe(2)
+
+    cancelSecond()
+    expect(pool.getRefCount('shared')).toBe(1)
+    expect(destroy).not.toHaveBeenCalled()
+
+    first.release()
+    expect(destroy).toHaveBeenCalledWith(resource)
+  })
+
+  it('releases stale or unmounted consumers without prematurely destroying a live lease', async () => {
+    const pool = new CanvasImageAsyncSharedResourcePool<object>()
+    const resource = {}
+    const destroy = vi.fn()
+    const stale = await pool.acquire('shared', async () => resource, destroy)
+    const mounted = await pool.acquire('shared', async () => resource, destroy)
+
+    stale.release()
+    expect(destroy).not.toHaveBeenCalled()
+    expect(mounted.resource).toBe(resource)
+
+    mounted.release()
+    expect(destroy).toHaveBeenCalledTimes(1)
+  })
+
+  it('destroys exactly once when the final listener releases synchronously during resolution', async () => {
+    const pool = new CanvasImageAsyncSharedResourcePool<object>()
+    const resource = {}
+    const destroy = vi.fn()
+    let resolve!: (resource: object) => void
+    pool.acquireWithCallback(
+      'shared',
+      () => new Promise<object>((next) => (resolve = next)),
+      destroy,
+      (lease) => lease.release(),
+      vi.fn()
+    )
+
+    resolve(resource)
+    await Promise.resolve()
+
+    expect(destroy).toHaveBeenCalledTimes(1)
+    expect(destroy).toHaveBeenCalledWith(resource)
+    expect(pool.getRefCount('shared')).toBe(0)
+  })
+
+  it('destroys a pending resource after every consumer releases before completion', async () => {
+    const pool = new CanvasImageAsyncSharedResourcePool<object>()
+    const resource = {}
+    const destroy = vi.fn()
+    let resolve!: (resource: object) => void
+    const load = () => new Promise<object>((next) => (resolve = next))
+    const firstPending = pool.acquire('shared', load, destroy)
+    const secondPending = pool.acquire('shared', load, destroy)
+
+    await Promise.resolve()
+    resolve(resource)
+    const [first, second] = await Promise.all([firstPending, secondPending])
+    first.release()
+    expect(destroy).not.toHaveBeenCalled()
+    second.release()
+    expect(destroy).toHaveBeenCalledTimes(1)
+  })
+
+  it('destroys a resolved resource whose only consumer unmounted while loading', async () => {
+    const pool = new CanvasImageAsyncSharedResourcePool<object>()
+    const resource = {}
+    const destroy = vi.fn()
+    let resolve!: (resource: object) => void
+    const pending = pool.acquire(
+      'shared',
+      () => new Promise<object>((next) => (resolve = next)),
+      destroy
+    )
+
+    resolve(resource)
+    const lease = await pending
+    lease.release()
+
+    expect(destroy).toHaveBeenCalledTimes(1)
+  })
+
+  it('destroys a cancelled late resource without disturbing a replacement same-key entry', async () => {
+    const pool = new CanvasImageAsyncSharedResourcePool<object>()
+    const oldResource = { generation: 'old' }
+    const newResource = { generation: 'new' }
+    const destroy = vi.fn()
+    const oldOnLease = vi.fn()
+    const newOnLease = vi.fn()
+    let resolveOld!: (resource: object) => void
+    let resolveNew!: (resource: object) => void
+
+    const cancelOld = pool.acquireWithCallback(
+      'shared',
+      () => new Promise<object>((resolve) => (resolveOld = resolve)),
+      destroy,
+      oldOnLease,
+      vi.fn()
+    )
+    cancelOld()
+
+    pool.acquireWithCallback(
+      'shared',
+      () => new Promise<object>((resolve) => (resolveNew = resolve)),
+      destroy,
+      newOnLease,
+      vi.fn()
+    )
+    expect(pool.getRefCount('shared')).toBe(1)
+
+    resolveOld(oldResource)
+    await Promise.resolve()
+
+    expect(destroy).toHaveBeenCalledWith(oldResource)
+    expect(oldOnLease).not.toHaveBeenCalled()
+    expect(pool.getRefCount('shared')).toBe(1)
+
+    resolveNew(newResource)
+    await Promise.resolve()
+
+    expect(newOnLease).toHaveBeenCalledTimes(1)
+    expect(destroy).not.toHaveBeenCalledWith(newResource)
+    expect(pool.getRefCount('shared')).toBe(1)
+  })
+
+  it('cancels the underlying pending load after the final callback consumer leaves', async () => {
+    const pool = new CanvasImageAsyncSharedResourcePool<object>()
+    const destroy = vi.fn()
+    const onLease = vi.fn()
+    const onError = vi.fn()
+    let observedSignal: AbortSignal | null = null
+    const cancel = pool.acquireWithCallback(
+      'shared',
+      (signal) => {
+        observedSignal = signal
+        return new Promise<object>(() => undefined)
+      },
+      destroy,
+      onLease,
+      onError
+    )
+
+    cancel()
+    await Promise.resolve()
+
+    expect((observedSignal as AbortSignal | null)?.aborted).toBe(true)
+    expect(pool.getRefCount('shared')).toBe(0)
+    expect(onLease).not.toHaveBeenCalled()
+    expect(onError).not.toHaveBeenCalled()
+    expect(destroy).not.toHaveBeenCalled()
+  })
+})

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasImageResourceLifecycle.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasImageResourceLifecycle.ts
@@ -1,0 +1,351 @@
+export type CanvasImageStableSource = {
+  src: string
+  sourceIdentity?: { cacheKey: string } | null
+  weakRevisionKey?: string | number | null
+}
+
+export function hasCanvasImageStrongSourceIdentity(source: CanvasImageStableSource): boolean {
+  return Boolean(source.sourceIdentity?.cacheKey) || /^data:/i.test(source.src)
+}
+
+export function getCanvasImageStableSourceKey(source: CanvasImageStableSource): string | null {
+  const identityKey = source.sourceIdentity?.cacheKey
+  if (identityKey) return `identity:${identityKey}`
+  if (/^(?:https?:|data:)/i.test(source.src)) return `src:${source.src}`
+  return null
+}
+
+export function getCanvasImageSourceRevisionKey(source: CanvasImageStableSource): string {
+  const weakRevisionKey = hasCanvasImageStrongSourceIdentity(source)
+    ? null
+    : (source.weakRevisionKey ?? null)
+  return JSON.stringify([source.src, source.sourceIdentity?.cacheKey ?? null, weakRevisionKey])
+}
+
+export function getCanvasImageSharedDecodedAssetKey({
+  source,
+  variant
+}: {
+  source: CanvasImageStableSource
+  variant: string
+}): string | null {
+  const sourceKey = getCanvasImageStableSourceKey(source)
+  if (!sourceKey) return null
+  const weakRevisionKey = hasCanvasImageStrongSourceIdentity(source)
+    ? null
+    : (source.weakRevisionKey ?? null)
+  const revisionSuffix = weakRevisionKey === null ? '' : `|weak-revision:${weakRevisionKey}`
+  return `${sourceKey}${revisionSuffix}|decoded-asset:${variant}`
+}
+
+export type CanvasImageRequestToken = Readonly<{
+  itemId: string
+  sourceRevisionKey: string
+  sequence: number
+}>
+
+export class CanvasImageRequestTokenTracker {
+  private readonly currentByItemId = new Map<string, CanvasImageRequestToken>()
+  private nextSequence = 1
+
+  begin(itemId: string, source: CanvasImageStableSource): CanvasImageRequestToken {
+    const token = {
+      itemId,
+      sourceRevisionKey: getCanvasImageSourceRevisionKey(source),
+      sequence: this.nextSequence
+    }
+    this.nextSequence += 1
+    this.currentByItemId.set(itemId, token)
+    return token
+  }
+
+  isCurrent(token: CanvasImageRequestToken, source: CanvasImageStableSource): boolean {
+    return (
+      this.currentByItemId.get(token.itemId) === token &&
+      token.sourceRevisionKey === getCanvasImageSourceRevisionKey(source)
+    )
+  }
+
+  invalidate(itemId: string) {
+    this.currentByItemId.delete(itemId)
+  }
+
+  clear() {
+    this.currentByItemId.clear()
+  }
+}
+
+export function getCanvasImageDecodedRevisionKey({
+  source,
+  decodedIdentity
+}: {
+  source: CanvasImageStableSource
+  decodedIdentity: string | number
+}): string {
+  return `${getCanvasImageStableSourceKey(source) ?? `unstable:${source.src}`}|decoded:${decodedIdentity}`
+}
+
+export class CanvasImageInFlightDeduper<T> {
+  private readonly pending = new Map<string, Promise<T>>()
+
+  run(key: string, load: () => Promise<T>): Promise<T> {
+    const existing = this.pending.get(key)
+    if (existing) return existing
+    const promise = load().finally(() => {
+      if (this.pending.get(key) === promise) this.pending.delete(key)
+    })
+    this.pending.set(key, promise)
+    return promise
+  }
+
+  clear() {
+    this.pending.clear()
+  }
+}
+
+export class CanvasImageSharedResourcePool<T> {
+  private readonly entries = new Map<string, { resource: T; refs: number }>()
+
+  acquire(key: string, create: () => T): T {
+    const existing = this.entries.get(key)
+    if (existing) {
+      existing.refs += 1
+      return existing.resource
+    }
+    const resource = create()
+    this.entries.set(key, { resource, refs: 1 })
+    return resource
+  }
+
+  release(key: string, destroy: (resource: T) => void) {
+    const entry = this.entries.get(key)
+    if (!entry) return
+    entry.refs -= 1
+    if (entry.refs > 0) return
+    this.entries.delete(key)
+    destroy(entry.resource)
+  }
+
+  clear(destroy: (resource: T) => void) {
+    this.entries.forEach(({ resource }) => destroy(resource))
+    this.entries.clear()
+  }
+
+  getRefCount(key: string) {
+    return this.entries.get(key)?.refs ?? 0
+  }
+}
+
+export class CanvasImageSharedResourceByteTracker {
+  private readonly entries = new Map<string, { bytes: number; refs: number }>()
+  private total = 0
+
+  acquire(key: string, bytes: number) {
+    const existing = this.entries.get(key)
+    if (existing) {
+      existing.refs += 1
+      return 0
+    }
+    const safeBytes = Number.isFinite(bytes) ? Math.max(0, bytes) : 0
+    this.entries.set(key, { bytes: safeBytes, refs: 1 })
+    this.total += safeBytes
+    return safeBytes
+  }
+
+  release(key: string) {
+    const entry = this.entries.get(key)
+    if (!entry) return 0
+    entry.refs -= 1
+    if (entry.refs > 0) return 0
+    this.entries.delete(key)
+    this.total = Math.max(0, this.total - entry.bytes)
+    return entry.bytes
+  }
+
+  getAdditionalBytes(key: string, bytes: number) {
+    if (this.entries.has(key)) return 0
+    return Number.isFinite(bytes) ? Math.max(0, bytes) : 0
+  }
+
+  getReleaseBytes(key: string) {
+    const entry = this.entries.get(key)
+    return entry?.refs === 1 ? entry.bytes : 0
+  }
+
+  getRefCount(key: string) {
+    return this.entries.get(key)?.refs ?? 0
+  }
+
+  getTotal() {
+    return this.total
+  }
+
+  clear() {
+    this.entries.clear()
+    this.total = 0
+  }
+}
+
+export class CanvasImageSharedReservationTracker {
+  private readonly refsByKey = new Map<string, number>()
+
+  acquire(
+    key: string,
+    reserve: () => boolean,
+    releaseReservation: () => void
+  ): (() => void) | null {
+    const existingRefs = this.refsByKey.get(key)
+    if (existingRefs !== undefined) {
+      this.refsByKey.set(key, existingRefs + 1)
+    } else {
+      if (!reserve()) return null
+      this.refsByKey.set(key, 1)
+    }
+
+    let active = true
+    return () => {
+      if (!active) return
+      active = false
+      const refs = this.refsByKey.get(key)
+      if (refs === undefined) return
+      if (refs > 1) {
+        this.refsByKey.set(key, refs - 1)
+        return
+      }
+      this.refsByKey.delete(key)
+      releaseReservation()
+    }
+  }
+
+  clear(releaseReservation: (key: string) => void) {
+    this.refsByKey.forEach((_refs, key) => releaseReservation(key))
+    this.refsByKey.clear()
+  }
+
+  getRefCount(key: string) {
+    return this.refsByKey.get(key) ?? 0
+  }
+}
+
+export type CanvasImageSharedResourceLease<T> = {
+  resource: T
+  release: () => void
+}
+
+type CanvasImagePendingSharedResource<T> = {
+  promise: Promise<T>
+  refs: number
+  abortController: AbortController
+  resource?: T
+  error?: unknown
+  destroyed?: boolean
+  listeners: Set<{
+    resolve: (lease: CanvasImageSharedResourceLease<T>) => void
+    reject: (error: unknown) => void
+    release: () => void
+  }>
+}
+
+export class CanvasImageAsyncSharedResourcePool<T> {
+  private readonly entries = new Map<string, CanvasImagePendingSharedResource<T>>()
+
+  acquireWithCallback(
+    key: string,
+    load: (signal: AbortSignal) => Promise<T>,
+    destroy: (resource: T) => void,
+    onLease: (lease: CanvasImageSharedResourceLease<T>) => void,
+    onError: (error: unknown) => void
+  ): () => void {
+    let entry = this.entries.get(key)
+    if (!entry) {
+      const abortController = new AbortController()
+      entry = {
+        promise: load(abortController.signal),
+        refs: 0,
+        abortController,
+        listeners: new Set()
+      }
+      this.entries.set(key, entry)
+      void entry.promise.then(
+        (resource) => {
+          entry!.resource = resource
+          entry!.listeners.forEach((listener) =>
+            listener.resolve({ resource, release: listener.release })
+          )
+          entry!.listeners.clear()
+          if (entry!.refs === 0 && !entry!.destroyed) {
+            entry!.destroyed = true
+            if (this.entries.get(key) === entry) this.entries.delete(key)
+            destroy(resource)
+          }
+        },
+        (error) => {
+          entry!.error = error
+          entry!.listeners.forEach((listener) => listener.reject(error))
+          entry!.listeners.clear()
+          if (this.entries.get(key) === entry) this.entries.delete(key)
+        }
+      )
+    }
+
+    entry.refs += 1
+    let active = true
+    const release = () => {
+      if (!active) return
+      active = false
+      entry!.refs -= 1
+      if (entry!.refs === 0 && entry!.resource !== undefined && !entry!.destroyed) {
+        entry!.destroyed = true
+        if (this.entries.get(key) === entry) this.entries.delete(key)
+        destroy(entry!.resource)
+      } else if (entry!.refs === 0 && entry!.resource === undefined) {
+        if (this.entries.get(key) === entry) this.entries.delete(key)
+        entry!.abortController.abort()
+      }
+    }
+
+    if (entry.resource !== undefined) {
+      onLease({ resource: entry.resource, release })
+      return release
+    }
+    if (entry.error !== undefined) {
+      release()
+      onError(entry.error)
+      return release
+    }
+    const listener = {
+      resolve: onLease,
+      reject: (error: unknown) => {
+        release()
+        onError(error)
+      },
+      release
+    }
+    entry.listeners.add(listener)
+    return () => {
+      entry?.listeners.delete(listener)
+      release()
+    }
+  }
+
+  acquire(key: string, load: (signal: AbortSignal) => Promise<T>, destroy: (resource: T) => void) {
+    return new Promise<CanvasImageSharedResourceLease<T>>((resolve, reject) => {
+      this.acquireWithCallback(key, load, destroy, resolve, reject)
+    })
+  }
+
+  getRefCount(key: string) {
+    return this.entries.get(key)?.refs ?? 0
+  }
+}
+
+export function createTokenSafeRelease<TArgs extends unknown[]>(
+  release: (...args: TArgs) => void
+): (...args: TArgs) => void {
+  let active = true
+  return (...args: TArgs) => {
+    if (!active) return
+    active = false
+    release(...args)
+  }
+}

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasLocalFileSource.test.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasLocalFileSource.test.ts
@@ -3,6 +3,7 @@ import {
   authorizeCanvasLocalMediaSourceUrl,
   getCanvasLocalMediaSourceUrl,
   getElectronCanvasFilePath,
+  resolveAuthorizedCanvasLocalMediaSourceUrl,
   resolveCanvasImageFileSource
 } from './canvasLocalFileSource'
 
@@ -10,14 +11,18 @@ const originalElectronFile = window.electronFile
 const originalElectronApi = (window as Window & { electronAPI?: unknown }).electronAPI
 const originalCreateObjectUrlDescriptor = Object.getOwnPropertyDescriptor(URL, 'createObjectURL')
 
-function setElectronFileBridge(value: typeof window.electronFile | undefined): void {
+function setElectronFileBridge(
+  value: Partial<NonNullable<typeof window.electronFile>> | undefined
+): void {
   Object.defineProperty(window, 'electronFile', {
     configurable: true,
     value
   })
 }
 
-function setElectronApiBridge(value: typeof window.electronFile | undefined): void {
+function setElectronApiBridge(
+  value: Partial<NonNullable<typeof window.electronFile>> | undefined
+): void {
   Object.defineProperty(window, 'electronAPI', {
     configurable: true,
     value
@@ -53,6 +58,44 @@ describe('canvasLocalFileSource', () => {
     expect(getCanvasLocalMediaSourceUrl(file)).toBe('local-media:///C:/assets/image.png')
   })
 
+  it.each([
+    {
+      label: 'Windows drive',
+      filePath: String.raw`C:\assets\hash#query?\literal%2F-%25-图像.png`,
+      expectedUrl:
+        'local-media:///C:/assets/hash%23query%3F/literal%252F-%2525-%E5%9B%BE%E5%83%8F.png',
+      expectedPath: 'C:/assets/hash#query?/literal%2F-%25-图像.png'
+    },
+    {
+      label: 'POSIX',
+      filePath: '/Users/demo/hash#query?/literal%2F-%25-图像.png',
+      expectedUrl:
+        'local-media:///Users/demo/hash%23query%3F/literal%252F-%2525-%E5%9B%BE%E5%83%8F.png',
+      expectedPath: '/Users/demo/hash#query?/literal%2F-%25-图像.png'
+    },
+    {
+      label: 'UNC',
+      filePath: String.raw`\\server-name\share\hash#query?\literal%2F-%25-图像.png`,
+      expectedUrl:
+        'local-media://server-name/share/hash%23query%3F/literal%252F-%2525-%E5%9B%BE%E5%83%8F.png',
+      expectedPath: '//server-name/share/hash#query?/literal%2F-%25-图像.png'
+    }
+  ])(
+    'round-trips URL-safe $label paths without treating literal percent escapes as syntax',
+    async ({ filePath, expectedUrl, expectedPath }) => {
+      const file = new File(['png'], 'image.png', { type: 'image/png' })
+      Object.defineProperty(file, 'path', { configurable: true, value: filePath })
+      expect(getCanvasLocalMediaSourceUrl(file)).toBe(expectedUrl)
+
+      const resolveAuthorizedLocalMediaPath = vi.fn(async () => filePath)
+      setElectronFileBridge({ resolveAuthorizedLocalMediaPath })
+      await expect(resolveAuthorizedCanvasLocalMediaSourceUrl(expectedUrl)).resolves.toBe(
+        expectedUrl
+      )
+      expect(resolveAuthorizedLocalMediaPath).toHaveBeenCalledWith(expectedPath)
+    }
+  )
+
   it('returns null for a pathless non-File blob', () => {
     expect(getCanvasLocalMediaSourceUrl(new Blob(['png'], { type: 'image/png' }))).toBeNull()
   })
@@ -71,14 +114,14 @@ describe('canvasLocalFileSource', () => {
     expect(getPathForFile).toHaveBeenCalledWith(file)
   })
 
-  it('falls back to the standard electronAPI bridge when electronFile is unavailable', () => {
+  it('does not fall back to a renderer-provided bridge when electronFile is unavailable', () => {
     setElectronFileBridge(undefined)
     const getPathForFile = vi.fn(() => String.raw`E:\project\project.mpcanvas`)
     setElectronApiBridge({ getPathForFile, authorizeLocalMediaFile: vi.fn() })
     const file = new File(['{}'], 'project.mpcanvas', { type: 'application/json' })
 
-    expect(getElectronCanvasFilePath(file)).toBe(String.raw`E:\project\project.mpcanvas`)
-    expect(getPathForFile).toHaveBeenCalledWith(file)
+    expect(getElectronCanvasFilePath(file)).toBe('')
+    expect(getPathForFile).not.toHaveBeenCalled()
   })
 
   it('returns a local-media URL only after the preload bridge authorizes the file', async () => {
@@ -101,6 +144,48 @@ describe('canvasLocalFileSource', () => {
     await expect(
       authorizeCanvasLocalMediaSourceUrl(new File(['video'], 'video.mp4', { type: 'video/mp4' }))
     ).resolves.toBeNull()
+  })
+
+  it('authorizes image Files before returning a persistent local-media URL', async () => {
+    const authorizeLocalMediaFile = vi.fn(async () => 'D:\\bridge\\image.png')
+    setElectronFileBridge({
+      getPathForFile: vi.fn(() => 'D:\\bridge\\image.png'),
+      authorizeLocalMediaFile
+    })
+    const createObjectURL = vi.fn(() => 'blob:canvas-image')
+    setCreateObjectUrl(createObjectURL)
+
+    const file = new File(['png'], 'image.png', { type: 'image/png' })
+    const readFileAsDataURL = vi.fn(async () => 'data:image/png;base64,AAAA')
+
+    await expect(resolveCanvasImageFileSource(file, readFileAsDataURL)).resolves.toBe(
+      'local-media:///D:/bridge/image.png'
+    )
+    expect(authorizeLocalMediaFile).toHaveBeenCalledWith(file)
+    expect(createObjectURL).not.toHaveBeenCalled()
+    expect(readFileAsDataURL).not.toHaveBeenCalled()
+  })
+
+  it('falls back to an object URL when image authorization fails', async () => {
+    const authorizeLocalMediaFile = vi.fn(async () => {
+      throw new Error('authorization failed')
+    })
+    setElectronFileBridge({
+      getPathForFile: vi.fn(() => 'D:\\bridge\\image.png'),
+      authorizeLocalMediaFile
+    })
+    const createObjectURL = vi.fn(() => 'blob:canvas-image')
+    setCreateObjectUrl(createObjectURL)
+
+    const file = new File(['png'], 'image.png', { type: 'image/png' })
+    const readFileAsDataURL = vi.fn(async () => 'data:image/png;base64,AAAA')
+
+    await expect(resolveCanvasImageFileSource(file, readFileAsDataURL)).resolves.toBe(
+      'blob:canvas-image'
+    )
+    expect(authorizeLocalMediaFile).toHaveBeenCalledWith(file)
+    expect(createObjectURL).toHaveBeenCalledWith(file)
+    expect(readFileAsDataURL).not.toHaveBeenCalled()
   })
 
   it('falls back to object URLs for browser-only image files', async () => {

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasLocalFileSource.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasLocalFileSource.ts
@@ -6,7 +6,34 @@ type ElectronCanvasFile = File & {
 
 type ElectronFileBridge = {
   getPathForFile?: (file: File) => string
-  authorizeLocalMediaFile?: (file: File) => Promise<string>
+  authorizeLocalMediaFile?: (file: File) => string | Promise<string>
+  resolveAuthorizedLocalMediaPath?: (filePath: string) => Promise<string>
+}
+
+function encodeLocalMediaPathSegments(filePath: string): string {
+  return filePath
+    .split('/')
+    .map((segment, index) =>
+      index === 1 && /^[a-zA-Z]:$/.test(segment) ? segment : encodeURIComponent(segment)
+    )
+    .join('/')
+}
+
+export function toLocalMediaUrl(filePath: string): string | null {
+  const trimmed = filePath.trim()
+  if (!trimmed) return null
+
+  const normalizedPath = trimmed.replace(/\\/g, '/')
+  if (normalizedPath.startsWith('//')) {
+    const [hostname, ...segments] = normalizedPath.slice(2).split('/')
+    if (!hostname) return null
+    return `local-media://${encodeURIComponent(hostname)}/${segments
+      .map(encodeURIComponent)
+      .join('/')}`
+  }
+
+  const pathname = normalizedPath.startsWith('/') ? normalizedPath : `/${normalizedPath}`
+  return `local-media://${encodeLocalMediaPathSegments(pathname)}`
 }
 
 export function getElectronCanvasFilePath(file: Blob): string {
@@ -22,9 +49,8 @@ export function getElectronCanvasFilePath(file: Blob): string {
   try {
     const bridgeWindow = window as Window & {
       electronFile?: ElectronFileBridge
-      electronAPI?: ElectronFileBridge
     }
-    const bridge = bridgeWindow.electronFile || bridgeWindow.electronAPI
+    const bridge = bridgeWindow.electronFile
     const bridgedPath = file instanceof File ? bridge?.getPathForFile?.(file) : ''
     return typeof bridgedPath === 'string' ? bridgedPath : ''
   } catch {
@@ -33,12 +59,7 @@ export function getElectronCanvasFilePath(file: Blob): string {
 }
 
 export function getCanvasLocalMediaSourceUrl(file: Blob): string | null {
-  const filePath = getElectronCanvasFilePath(file).replace(/\\/g, '/')
-  if (!filePath) {
-    return null
-  }
-
-  return normalizeLocalMediaUrl(`file://${filePath}`)
+  return toLocalMediaUrl(getElectronCanvasFilePath(file))
 }
 
 export async function authorizeCanvasLocalMediaSourceUrl(file: File): Promise<string | null> {
@@ -46,8 +67,31 @@ export async function authorizeCanvasLocalMediaSourceUrl(file: File): Promise<st
 
   try {
     const filePath = await window.electronFile?.authorizeLocalMediaFile?.(file)
-    if (!filePath) return null
-    return normalizeLocalMediaUrl(`file://${filePath.replace(/\\/g, '/')}`)
+    return filePath ? toLocalMediaUrl(filePath) : null
+  } catch {
+    return null
+  }
+}
+
+export async function resolveAuthorizedCanvasLocalMediaSourceUrl(
+  sourceUrl: string
+): Promise<string | null> {
+  const normalized = normalizeLocalMediaUrl(sourceUrl).trim()
+  if (!/^local-media:|^file:/i.test(normalized) || typeof window === 'undefined') return null
+
+  try {
+    const parsed = new URL(normalized)
+    const decodedPathSegments = parsed.pathname
+      .split('/')
+      .map((segment) => decodeURIComponent(segment))
+    let filePath = decodedPathSegments.join('/').replace(/^\/([a-zA-Z]:\/)/, '$1')
+    if (/^[a-zA-Z]$/.test(parsed.hostname)) {
+      filePath = `${parsed.hostname}:/${filePath.replace(/^\/+/, '')}`
+    } else if (parsed.hostname) {
+      filePath = `//${decodeURIComponent(parsed.hostname)}/${filePath.replace(/^\/+/, '')}`
+    }
+    const authorized = await window.electronFile?.resolveAuthorizedLocalMediaPath?.(filePath)
+    return authorized ? toLocalMediaUrl(authorized) : null
   } catch {
     return null
   }
@@ -57,7 +101,7 @@ export async function resolveCanvasImageFileSource(
   file: File,
   readFileAsDataURL: (file: File) => Promise<string>
 ): Promise<string> {
-  const localMediaUrl = getCanvasLocalMediaSourceUrl(file)
+  const localMediaUrl = await authorizeCanvasLocalMediaSourceUrl(file)
   if (localMediaUrl) {
     return localMediaUrl
   }

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasLocalImageSource.test.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasLocalImageSource.test.ts
@@ -2,20 +2,28 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import {
   createCanvasLocalImageObjectUrl,
+  readCanvasLocalImageBlobFromSource,
   resolveCanvasLocalFilePathFromSource
 } from './canvasLocalImageSource'
 
-describe('canvasLocalImageSource', () => {
-  const originalApi = window.api
-  const originalCreateObjectURL = URL.createObjectURL
+const originalApi = window.api
+const originalElectronFile = window.electronFile
+const originalCreateObjectURL = URL.createObjectURL
+const originalFetch = globalThis.fetch
 
+describe('canvasLocalImageSource', () => {
   afterEach(() => {
     Object.defineProperty(window, 'api', {
       configurable: true,
       writable: true,
       value: originalApi
     })
+    Object.defineProperty(window, 'electronFile', {
+      configurable: true,
+      value: originalElectronFile
+    })
     URL.createObjectURL = originalCreateObjectURL
+    globalThis.fetch = originalFetch
     vi.restoreAllMocks()
   })
 
@@ -31,30 +39,84 @@ describe('canvasLocalImageSource', () => {
     )
   })
 
-  it('creates a blob URL from a local image path through svcFs', async () => {
-    const image = new Uint8Array([1, 2, 3, 4])
-    const readImageFromPath = vi.fn(async () => ({ image, filename: '无标题(95).png' }))
-    const createObjectUrl = vi.fn((_blob: Blob) => 'blob:local-image')
-    URL.createObjectURL = createObjectUrl as unknown as typeof URL.createObjectURL
-
+  it('streams an authorized local image through the local-media protocol without svcFs bytes', async () => {
+    const resolveAuthorizedLocalMediaPath = vi.fn(async (filePath: string) => filePath)
+    Object.defineProperty(window, 'electronFile', {
+      configurable: true,
+      value: { resolveAuthorizedLocalMediaPath }
+    })
+    const readImageFromPath = vi.fn()
     Object.defineProperty(window, 'api', {
       configurable: true,
       writable: true,
-      value: {
-        svcFs: {
-          readImageFromPath
-        }
-      }
+      value: { svcFs: { readImageFromPath } }
     })
 
-    const objectUrl = await createCanvasLocalImageObjectUrl(
+    const fetchMock = vi.fn(async () => new Response(new Uint8Array([1, 2, 3, 4])))
+    globalThis.fetch = fetchMock as typeof fetch
+    const createObjectUrl = vi.fn((_blob: Blob) => 'blob:local-image')
+    URL.createObjectURL = createObjectUrl as unknown as typeof URL.createObjectURL
+
+    const sourceUrl =
       'local-media://c/Users/17290/Desktop/%E6%96%B0%E5%BB%BA%E6%96%87%E4%BB%B6%E5%A4%B9/%E6%97%A0%E6%A0%87%E9%A2%98(95).png'
-    )
+    const objectUrl = await createCanvasLocalImageObjectUrl(sourceUrl, '无标题(95).png')
 
     expect(objectUrl).toBe('blob:local-image')
-    expect(readImageFromPath).toHaveBeenCalledWith({
-      fullPath: 'c:/Users/17290/Desktop/新建文件夹/无标题(95).png'
-    })
+    expect(resolveAuthorizedLocalMediaPath).toHaveBeenCalledWith(
+      'c:/Users/17290/Desktop/新建文件夹/无标题(95).png'
+    )
+    expect(fetchMock).toHaveBeenCalledWith(
+      'local-media:///c:/Users/17290/Desktop/%E6%96%B0%E5%BB%BA%E6%96%87%E4%BB%B6%E5%A4%B9/%E6%97%A0%E6%A0%87%E9%A2%98(95).png',
+      { signal: undefined }
+    )
+    expect(readImageFromPath).not.toHaveBeenCalled()
     expect((createObjectUrl.mock.calls[0]?.[0] as Blob | undefined)?.type).toBe('image/png')
+  })
+
+  it('aborts an authorized local image fetch without swallowing the abort', async () => {
+    Object.defineProperty(window, 'electronFile', {
+      configurable: true,
+      value: { resolveAuthorizedLocalMediaPath: vi.fn(async (filePath: string) => filePath) }
+    })
+    let observedSignal: AbortSignal | undefined
+    const fetchMock = vi.fn(
+      (_url: string | URL | Request, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          observedSignal = init?.signal ?? undefined
+          observedSignal?.addEventListener(
+            'abort',
+            () => reject(new DOMException('Aborted', 'AbortError')),
+            { once: true }
+          )
+        })
+    )
+    globalThis.fetch = fetchMock as typeof fetch
+    const controller = new AbortController()
+
+    const pending = readCanvasLocalImageBlobFromSource(
+      'local-media:///C:/Users/me/large.png',
+      undefined,
+      { signal: controller.signal }
+    )
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+    controller.abort()
+
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' })
+    expect(observedSignal).toBe(controller.signal)
+    expect(controller.signal.aborted).toBe(true)
+  })
+
+  it('rejects an unapproved local path before fetching it', async () => {
+    Object.defineProperty(window, 'electronFile', {
+      configurable: true,
+      value: { resolveAuthorizedLocalMediaPath: vi.fn(async () => '') }
+    })
+    const fetchMock = vi.fn()
+    globalThis.fetch = fetchMock as typeof fetch
+
+    await expect(
+      readCanvasLocalImageBlobFromSource('local-media:///C:/Users/me/private.png')
+    ).resolves.toBeNull()
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 })

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasLocalImageSource.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasLocalImageSource.ts
@@ -1,4 +1,7 @@
 import { normalizeFileMimeType } from '@renderer/utils/fileDisplay'
+import { resolveAuthorizedCanvasLocalMediaSourceUrl } from './canvasLocalFileSource'
+
+const inFlightLocalImageBlobReads = new Map<string, Promise<Blob | null>>()
 
 function decodePathPart(value: string): string {
   try {
@@ -79,33 +82,85 @@ export function canReadCanvasLocalImageSource(sourceUrl: string): boolean {
   return Boolean(
     resolveCanvasLocalFilePathFromSource(sourceUrl) &&
     typeof window !== 'undefined' &&
-    window.api?.svcFs?.readImageFromPath
+    typeof fetch === 'function' &&
+    window.electronFile?.resolveAuthorizedLocalMediaPath
   )
 }
 
 export async function readCanvasLocalImageBlobFromSource(
   sourceUrl: string,
-  fileName?: string
+  fileName?: string,
+  options: { signal?: AbortSignal } = {}
 ): Promise<Blob | null> {
-  const fullPath = resolveCanvasLocalFilePathFromSource(sourceUrl)
-  if (!fullPath || typeof window === 'undefined' || !window.api?.svcFs?.readImageFromPath) {
+  if (options.signal?.aborted) {
+    throw new DOMException('Local image read aborted.', 'AbortError')
+  }
+  const authorizedSource = await resolveAuthorizedCanvasLocalMediaSourceUrl(sourceUrl)
+  if (options.signal?.aborted) {
+    throw new DOMException('Local image read aborted.', 'AbortError')
+  }
+  if (!authorizedSource || typeof fetch !== 'function') {
     return null
   }
 
   try {
-    const { image, filename } = await window.api.svcFs.readImageFromPath({ fullPath })
-    const mimeType = normalizeFileMimeType(fileName ?? filename ?? fullPath, undefined, 'image/png')
-    return new Blob([image as BlobPart], { type: mimeType })
+    const response = await fetch(authorizedSource, { signal: options.signal })
+    if (!response.ok && response.status !== 0) {
+      throw new Error(`Failed to fetch local image source: ${response.status}`)
+    }
+
+    const blob = await response.blob()
+    if (options.signal?.aborted) {
+      throw new DOMException('Local image read aborted.', 'AbortError')
+    }
+    if (blob.type) return blob
+
+    const fullPath = resolveCanvasLocalFilePathFromSource(authorizedSource) ?? authorizedSource
+    const mimeType = normalizeFileMimeType(fileName ?? fullPath, undefined, 'image/png')
+    return blob.slice(0, blob.size, mimeType)
   } catch (error) {
-    console.warn('[Canvas] Failed to read local image source:', fullPath, error)
+    if (options.signal?.aborted || (error as { name?: unknown } | null)?.name === 'AbortError') {
+      throw error
+    }
+    console.warn('[Canvas] Failed to read local image source:', authorizedSource, error)
     return null
   }
+}
+
+export function readCanvasLocalImageBlobFromSourceShared(
+  sourceUrl: string,
+
+  fileName?: string
+): Promise<Blob | null> {
+  const fullPath = resolveCanvasLocalFilePathFromSource(sourceUrl)
+
+  if (!fullPath) {
+    return Promise.resolve(null)
+  }
+
+  const key = `${fullPath}\n${fileName ?? ''}`
+
+  const existing = inFlightLocalImageBlobReads.get(key)
+
+  if (existing) {
+    return existing
+  }
+
+  const pending = readCanvasLocalImageBlobFromSource(sourceUrl, fileName).finally(() => {
+    if (inFlightLocalImageBlobReads.get(key) === pending) {
+      inFlightLocalImageBlobReads.delete(key)
+    }
+  })
+
+  inFlightLocalImageBlobReads.set(key, pending)
+
+  return pending
 }
 
 export async function createCanvasLocalImageObjectUrl(
   sourceUrl: string,
   fileName?: string
 ): Promise<string | null> {
-  const blob = await readCanvasLocalImageBlobFromSource(sourceUrl, fileName)
+  const blob = await readCanvasLocalImageBlobFromSourceShared(sourceUrl, fileName)
   return blob ? URL.createObjectURL(blob) : null
 }

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/CanvasImageDomPreview.test.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/CanvasImageDomPreview.test.tsx
@@ -12,6 +12,7 @@ const originalDevicePixelRatio = window.devicePixelRatio
 const originalCreateObjectURL = URL.createObjectURL
 const originalRevokeObjectURL = URL.revokeObjectURL
 const originalApi = window.api
+const originalElectronFile = window.electronFile
 
 function createImage(width: number, height: number) {
   const image = document.createElement('img')
@@ -66,6 +67,11 @@ afterEach(() => {
     configurable: true,
     writable: true,
     value: originalApi
+  })
+  Object.defineProperty(window, 'electronFile', {
+    configurable: true,
+    writable: true,
+    value: originalElectronFile
   })
   Object.defineProperty(window, 'devicePixelRatio', {
     configurable: true,
@@ -191,25 +197,24 @@ describe('CanvasImageDomPreview', () => {
     expect(document.querySelector('img')).toBeNull()
   })
 
-  it('materializes local source previews through svcFs before rendering the image', async () => {
-    const readImageFromPath = vi.fn(async () => ({
-      image: new Uint8Array([1, 2, 3, 4]),
-      filename: 'huge.png'
-    }))
+  it('materializes authorized local source previews before rendering the image', async () => {
+    const resolveAuthorizedLocalMediaPath = vi.fn(async () => 'C:/real-board/huge.png')
+    const fetchLocalMedia = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(
+        new Response(new Blob([new Uint8Array([1, 2, 3, 4])], { type: 'image/png' }))
+      )
     const createObjectUrl = vi.fn(() => 'blob:materialized-preview')
     const revokeObjectUrl = vi.fn()
     URL.createObjectURL = createObjectUrl as unknown as typeof URL.createObjectURL
     URL.revokeObjectURL = revokeObjectUrl as unknown as typeof URL.revokeObjectURL
-    Object.defineProperty(window, 'api', {
+    Object.defineProperty(window, 'electronFile', {
       configurable: true,
       writable: true,
       value: {
-        svcFs: {
-          readImageFromPath
-        }
+        resolveAuthorizedLocalMediaPath
       }
     })
-
     const { unmount } = render(
       <CanvasImageDomPreview
         item={createItem({ image: undefined as unknown as CanvasImageItem['image'] })}
@@ -223,7 +228,10 @@ describe('CanvasImageDomPreview', () => {
     await waitFor(() => {
       expect(document.querySelector('img')?.getAttribute('src')).toBe('blob:materialized-preview')
     })
-    expect(readImageFromPath).toHaveBeenCalledWith({ fullPath: 'C:/real-board/huge.png' })
+    expect(resolveAuthorizedLocalMediaPath).toHaveBeenCalledWith('C:/real-board/huge.png')
+    expect(fetchLocalMedia).toHaveBeenCalledWith('local-media:///C:/real-board/huge.png', {
+      signal: undefined
+    })
 
     unmount()
 

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/CanvasTransientUi.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/CanvasTransientUi.tsx
@@ -220,7 +220,7 @@ const CanvasTransientUi: React.FC<CanvasTransientUiProps> = (props) => {
                 // 转成 Electron accelerator 格式
                 const accelerator = recordedShortcut.replace('Ctrl', 'CommandOrControl')
                 try {
-                  window.electron?.ipcRenderer?.invoke?.('screenshot:setShortcut', accelerator)
+                  void window.canvasScreenshot?.setShortcut(accelerator)
                   setCurrentShortcut(recordedShortcut)
                 } catch (err) {
                   console.error('[Canvas] 保存截图快捷键失败', err)

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasWebGLImageLayer.test.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasWebGLImageLayer.test.tsx
@@ -113,6 +113,7 @@ let textureFromWidths: number[] = []
 let textureFromAlphaModes: unknown[] = []
 let textureScaleModeReadCount = 0
 let textureScaleModeWriteCount = 0
+let createdBaseTextures: MockTextureInstance[] = []
 const originalDevicePixelRatio = typeof window === 'undefined' ? 1 : window.devicePixelRatio
 
 type MockImageInstance = {
@@ -256,7 +257,7 @@ function installPixiMock() {
           }
         }
 
-        return new MockTexture({
+        const texture = new MockTexture({
           source,
           frame: {
             x: 0,
@@ -265,6 +266,8 @@ function installPixiMock() {
             height: image.naturalHeight || image.height || 1
           }
         })
+        createdBaseTextures.push(texture)
+        return texture
       }
     }
 
@@ -448,8 +451,83 @@ describe('ProjectCanvasWebGLImageLayer', () => {
     textureFromAlphaModes = []
     textureScaleModeReadCount = 0
     textureScaleModeWriteCount = 0
+    createdBaseTextures = []
     setWindowDevicePixelRatio(originalDevicePixelRatio)
     installPixiMock()
+  })
+
+  it('shares one source texture across stable-source crops with independent decoded objects and destroys it after the final consumer leaves', async () => {
+    const { default: ProjectCanvasWebGLImageLayer } = await import('./ProjectCanvasWebGLImageLayer')
+    const firstDecodedImage = createImage(400, 240)
+    const secondDecodedImage = createImage(400, 240)
+    const sharedIdentity: CanvasImageSourceIdentity = {
+      version: 1,
+      kind: 'local-file',
+      cacheKey: 'shared-crop-source',
+      canonicalPath: 'C:/images/shared.png',
+      sizeBytes: 1_024,
+      lastModifiedMs: 1
+    }
+    const first = createItem({
+      id: 'shared-crop-a',
+      src: 'local-media:///C:/images/shared.png',
+      image: firstDecodedImage,
+      sourceIdentity: sharedIdentity,
+      crop: { x: 0, y: 0, width: 200, height: 240 }
+    })
+    const second = createItem({
+      id: 'shared-crop-b',
+      src: first.src,
+      x: 260,
+      image: secondDecodedImage,
+      sourceIdentity: sharedIdentity,
+      crop: { x: 200, y: 0, width: 200, height: 240 }
+    })
+
+    const { rerender } = render(
+      <ProjectCanvasWebGLImageLayer items={[first, second]} {...TEST_STAGE_VIEWPORT_1280_720} />
+    )
+
+    await waitFor(() => {
+      expect(getLiveSpriteByLabel(first.id)).not.toBeNull()
+      expect(getLiveSpriteByLabel(second.id)).not.toBeNull()
+    })
+    expect(createdBaseTextures).toHaveLength(1)
+
+    rerender(<ProjectCanvasWebGLImageLayer items={[second]} {...TEST_STAGE_VIEWPORT_1280_720} />)
+    await waitFor(() => expect(getLiveSpriteByLabel(first.id)).toBeNull())
+    expect(createdBaseTextures[0].destroyed).toBe(false)
+
+    rerender(<ProjectCanvasWebGLImageLayer items={[]} {...TEST_STAGE_VIEWPORT_1280_720} />)
+    await waitFor(() => expect(getLiveSpriteByLabel(second.id)).toBeNull())
+    expect(createdBaseTextures[0].destroyed).toBe(true)
+    expect(createdBaseTextures[0].destroySourceCalled).toBe(true)
+  })
+
+  it('dedupes immutable data URLs across independent provided image objects', async () => {
+    const { default: ProjectCanvasWebGLImageLayer } = await import('./ProjectCanvasWebGLImageLayer')
+    const src = 'data:image/png;base64,c2FtZS1waXhlbHM='
+    const first = createItem({
+      id: 'data-url-a',
+      src,
+      image: createImage(320, 180)
+    })
+    const second = createItem({
+      id: 'data-url-b',
+      src,
+      x: 360,
+      image: createImage(320, 180)
+    })
+
+    render(
+      <ProjectCanvasWebGLImageLayer items={[first, second]} {...TEST_STAGE_VIEWPORT_1280_720} />
+    )
+
+    await waitFor(() => {
+      expect(getLiveSpriteByLabel(first.id)).not.toBeNull()
+      expect(getLiveSpriteByLabel(second.id)).not.toBeNull()
+    })
+    expect(createdBaseTextures).toHaveLength(1)
   })
 
   it('initializes Pixi with explicit canvas clearing to avoid transparent-frame trails', async () => {
@@ -828,6 +906,30 @@ describe('ProjectCanvasWebGLImageLayer', () => {
     expect(updatedSprite.scale.x).toBe(5)
     expect(updatedSprite.scale.y).toBe(6)
   }, 30000)
+
+  it('does not reuse a stale texture when the same URL is refreshed with a new decoded object', async () => {
+    const { default: ProjectCanvasWebGLImageLayer } = await import('./ProjectCanvasWebGLImageLayer')
+    const firstImage = createImage(200, 120)
+    const secondImage = createImage(200, 120)
+    const first = createItem({ src: 'https://example.test/same.png', image: firstImage })
+    const { rerender } = render(
+      <ProjectCanvasWebGLImageLayer items={[first]} {...TEST_STAGE_VIEWPORT_1280_720} />
+    )
+
+    await waitFor(() => expect(createdBaseTextures).toHaveLength(1))
+    const firstTexture = createdBaseTextures[0]
+
+    rerender(
+      <ProjectCanvasWebGLImageLayer
+        items={[createItem({ src: first.src, image: secondImage })]}
+        {...TEST_STAGE_VIEWPORT_1280_720}
+      />
+    )
+
+    await waitFor(() => expect(createdBaseTextures).toHaveLength(2))
+    expect(firstTexture.destroyed).toBe(true)
+    expect((createdBaseTextures[1].source as { image?: unknown }).image).toBe(secondImage)
+  })
 
   it('re-sorts sprites when an item z-index changes', async () => {
     const { default: ProjectCanvasWebGLImageLayer } = await import('./ProjectCanvasWebGLImageLayer')
@@ -1890,7 +1992,7 @@ describe('ProjectCanvasWebGLImageLayer', () => {
     )
   }, 30000)
 
-  it('queues visible src-only image loads behind a bounded initial load pool', async () => {
+  it('does not start queued initial decodes while tearing down the bounded load pool', async () => {
     const {
       default: ProjectCanvasWebGLImageLayer,
       PROJECT_CANVAS_WEBGL_INITIAL_IMAGE_LOAD_CONCURRENCY
@@ -1922,7 +2024,7 @@ describe('ProjectCanvasWebGLImageLayer', () => {
         image: undefined as unknown as HTMLImageElement
       })
 
-      render(
+      const { unmount } = render(
         <ProjectCanvasWebGLImageLayer
           items={[...srcOnlyItems, offscreenSrcOnlyItem]}
           {...TEST_STAGE_VIEWPORT_1280_720}
@@ -1945,19 +2047,29 @@ describe('ProjectCanvasWebGLImageLayer', () => {
         { timeout: 15000 }
       )
 
-      expect(attemptedSrcs).toHaveLength(PROJECT_CANVAS_WEBGL_INITIAL_IMAGE_LOAD_CONCURRENCY)
+      expect(attemptedSrcs.filter(Boolean)).toHaveLength(
+        PROJECT_CANVAS_WEBGL_INITIAL_IMAGE_LOAD_CONCURRENCY
+      )
       const visibleSrcs = new Set(srcOnlyItems.map((item) => item.src))
       expect(attemptedSrcs.every((src) => visibleSrcs.has(src))).toBe(true)
       expect(attemptedSrcs).not.toContain(offscreenSrcOnlyItem.src)
       expect(createdSprites).toHaveLength(0)
 
+      unmount()
+      await act(async () => {
+        await Promise.resolve()
+      })
+      expect(attemptedSrcs.filter(Boolean)).toHaveLength(
+        PROJECT_CANVAS_WEBGL_INITIAL_IMAGE_LOAD_CONCURRENCY
+      )
+
       act(() => {
         imageInstances[0].onload?.()
       })
 
-      await waitFor(() => {
-        expect(attemptedSrcs).toHaveLength(PROJECT_CANVAS_WEBGL_INITIAL_IMAGE_LOAD_CONCURRENCY + 1)
-      })
+      expect(attemptedSrcs.filter(Boolean)).toHaveLength(
+        PROJECT_CANVAS_WEBGL_INITIAL_IMAGE_LOAD_CONCURRENCY
+      )
     } finally {
       vi.unstubAllGlobals()
     }
@@ -2006,9 +2118,10 @@ describe('ProjectCanvasWebGLImageLayer', () => {
       })
       queuedAnimationFrames.clear()
 
-      act(() => {
+      await act(async () => {
         imageInstances[0].onload?.()
         imageInstances[1].onload?.()
+        await Promise.resolve()
       })
 
       expect(queuedAnimationFrames.size).toBe(1)
@@ -2072,7 +2185,7 @@ describe('ProjectCanvasWebGLImageLayer', () => {
 
       await waitFor(
         () => {
-          expect(attemptedSrcs).toEqual([
+          expect(attemptedSrcs.filter(Boolean)).toEqual([
             'file:///image-replaced-old.png',
             'file:///image-replaced-new.png'
           ])
@@ -2151,6 +2264,63 @@ describe('ProjectCanvasWebGLImageLayer', () => {
         },
         { timeout: 15000 }
       )
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  }, 30000)
+
+  it('re-decodes a populated weak remote source cache when the provided image revision changes', async () => {
+    const { default: ProjectCanvasWebGLImageLayer } = await import('./ProjectCanvasWebGLImageLayer')
+    const attemptedSrcs: string[] = []
+    const imageInstances: MockImageInstance[] = []
+    const MockImage = createMockImageClass({
+      width: 4096,
+      height: 4096,
+      attemptedSrcs,
+      imageInstances
+    })
+    vi.stubGlobal('Image', MockImage as unknown as typeof Image)
+
+    try {
+      const src = 'https://example.test/populated-cache.png'
+      const firstPreview = createImage(1024, 1024)
+      const secondPreview = createImage(1024, 1024)
+      const firstItem = createItem({
+        id: 'image-populated-cache',
+        src,
+        width: 4096,
+        height: 4096,
+        sourceWidth: 4096,
+        sourceHeight: 4096,
+        image: firstPreview
+      })
+      const { rerender } = render(
+        <ProjectCanvasWebGLImageLayer
+          items={[firstItem]}
+          {...TEST_STAGE_VIEWPORT_1280_720}
+          stageScale={2}
+        />
+      )
+
+      await waitFor(() => expect(attemptedSrcs.filter(Boolean)).toEqual([src]))
+      act(() => imageInstances[0].onload?.())
+      await waitFor(() => expect(getLiveSpriteByLabel(firstItem.id)?.texture.width).toBe(4096))
+
+      rerender(
+        <ProjectCanvasWebGLImageLayer
+          items={[{ ...firstItem, image: secondPreview }]}
+          {...TEST_STAGE_VIEWPORT_1280_720}
+          stageScale={2}
+        />
+      )
+
+      await waitFor(() => expect(attemptedSrcs.filter(Boolean)).toEqual([src, src]))
+      act(() => imageInstances[1].onload?.())
+      await waitFor(() => {
+        const liveTexture = getLiveSpriteByLabel(firstItem.id)?.texture
+        expect(liveTexture?.width).toBe(4096)
+        expect((liveTexture?.source as { image?: unknown }).image).toBe(imageInstances[1])
+      })
     } finally {
       vi.unstubAllGlobals()
     }
@@ -2942,11 +3112,12 @@ describe('ProjectCanvasWebGLImageLayer', () => {
       )
 
       await waitFor(() => {
-        expect(attemptedSrcs).toEqual([
+        expect(attemptedSrcs.filter(Boolean)).toEqual([
           'local-media:///thumb-lod/1024.webp',
           'local-media:///thumb-lod-second/1024.webp'
         ])
         expect(imageInstances).toHaveLength(2)
+        expect(imageInstances[0].src).toBe('')
       })
 
       act(() => {
@@ -2960,6 +3131,131 @@ describe('ProjectCanvasWebGLImageLayer', () => {
       vi.unstubAllGlobals()
     }
   }, 30000)
+
+  it('restarts a thumbnail load when the source revision changes but the level URL stays the same', async () => {
+    const { default: ProjectCanvasWebGLImageLayer } = await import('./ProjectCanvasWebGLImageLayer')
+    const attemptedSrcs: string[] = []
+    const imageInstances: MockImageInstance[] = []
+    const MockImage = createMockImageClass({
+      width: 1024,
+      height: 512,
+      attemptedSrcs,
+      imageInstances
+    })
+    vi.stubGlobal('Image', MockImage as unknown as typeof Image)
+
+    try {
+      const firstFixture = createThumbnailSetFixture('canvas-thumbnail-same-url-first')
+      const secondFixture = createThumbnailSetFixture('canvas-thumbnail-same-url-second')
+      const firstItem = createItem({
+        id: 'image-thumbnail-same-url',
+        src: 'file:///image-thumbnail-same-url.png',
+        image: createImage(192, 96),
+        width: 3200,
+        height: 1600,
+        sourceWidth: 4096,
+        sourceHeight: 2048,
+        sourceIdentity: firstFixture.sourceIdentity,
+        thumbnailSet: firstFixture.thumbnailSet
+      })
+      const secondThumbnailSet: CanvasImageThumbnailSet = {
+        ...firstFixture.thumbnailSet,
+        cacheKey: secondFixture.sourceIdentity.cacheKey,
+        sourceIdentity: secondFixture.sourceIdentity,
+        updatedAt: '2026-05-03T00:00:00.000Z'
+      }
+      const secondItem = createItem({
+        ...firstItem,
+        sourceIdentity: secondFixture.sourceIdentity,
+        thumbnailSet: secondThumbnailSet
+      })
+      const thumbnailSrc = 'local-media:///thumb-lod/1024.webp'
+
+      const { rerender } = render(
+        <ProjectCanvasWebGLImageLayer
+          items={[firstItem]}
+          {...TEST_STAGE_VIEWPORT_1280_720}
+          stageScale={0.15}
+        />
+      )
+
+      await waitFor(() => {
+        expect(attemptedSrcs.filter(Boolean)).toEqual([thumbnailSrc])
+        expect(imageInstances).toHaveLength(1)
+      })
+
+      rerender(
+        <ProjectCanvasWebGLImageLayer
+          items={[secondItem]}
+          {...TEST_STAGE_VIEWPORT_1280_720}
+          stageScale={0.15}
+        />
+      )
+
+      await waitFor(() => {
+        expect(attemptedSrcs.filter(Boolean)).toEqual([thumbnailSrc, thumbnailSrc])
+        expect(imageInstances).toHaveLength(2)
+        expect(imageInstances[0].src).toBe('')
+      })
+
+      act(() => imageInstances[1].onload?.())
+      await waitFor(() => {
+        const liveTexture = getLiveSpriteByLabel(secondItem.id)?.texture
+        expect(liveTexture?.width).toBe(1024)
+        expect((liveTexture?.source as { image?: unknown }).image).toBe(imageInstances[1])
+      })
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  }, 30000)
+
+  it('aborts an active thumbnail load when its item is removed', async () => {
+    const { default: ProjectCanvasWebGLImageLayer } = await import('./ProjectCanvasWebGLImageLayer')
+    const attemptedSrcs: string[] = []
+    const imageInstances: MockImageInstance[] = []
+    const MockImage = createMockImageClass({
+      width: 1024,
+      height: 512,
+      attemptedSrcs,
+      imageInstances
+    })
+    vi.stubGlobal('Image', MockImage as unknown as typeof Image)
+
+    try {
+      const fixture = createThumbnailSetFixture('canvas-thumbnail-abort')
+      const item = createItem({
+        id: 'image-thumbnail-abort',
+        image: createImage(192, 96),
+        width: 3200,
+        height: 1600,
+        sourceWidth: 4096,
+        sourceHeight: 2048,
+        sourceIdentity: fixture.sourceIdentity,
+        thumbnailSet: fixture.thumbnailSet
+      })
+      const { rerender } = render(
+        <ProjectCanvasWebGLImageLayer
+          items={[item]}
+          {...TEST_STAGE_VIEWPORT_1280_720}
+          stageScale={0.15}
+        />
+      )
+
+      await waitFor(() => expect(imageInstances).toHaveLength(1))
+      rerender(
+        <ProjectCanvasWebGLImageLayer
+          items={[]}
+          {...TEST_STAGE_VIEWPORT_1280_720}
+          stageScale={0.15}
+        />
+      )
+
+      await waitFor(() => expect(imageInstances[0].src).toBe(''))
+      expect(attemptedSrcs.filter(Boolean)).toEqual(['local-media:///thumb-lod/1024.webp'])
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
 
   it('upgrades large-batch preview sprites through thumbnail LOD without loading source textures', async () => {
     const { default: ProjectCanvasWebGLImageLayer } = await import('./ProjectCanvasWebGLImageLayer')
@@ -3553,6 +3849,12 @@ describe('ProjectCanvasWebGLImageLayer', () => {
       attemptedSrcs
     })
 
+    const originalElectronFile = window.electronFile
+    const resolveAuthorizedLocalMediaPath = vi.fn(async (filePath: string) => filePath)
+    Object.defineProperty(window, 'electronFile', {
+      configurable: true,
+      value: { resolveAuthorizedLocalMediaPath }
+    })
     vi.stubGlobal('Image', MockImage as unknown as typeof Image)
     vi.stubGlobal('fetch', fetchMock)
     vi.stubGlobal('createImageBitmap', createImageBitmapMock)
@@ -3578,7 +3880,10 @@ describe('ProjectCanvasWebGLImageLayer', () => {
 
       await waitFor(
         () => {
-          expect(fetchMock).toHaveBeenCalledWith('local-media:///C:/real-board/huge.png')
+          expect(fetchMock).toHaveBeenCalledWith(
+            'local-media:///C:/real-board/huge.png',
+            expect.objectContaining({ signal: expect.any(AbortSignal) })
+          )
           expect(createImageBitmapMock).toHaveBeenCalledWith(expect.any(Blob), {
             resizeWidth: 4096,
             resizeHeight: 2509,
@@ -3593,21 +3898,18 @@ describe('ProjectCanvasWebGLImageLayer', () => {
       expect(attemptedSrcs).toEqual([])
     } finally {
       vi.unstubAllGlobals()
+      Object.defineProperty(window, 'electronFile', {
+        configurable: true,
+        value: originalElectronFile
+      })
     }
   }, 30000)
 
-  it('loads source-only local-media images through svcFs object URLs', async () => {
+  it('loads source-only local-media images through authorized protocol URLs', async () => {
     const { default: ProjectCanvasWebGLImageLayer } = await import('./ProjectCanvasWebGLImageLayer')
-    const originalApi = window.api
-    const originalCreateObjectURL = URL.createObjectURL
-    const originalRevokeObjectURL = URL.revokeObjectURL
+    const originalElectronFile = window.electronFile
     const attemptedSrcs: string[] = []
-    const readImageFromPath = vi.fn(async () => ({
-      image: new Uint8Array([1, 2, 3, 4]),
-      filename: 'source-only.png'
-    }))
-    const createObjectURLMock = vi.fn((_blob: Blob) => 'blob:webgl-local-image')
-    const revokeObjectURLMock = vi.fn()
+    const resolveAuthorizedLocalMediaPath = vi.fn(async (filePath: string) => filePath)
 
     const MockImage = createMockImageClass({
       width: 640,
@@ -3618,16 +3920,9 @@ describe('ProjectCanvasWebGLImageLayer', () => {
       }
     })
 
-    URL.createObjectURL = createObjectURLMock as unknown as typeof URL.createObjectURL
-    URL.revokeObjectURL = revokeObjectURLMock as unknown as typeof URL.revokeObjectURL
-    Object.defineProperty(window, 'api', {
+    Object.defineProperty(window, 'electronFile', {
       configurable: true,
-      writable: true,
-      value: {
-        svcFs: {
-          readImageFromPath
-        }
-      }
+      value: { resolveAuthorizedLocalMediaPath }
     })
     vi.stubGlobal('Image', MockImage as unknown as typeof Image)
 
@@ -3648,39 +3943,34 @@ describe('ProjectCanvasWebGLImageLayer', () => {
 
       await waitFor(
         () => {
-          expect(readImageFromPath).toHaveBeenCalledWith({
-            fullPath: 'C:/real-board/source-only.png'
-          })
-          expect(attemptedSrcs).toEqual(['blob:webgl-local-image'])
-          expect(revokeObjectURLMock).toHaveBeenCalledWith('blob:webgl-local-image')
+          expect(resolveAuthorizedLocalMediaPath).toHaveBeenCalledWith(
+            'C:/real-board/source-only.png'
+          )
+          expect(attemptedSrcs).toEqual(['local-media:///C:/real-board/source-only.png'])
           expect(getLiveSpriteByLabel('image-local-source-only')?.texture.width).toBe(640)
         },
         { timeout: 15000 }
       )
     } finally {
       vi.unstubAllGlobals()
-      URL.createObjectURL = originalCreateObjectURL
-      URL.revokeObjectURL = originalRevokeObjectURL
-      Object.defineProperty(window, 'api', {
+      Object.defineProperty(window, 'electronFile', {
         configurable: true,
-        writable: true,
-        value: originalApi
+        value: originalElectronFile
       })
     }
   }, 30000)
 
-  it('releases pending local-media object URLs when the WebGL layer unmounts before image load settles', async () => {
+  it('ignores a local-media authorization result that arrives after unmount', async () => {
     const { default: ProjectCanvasWebGLImageLayer } = await import('./ProjectCanvasWebGLImageLayer')
-    const originalApi = window.api
-    const originalCreateObjectURL = URL.createObjectURL
-    const originalRevokeObjectURL = URL.revokeObjectURL
+    const originalElectronFile = window.electronFile
     const attemptedSrcs: string[] = []
-    const readImageFromPath = vi.fn(async () => ({
-      image: new Uint8Array([1, 2, 3, 4]),
-      filename: 'pending-source.png'
-    }))
-    const createObjectURLMock = vi.fn((_blob: Blob) => 'blob:webgl-pending-local-image')
-    const revokeObjectURLMock = vi.fn()
+    let resolveAuthorization: ((filePath: string) => void) | null = null
+    const resolveAuthorizedLocalMediaPath = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveAuthorization = resolve
+        })
+    )
 
     const MockImage = createMockImageClass({
       width: 640,
@@ -3688,16 +3978,9 @@ describe('ProjectCanvasWebGLImageLayer', () => {
       attemptedSrcs
     })
 
-    URL.createObjectURL = createObjectURLMock as unknown as typeof URL.createObjectURL
-    URL.revokeObjectURL = revokeObjectURLMock as unknown as typeof URL.revokeObjectURL
-    Object.defineProperty(window, 'api', {
+    Object.defineProperty(window, 'electronFile', {
       configurable: true,
-      writable: true,
-      value: {
-        svcFs: {
-          readImageFromPath
-        }
-      }
+      value: { resolveAuthorizedLocalMediaPath }
     })
     vi.stubGlobal('Image', MockImage as unknown as typeof Image)
 
@@ -3716,29 +3999,24 @@ describe('ProjectCanvasWebGLImageLayer', () => {
         />
       )
 
-      await waitFor(
-        () => {
-          expect(readImageFromPath).toHaveBeenCalledWith({
-            fullPath: 'C:/real-board/pending-source.png'
-          })
-          expect(attemptedSrcs).toEqual(['blob:webgl-pending-local-image'])
-        },
-        { timeout: 15000 }
-      )
-
-      expect(revokeObjectURLMock).not.toHaveBeenCalled()
+      await waitFor(() => {
+        expect(resolveAuthorizedLocalMediaPath).toHaveBeenCalledWith(
+          'C:/real-board/pending-source.png'
+        )
+      })
       unmount()
 
-      expect(revokeObjectURLMock).toHaveBeenCalledWith('blob:webgl-pending-local-image')
-      expect(revokeObjectURLMock).toHaveBeenCalledTimes(1)
+      await act(async () => {
+        resolveAuthorization?.('C:/real-board/pending-source.png')
+        await Promise.resolve()
+      })
+
+      expect(attemptedSrcs).toEqual([])
     } finally {
       vi.unstubAllGlobals()
-      URL.createObjectURL = originalCreateObjectURL
-      URL.revokeObjectURL = originalRevokeObjectURL
-      Object.defineProperty(window, 'api', {
+      Object.defineProperty(window, 'electronFile', {
         configurable: true,
-        writable: true,
-        value: originalApi
+        value: originalElectronFile
       })
     }
   }, 30000)
@@ -3761,6 +4039,12 @@ describe('ProjectCanvasWebGLImageLayer', () => {
       imageInstances
     })
 
+    const originalElectronFile = window.electronFile
+    const resolveAuthorizedLocalMediaPath = vi.fn(async (filePath: string) => filePath)
+    Object.defineProperty(window, 'electronFile', {
+      configurable: true,
+      value: { resolveAuthorizedLocalMediaPath }
+    })
     vi.stubGlobal('Image', MockImage as unknown as typeof Image)
     vi.stubGlobal('fetch', fetchMock)
     vi.stubGlobal('createImageBitmap', createImageBitmapMock)
@@ -3786,7 +4070,10 @@ describe('ProjectCanvasWebGLImageLayer', () => {
 
       await waitFor(
         () => {
-          expect(fetchMock).toHaveBeenCalledWith('local-media:///C:/real-board/huge-fallback.png')
+          expect(fetchMock).toHaveBeenCalledWith(
+            'local-media:///C:/real-board/huge-fallback.png',
+            expect.objectContaining({ signal: expect.any(AbortSignal) })
+          )
           expect(attemptedSrcs).toEqual(['local-media:///C:/real-board/huge-fallback.png'])
         },
         { timeout: 15000 }
@@ -3810,6 +4097,10 @@ describe('ProjectCanvasWebGLImageLayer', () => {
       )
     } finally {
       vi.unstubAllGlobals()
+      Object.defineProperty(window, 'electronFile', {
+        configurable: true,
+        value: originalElectronFile
+      })
     }
   }, 30000)
 
@@ -3826,6 +4117,12 @@ describe('ProjectCanvasWebGLImageLayer', () => {
       attemptedSrcs
     })
 
+    const originalElectronFile = window.electronFile
+    const resolveAuthorizedLocalMediaPath = vi.fn(async (filePath: string) => filePath)
+    Object.defineProperty(window, 'electronFile', {
+      configurable: true,
+      value: { resolveAuthorizedLocalMediaPath }
+    })
     vi.stubGlobal('Image', MockImage as unknown as typeof Image)
     vi.stubGlobal('fetch', fetchMock)
     vi.stubGlobal(
@@ -3854,7 +4151,10 @@ describe('ProjectCanvasWebGLImageLayer', () => {
 
       await waitFor(
         () => {
-          expect(fetchMock).toHaveBeenCalledWith('local-media:///C:/real-board/ultra-jumbo.png')
+          expect(fetchMock).toHaveBeenCalledWith(
+            'local-media:///C:/real-board/ultra-jumbo.png',
+            expect.objectContaining({ signal: expect.any(AbortSignal) })
+          )
           expect(getLiveSpriteByLabel('image-ultra-jumbo-fetch-fail')?.texture.width).toBe(512)
         },
         { timeout: 15000 }
@@ -3868,6 +4168,10 @@ describe('ProjectCanvasWebGLImageLayer', () => {
       expect(getLiveSpriteByLabel('image-ultra-jumbo-fetch-fail')?.texture.width).toBe(512)
     } finally {
       vi.unstubAllGlobals()
+      Object.defineProperty(window, 'electronFile', {
+        configurable: true,
+        value: originalElectronFile
+      })
     }
   }, 30000)
 

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasWebGLImageLayer.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasWebGLImageLayer.tsx
@@ -50,7 +50,6 @@ import {
   insertProjectCanvasWebGLPriorityQueueEntry,
   refreshProjectCanvasWebGLPriorityQueuePriorities,
   reprioritizeProjectCanvasWebGLPriorityQueueEntry,
-  createProjectCanvasWebGLResidentTextureByteTracker,
   buildProjectCanvasWebGLItemReconcileSnapshot,
   areProjectCanvasWebGLItemReconcileSnapshotsEqual,
   createProjectCanvasWebGLSpatialTileStateMachine,
@@ -60,10 +59,23 @@ import {
 } from './projectCanvasWebGLImageLayerRuntime'
 import {
   canReadCanvasLocalImageSource,
-  createCanvasLocalImageObjectUrl,
   readCanvasLocalImageBlobFromSource
 } from '../canvasLocalImageSource'
+import { resolveAuthorizedCanvasLocalMediaSourceUrl } from '../canvasLocalFileSource'
 import { CanvasSpatialTileResourceManager } from '../canvasSpatialTileResourceManager'
+import {
+  CanvasImageAsyncSharedResourcePool,
+  CanvasImageRequestTokenTracker,
+  CanvasImageSharedResourceByteTracker,
+  CanvasImageSharedReservationTracker,
+  CanvasImageSharedResourcePool,
+  type CanvasImageSharedResourceLease,
+  getCanvasImageSharedDecodedAssetKey,
+  getCanvasImageSourceRevisionKey,
+  getCanvasImageStableSourceKey,
+  hasCanvasImageStrongSourceIdentity,
+  type CanvasImageRequestToken
+} from '../canvasImageResourceLifecycle'
 import { CanvasSpatialTileScheduler } from '../canvasSpatialTileScheduler'
 import { createCanvasSpatialTileWorkerClient } from '../canvasSpatialTileWorkerClient'
 import { buildCanvasSpatialTilePolicy } from '../canvasSpatialTilePolicy'
@@ -90,9 +102,38 @@ type ProjectCanvasWebGLImageLayerProps = {
 type CachedImageRecord = {
   image: CanvasImageAsset
   src: string
+  sourceRevisionKey: string
+  providedImageIdentityKey: number | string
   imageBitmapOwnership: 'owned' | 'borrowed'
-  imageBitmapReleaseId?: string
-  objectUrlReleaseId?: string
+  decodedAssetReleaseId?: string
+}
+
+function isCachedImageRecordCurrent(
+  record: CachedImageRecord | null | undefined,
+  source: CanvasImageItem,
+  providedImageIdentityKey: number | string
+): record is CachedImageRecord {
+  return Boolean(
+    record &&
+    record.sourceRevisionKey === getCanvasImageSourceRevisionKey(source) &&
+    (hasCanvasImageStrongSourceIdentity(source) ||
+      record.providedImageIdentityKey === providedImageIdentityKey)
+  )
+}
+
+function getCanvasImageSharedTextureKey(
+  item: CanvasImageItem,
+  image: CanvasImageAsset,
+  decodedVariantKey: string,
+  decodedIdentityKey: number | string
+): string {
+  const { width, height } = getCanvasImageAssetSize(image)
+  const stableSourceKey = getCanvasImageStableSourceKey(item)
+  const sourceKey = stableSourceKey ?? `unstable:${getCanvasImageSourceRevisionKey(item)}`
+  const decodedIdentitySuffix = hasCanvasImageStrongSourceIdentity(item)
+    ? ''
+    : `|decoded:${decodedIdentityKey}`
+  return `${sourceKey}|decoded-variant:${decodedVariantKey}${decodedIdentitySuffix}|texture:${width}x${height}`
 }
 
 type SpatialTilePresentationAsset = {
@@ -126,9 +167,19 @@ type SpriteRecord = {
   textureByteSize: number
   lastUsedAt: number
   sawTinyPreview: boolean
+  sharedTextureKey: string
 }
 
 type SourceUpgradeQueueEntry = ProjectCanvasWebGLPriorityQueueEntry
+
+type ThumbnailLoadQueueEntry = SourceUpgradeQueueEntry & {
+  sourceRevisionKey: string
+}
+
+type ImageLoadQueueEntry = SourceUpgradeQueueEntry & {
+  sourceRevisionKey: string
+  requestToken: CanvasImageRequestToken
+}
 
 type ResizablePixiApplication = Application & {
   renderer?: {
@@ -316,18 +367,18 @@ function isProjectCanvasCachedSourceImage(
 function withProjectCanvasWebGLTimeout<T>(
   promise: Promise<T>,
   timeoutMs: number,
-  message: string
+  message: string,
+  onTimeout?: () => void
 ): Promise<T> {
   let settled = false
+  let timedOut = false
+  const timeoutError = new Error(message)
 
   return new Promise((resolve, reject) => {
     const timeoutId = window.setTimeout(() => {
-      if (settled) {
-        return
-      }
-
-      settled = true
-      reject(new Error(message))
+      if (settled) return
+      timedOut = true
+      onTimeout?.()
     }, timeoutMs)
 
     promise.then(
@@ -339,16 +390,18 @@ function withProjectCanvasWebGLTimeout<T>(
 
         settled = true
         window.clearTimeout(timeoutId)
+        if (timedOut) {
+          closeCanvasImageAssetIfPossible(value)
+          reject(timeoutError)
+          return
+        }
         resolve(value)
       },
       (error) => {
-        if (settled) {
-          return
-        }
-
+        if (settled) return
         settled = true
         window.clearTimeout(timeoutId)
-        reject(error)
+        reject(timedOut ? timeoutError : error)
       }
     )
   })
@@ -385,14 +438,14 @@ function destroyProjectCanvasTexture(texture: Texture | null | undefined, destro
   texture.destroy(destroySource)
 }
 
-function destroyProjectCanvasSpriteRecord(record: SpriteRecord) {
+function destroyProjectCanvasSpriteRecord(record: SpriteRecord, releaseSourceTexture: () => void) {
   record.sprite.removeFromParent()
   record.sprite.destroy()
 
   if (record.texture !== record.sourceTexture) {
     destroyProjectCanvasTexture(record.texture, false)
   }
-  destroyProjectCanvasTexture(record.sourceTexture ?? record.texture, true)
+  releaseSourceTexture()
 }
 
 function getProjectCanvasTextureScaleMode(): 'linear' {
@@ -411,8 +464,7 @@ function createProjectCanvasTexture(image: CanvasImageAsset): Texture {
 
 function applyProjectCanvasTextureScaleMode(record: SpriteRecord) {
   const textureSource = (record.sourceTexture ?? record.texture).source as
-    | { scaleMode?: 'nearest' | 'linear' }
-    | undefined
+    { scaleMode?: 'nearest' | 'linear' } | undefined
   if (!textureSource) {
     return
   }
@@ -460,8 +512,7 @@ function refreshProjectCanvasTextureAfterTinyPreview(
   }
 
   const textureSource = (record.sourceTexture ?? record.texture).source as
-    | { destroyed?: boolean; unload?: () => void }
-    | undefined
+    { destroyed?: boolean; unload?: () => void } | undefined
   if (textureSource && !textureSource.destroyed && typeof textureSource.unload === 'function') {
     textureSource.unload()
   }
@@ -569,22 +620,23 @@ function shouldForceSelectedSourceTextureUpgrade(
   )
 }
 
-function loadImageElementDirect(
+async function loadImageElementDirect(
   src: string,
-  options: { crossOrigin?: 'anonymous' | null } = {}
+  options: { crossOrigin?: 'anonymous' | null; signal?: AbortSignal } = {}
 ): Promise<HTMLImageElement> {
   return new Promise((resolve, reject) => {
     const image = new Image()
     let settled = false
-    const timeoutId = window.setTimeout(() => {
-      if (settled) {
-        return
-      }
-
-      settled = true
+    const stopBrowserLoad = () => {
       image.onload = null
       image.onerror = null
-      reject(new Error('Timed out loading image element.'))
+      if (image.src) image.src = ''
+    }
+    const timeoutId = window.setTimeout(() => {
+      settle(() => {
+        stopBrowserLoad()
+        reject(new Error('Timed out loading image element.'))
+      })
     }, PROJECT_CANVAS_WEBGL_IMAGE_ELEMENT_LOAD_TIMEOUT_MS)
     const settle = (callback: () => void) => {
       if (settled) {
@@ -595,8 +647,20 @@ function loadImageElementDirect(
       window.clearTimeout(timeoutId)
       image.onload = null
       image.onerror = null
+      options.signal?.removeEventListener('abort', abort)
       callback()
     }
+    const abort = () => {
+      settle(() => {
+        stopBrowserLoad()
+        reject(new DOMException('Image load aborted.', 'AbortError'))
+      })
+    }
+    if (options.signal?.aborted) {
+      abort()
+      return
+    }
+    options.signal?.addEventListener('abort', abort, { once: true })
     if (options.crossOrigin) {
       image.crossOrigin = options.crossOrigin
     }
@@ -607,25 +671,29 @@ function loadImageElementDirect(
   })
 }
 
-function loadImageElement(
+async function loadImageElement(
   src: string,
-  options: { crossOrigin?: 'anonymous' | null } = {}
+  options: {
+    crossOrigin?: 'anonymous' | null
+    isCurrent?: () => boolean
+    signal?: AbortSignal
+  } = {}
 ): Promise<HTMLImageElement> {
   if (!canReadCanvasLocalImageSource(src)) {
     return loadImageElementDirect(src, options)
   }
 
-  return createCanvasLocalImageObjectUrl(src).then(async (localObjectUrl) => {
-    if (!localObjectUrl) {
-      return loadImageElementDirect(src, options)
-    }
-
-    try {
-      return await loadImageElementDirect(localObjectUrl, options)
-    } finally {
-      URL.revokeObjectURL(localObjectUrl)
-    }
-  })
+  const authorizedSource = await resolveAuthorizedCanvasLocalMediaSourceUrl(src)
+  if (options.signal?.aborted) {
+    throw new DOMException('Image load aborted.', 'AbortError')
+  }
+  if (!authorizedSource) {
+    throw new Error('Local image source is not authorized.')
+  }
+  if (options.isCurrent?.() === false) {
+    throw new Error('Image load request is stale.')
+  }
+  return loadImageElementDirect(authorizedSource, options)
 }
 
 function resolveBoundedSourceTextureSize(width: number, height: number) {
@@ -764,11 +832,13 @@ function resolveCanvasImageThumbnailLodLevel(
 async function loadBoundedSourceTextureFromUrl({
   src,
   sourceWidth,
-  sourceHeight
+  sourceHeight,
+  signal
 }: {
   src: string
   sourceWidth: number
   sourceHeight: number
+  signal?: AbortSignal
 }): Promise<CanvasImageAsset | null> {
   if (typeof fetch !== 'function' || typeof createImageBitmap !== 'function') {
     return null
@@ -779,23 +849,39 @@ async function loadBoundedSourceTextureFromUrl({
     return null
   }
 
-  const localBlob = await readCanvasLocalImageBlobFromSource(src)
+  if (signal?.aborted) throw new DOMException('Image decode aborted.', 'AbortError')
+  const isLocalImageSource = /^(?:file:|local-media:)/i.test(src)
+  const localBlob = isLocalImageSource
+    ? await readCanvasLocalImageBlobFromSource(src, undefined, { signal })
+    : null
+  if (signal?.aborted) throw new DOMException('Image decode aborted.', 'AbortError')
+  if (isLocalImageSource && !localBlob) {
+    throw new Error('Local image source is not authorized or could not be read.')
+  }
   let blob = localBlob
   if (!blob) {
-    const response = await fetch(src)
+    const response = await fetch(src, { signal })
+    if (signal?.aborted) throw new DOMException('Image decode aborted.', 'AbortError')
     if (!response.ok && response.status !== 0) {
       throw new Error(`Failed to fetch bounded source texture: ${response.status}`)
     }
 
     blob = await response.blob()
+    if (signal?.aborted) throw new DOMException('Image decode aborted.', 'AbortError')
   }
 
-  return createImageBitmap(blob, {
+  if (signal?.aborted) throw new DOMException('Image decode aborted.', 'AbortError')
+  const bitmap = await createImageBitmap(blob, {
     resizeWidth: targetSize.width,
     resizeHeight: targetSize.height,
     resizeQuality: 'high',
     premultiplyAlpha: PROJECT_CANVAS_IMAGE_BITMAP_PREMULTIPLY_ALPHA
   })
+  if (signal?.aborted) {
+    bitmap.close()
+    return null
+  }
+  return bitmap
 }
 
 async function downscaleSourceTextureForWebGL(image: HTMLImageElement): Promise<CanvasImageAsset> {
@@ -858,13 +944,16 @@ async function downscaleSourceTextureForWebGL(image: HTMLImageElement): Promise<
 
 async function loadBoundedSourceTextureViaImageElement({
   src,
-  useAnonymousCrossOrigin
+  useAnonymousCrossOrigin,
+  signal
 }: {
   src: string
   useAnonymousCrossOrigin: boolean
+  signal?: AbortSignal
 }): Promise<CanvasImageAsset> {
   const image = await loadImageElement(src, {
-    crossOrigin: useAnonymousCrossOrigin ? 'anonymous' : null
+    crossOrigin: useAnonymousCrossOrigin ? 'anonymous' : null,
+    signal
   })
   return downscaleSourceTextureForWebGL(image)
 }
@@ -901,16 +990,22 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
   const skippedSourceUpgradeSrcByIdRef = useRef(new Map<string, string>())
   const pendingLoadsRef = useRef(new Set<string>())
   const pendingLoadSrcByIdRef = useRef(new Map<string, string>())
+  const pendingLoadRequestTokenByIdRef = useRef(new Map<string, CanvasImageRequestToken>())
+  const pendingLoadCancelByTokenRef = useRef(new Map<number, () => void>())
   const pendingThumbnailLoadSrcByIdRef = useRef(new Map<string, string>())
+  const thumbnailLoadRevisionByIdRef = useRef(new Map<string, string>())
   const thumbnailLoadGenerationByIdRef = useRef(new Map<string, number>())
+  const thumbnailLoadAbortByIdRef = useRef(new Map<string, AbortController>())
   const failedThumbnailLoadSrcByIdRef = useRef(new Map<string, string>())
-  const thumbnailLoadQueueRef = useRef<SourceUpgradeQueueEntry[]>([])
+  const failedThumbnailLoadRevisionByIdRef = useRef(new Map<string, string>())
+  const thumbnailLoadQueueRef = useRef<ThumbnailLoadQueueEntry[]>([])
   const activeThumbnailLoadCountRef = useRef(0)
-  const initialLoadQueueRef = useRef<SourceUpgradeQueueEntry[]>([])
+  const initialLoadQueueRef = useRef<ImageLoadQueueEntry[]>([])
   const activeInitialLoadCountRef = useRef(0)
-  const sourceUpgradeQueueRef = useRef<SourceUpgradeQueueEntry[]>([])
+  const sourceUpgradeQueueRef = useRef<ImageLoadQueueEntry[]>([])
   const sourceUpgradeEligibleIdsRef = useRef(new Set<string>())
   const activeSourceUpgradeSrcByIdRef = useRef(new Map<string, string>())
+  const activeSourceUpgradeRequestTokenByIdRef = useRef(new Map<string, CanvasImageRequestToken>())
   const activeSourceUpgradeCountRef = useRef(0)
   const spriteRecordsRef = useRef(new Map<string, SpriteRecord>())
   const itemReconcileSnapshotByIdRef = useRef(
@@ -918,7 +1013,14 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
   )
   const imageIdentityIdsRef = useRef(new WeakMap<object, number>())
   const nextImageIdentityIdRef = useRef(1)
-  const residentTextureByteTrackerRef = useRef(createProjectCanvasWebGLResidentTextureByteTracker())
+  const sharedTexturePoolRef = useRef(new CanvasImageSharedResourcePool<Texture>())
+  const sharedTextureByteTrackerRef = useRef(new CanvasImageSharedResourceByteTracker())
+  const imageLoadRequestTokensRef = useRef(new CanvasImageRequestTokenTracker())
+  const sharedDecodedImagePoolRef = useRef(
+    new CanvasImageAsyncSharedResourcePool<CanvasImageAsset | null>()
+  )
+  const sharedDecodeBudgetReservationsRef = useRef(new CanvasImageSharedReservationTracker())
+  const runtimeGenerationRef = useRef(0)
   const releaseManagerRef = useRef(new CanvasImageReleaseManager())
   const spatialTileWorkerClientRef = useRef(createCanvasSpatialTileWorkerClient())
   const spatialTileSchedulerRef = useRef(
@@ -1114,7 +1216,7 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
   )
 
   const getResidentTextureBytes = useCallback(
-    () => residentTextureByteTrackerRef.current.getTotal(),
+    () => sharedTextureByteTrackerRef.current.getTotal(),
     []
   )
 
@@ -1137,18 +1239,33 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
     []
   )
 
+  const getCanvasImageLoadSource = useCallback(
+    (item: CanvasImageItem) => ({
+      ...item,
+      weakRevisionKey: getCanvasImageAssetIdentityKey(item.image)
+    }),
+    [getCanvasImageAssetIdentityKey]
+  )
+
+  const beginImageLoadToken = useCallback(
+    (item: CanvasImageItem) =>
+      imageLoadRequestTokensRef.current.begin(item.id, getCanvasImageLoadSource(item)),
+    [getCanvasImageLoadSource]
+  )
+  const isCurrentImageLoadToken = useCallback(
+    (token: CanvasImageRequestToken, item: CanvasImageItem) =>
+      imageLoadRequestTokensRef.current.isCurrent(token, getCanvasImageLoadSource(item)),
+    [getCanvasImageLoadSource]
+  )
+
   const releaseCachedImageRecord = useCallback(
     (record: CachedImageRecord | undefined, reason: CanvasImageReleaseReason) => {
       if (!record) {
         return
       }
 
-      if (record.imageBitmapReleaseId) {
-        releaseManagerRef.current.release(record.imageBitmapReleaseId, reason)
-      }
-      if (record.objectUrlReleaseId) {
-        releaseManagerRef.current.release(record.objectUrlReleaseId, reason)
-        resourceBudgetTrackerRef.current.remove(record.objectUrlReleaseId)
+      if (record.decodedAssetReleaseId) {
+        releaseManagerRef.current.release(record.decodedAssetReleaseId, reason)
       }
     },
     []
@@ -1220,7 +1337,10 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
       itemId,
       image,
       src,
+      sourceRevisionKey,
+      providedImageIdentityKey,
       imageBitmapOwnership = 'borrowed',
+      decodedAssetRelease,
       reason = 'replaced'
     }: {
       cache: Map<string, CachedImageRecord>
@@ -1228,35 +1348,53 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
       itemId: string
       image: CanvasImageAsset
       src: string
+      sourceRevisionKey: string
+      providedImageIdentityKey: number | string
       imageBitmapOwnership?: 'owned' | 'borrowed'
+      decodedAssetRelease?: () => void
       reason?: CanvasImageReleaseReason
     }) => {
       const existing = cache.get(itemId)
-      if (existing?.image === image && existing.src === src) {
+      if (
+        existing?.image === image &&
+        existing.src === src &&
+        existing.sourceRevisionKey === sourceRevisionKey &&
+        existing.providedImageIdentityKey === providedImageIdentityKey
+      ) {
+        decodedAssetRelease?.()
         return existing
       }
 
       releaseCachedImageRecord(existing, reason)
-      let imageBitmapReleaseId: string | undefined
-      if (imageBitmapOwnership === 'owned' && isCanvasImageBitmapLike(image)) {
-        imageBitmapReleaseId = getProjectCanvasCachedImageReleaseId(
+      let decodedAssetReleaseId: string | undefined
+      if (
+        decodedAssetRelease ||
+        (imageBitmapOwnership === 'owned' && isCanvasImageBitmapLike(image))
+      ) {
+        decodedAssetReleaseId = getProjectCanvasCachedImageReleaseId(
           cacheKind,
           'imageBitmap',
           itemId,
-          src
+          sourceRevisionKey
         )
-        releaseManagerRef.current.trackImageBitmap(
-          imageBitmapReleaseId,
-          image,
-          imageBitmapOwnership ?? 'borrowed'
-        )
+        if (decodedAssetRelease) {
+          releaseManagerRef.current.trackLease(decodedAssetReleaseId, decodedAssetRelease)
+        } else if (isCanvasImageBitmapLike(image)) {
+          releaseManagerRef.current.trackImageBitmap(
+            decodedAssetReleaseId,
+            image,
+            imageBitmapOwnership
+          )
+        }
       }
 
       const record: CachedImageRecord = {
         image,
         src,
-        imageBitmapOwnership: imageBitmapOwnership ?? 'borrowed',
-        imageBitmapReleaseId
+        sourceRevisionKey,
+        providedImageIdentityKey,
+        imageBitmapOwnership,
+        decodedAssetReleaseId
       }
       cache.set(itemId, record)
       return record
@@ -1264,31 +1402,12 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
     [releaseCachedImageRecord]
   )
 
-  const trackTransientObjectUrl = useCallback((itemId: string, src: string, objectUrl: string) => {
-    const objectUrlReleaseId = getProjectCanvasCachedImageReleaseId(
-      'transient',
-      'objectUrl',
-      itemId,
-      src
-    )
-    releaseManagerRef.current.trackObjectUrl(objectUrlReleaseId, objectUrl)
-    resourceBudgetTrackerRef.current.upsert({
-      id: objectUrlReleaseId,
-      objectUrlCount: 1,
-      evictable: false
-    })
-
-    return (reason: CanvasImageReleaseReason = 'manual') => {
-      releaseManagerRef.current.release(objectUrlReleaseId, reason)
-      resourceBudgetTrackerRef.current.remove(objectUrlReleaseId)
-    }
-  }, [])
-
   const setTextureBudgetReservation = useCallback(
     ({
       itemId,
       image,
       textureByteSize,
+      sharedTextureKey,
       selected,
       priority,
       lastAccessedAt
@@ -1296,6 +1415,7 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
       itemId: string
       image: CanvasImageAsset
       textureByteSize: number
+      sharedTextureKey: string
       selected: boolean
       priority: number
       lastAccessedAt: number
@@ -1303,7 +1423,7 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
       const cachedSource = imageCacheRef.current.get(itemId)
       const isSourceTexture = isProjectCanvasCachedSourceImage(image, cachedSource)
       resourceBudgetTrackerRef.current.upsert({
-        id: `project-canvas-webgl:texture:${itemId}`,
+        id: `project-canvas-webgl:texture:${sharedTextureKey}`,
         sourceTextureBytes: isSourceTexture ? textureByteSize : 0,
         thumbnailTextureBytes: isSourceTexture ? 0 : textureByteSize,
         evictable: true,
@@ -1316,26 +1436,27 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
     []
   )
 
-  const removeTextureBudgetReservation = useCallback((itemId: string) => {
-    resourceBudgetTrackerRef.current.remove(`project-canvas-webgl:texture:${itemId}`)
+  const removeTextureBudgetReservation = useCallback((sharedTextureKey: string) => {
+    resourceBudgetTrackerRef.current.remove(`project-canvas-webgl:texture:${sharedTextureKey}`)
   }, [])
 
   const beginDecodeBudgetReservation = useCallback(
-    (item: CanvasImageItem, mode: 'initial' | 'source-upgrade', decodeByteSize: number) => {
-      const reservationId = `project-canvas-webgl:decode:${mode}:${item.id}:${item.src}`
-      resourceBudgetTrackerRef.current.upsert({
-        id: reservationId,
-        decodedInFlightBytes: Math.min(
-          Math.max(0, decodeByteSize),
-          PROJECT_CANVAS_WEBGL_TEXTURE_UPLOAD_MAX_BYTES
-        ),
-        activeSourceUpgrades: mode === 'source-upgrade' ? 1 : 0,
-        evictable: false
-      })
-
-      return () => {
-        resourceBudgetTrackerRef.current.remove(reservationId)
-      }
+    (sharedDecodedKey: string, mode: 'initial' | 'source-upgrade', decodeByteSize: number) => {
+      const reservationId = `project-canvas-webgl:decode:${sharedDecodedKey}`
+      return sharedDecodeBudgetReservationsRef.current.acquire(
+        sharedDecodedKey,
+        () =>
+          resourceBudgetTrackerRef.current.admit({
+            id: reservationId,
+            decodedInFlightBytes: Math.min(
+              Math.max(0, decodeByteSize),
+              PROJECT_CANVAS_WEBGL_TEXTURE_UPLOAD_MAX_BYTES
+            ),
+            activeSourceUpgrades: mode === 'source-upgrade' ? 1 : 0,
+            evictable: false
+          }).allowed,
+        () => resourceBudgetTrackerRef.current.remove(reservationId)
+      )
     },
     []
   )
@@ -1356,12 +1477,20 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
         const fallbackImage = item.image
         const cachedThumbnail = thumbnailCacheRef.current.get(item.id)
         const hasCurrentThumbnailCache =
-          cachedThumbnail &&
+          isCachedImageRecordCurrent(
+            cachedThumbnail,
+            item,
+            getCanvasImageAssetIdentityKey(item.image)
+          ) &&
           isCanvasThumbnailSetFresh(item.thumbnailSet, item.sourceIdentity) &&
           item.thumbnailSet.levels.some((level) => level.src === cachedThumbnail.src)
         const previewImage = hasCurrentThumbnailCache ? cachedThumbnail.image : fallbackImage
         const cached = imageCacheRef.current.get(item.id)
-        const hasCachedSource = Boolean(cached && cached.src === item.src)
+        const hasCachedSource = isCachedImageRecordCurrent(
+          cached,
+          item,
+          getCanvasImageAssetIdentityKey(item.image)
+        )
         const renderItem = renderItemsRef.current.get(item.id)
         const forceSelectedSourceTexture = shouldForceSelectedSourceTextureUpgrade(
           item.id,
@@ -1410,7 +1539,7 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
             if (shouldUpgradeFallback) {
               sourceUpgradeablePreviewImageCount += 1
             }
-          } else if (cached && cached.src === item.src && renderItem.image === cached.image) {
+          } else if (hasCachedSource && renderItem.image === cached.image) {
             usingSourceImageCount += 1
           } else if (!fallbackImage && hasCachedSource) {
             usingSourceImageCount += 1
@@ -1435,8 +1564,11 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
           }
         }
 
-        const pendingSrc = pendingLoadSrcByIdRef.current.get(item.id)
-        if (!renderItem && !previewImage && !hasCachedSource && pendingSrc !== item.src) {
+        const pendingToken = pendingLoadRequestTokenByIdRef.current.get(item.id)
+        const hasCurrentPendingLoad = Boolean(
+          pendingToken && isCurrentImageLoadToken(pendingToken, item)
+        )
+        if (!renderItem && !previewImage && !hasCachedSource && !hasCurrentPendingLoad) {
           missingImageCount += 1
         }
       }
@@ -1464,7 +1596,7 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
         missingImageCount
       }
     },
-    [getResidentTextureBytes]
+    [getCanvasImageAssetIdentityKey, getResidentTextureBytes, isCurrentImageLoadToken]
   )
 
   const collectResolvedImageIds = useCallback(() => {
@@ -1476,13 +1608,13 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
       }
 
       const cached = imageCacheRef.current.get(item.id)
-      if (cached && cached.src === item.src) {
+      if (isCachedImageRecordCurrent(cached, item, getCanvasImageAssetIdentityKey(item.image))) {
         resolvedIds.add(item.id)
       }
     })
 
     return resolvedIds
-  }, [])
+  }, [getCanvasImageAssetIdentityKey])
 
   const emitItemLoadMetricsSnapshot = useCallback(
     (
@@ -1664,7 +1796,11 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
         }
         sourceUpgradeAllowedAtRef.current = Number.POSITIVE_INFINITY
         thumbnailLoadQueueRef.current = []
-        pendingThumbnailLoadSrcByIdRef.current.clear()
+        pendingThumbnailLoadSrcByIdRef.current.forEach((_src, itemId) => {
+          if (thumbnailLoadAbortByIdRef.current.has(itemId)) return
+          pendingThumbnailLoadSrcByIdRef.current.delete(itemId)
+          thumbnailLoadRevisionByIdRef.current.delete(itemId)
+        })
         clearSourceUpgradeQueue()
         return
       }
@@ -1706,7 +1842,11 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
       }
       sourceUpgradeAllowedAtRef.current = 0
       thumbnailLoadQueueRef.current = []
-      pendingThumbnailLoadSrcByIdRef.current.clear()
+      pendingThumbnailLoadSrcByIdRef.current.forEach((_src, itemId) => {
+        if (thumbnailLoadAbortByIdRef.current.has(itemId)) return
+        pendingThumbnailLoadSrcByIdRef.current.delete(itemId)
+        thumbnailLoadRevisionByIdRef.current.delete(itemId)
+      })
       hasDeferredMetricsReportRef.current = true
       forceViewportReconcile()
       return
@@ -1885,11 +2025,17 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
         return
       }
 
-      destroyProjectCanvasSpriteRecord(record)
+      destroyProjectCanvasSpriteRecord(record, () => {
+        sharedTexturePoolRef.current.release(record.sharedTextureKey, (texture) =>
+          destroyProjectCanvasTexture(texture, true)
+        )
+        const releasedBytes = sharedTextureByteTrackerRef.current.release(record.sharedTextureKey)
+        if (releasedBytes > 0) {
+          removeTextureBudgetReservation(record.sharedTextureKey)
+        }
+      })
       spriteRecordsRef.current.delete(itemId)
       itemReconcileSnapshotByIdRef.current.delete(itemId)
-      residentTextureByteTrackerRef.current.delete(itemId)
-      removeTextureBudgetReservation(itemId)
 
       if (!options?.retainPreview) {
         previewStateRef.current.delete(itemId)
@@ -1932,6 +2078,8 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
     }
 
     let disposed = false
+    runtimeGenerationRef.current += 1
+    const runtimeGeneration = runtimeGenerationRef.current
     const pendingLoads = pendingLoadsRef.current
     const failedLoadSrcById = failedLoadSrcByIdRef.current
     const failedSourceUpgradeSrcById = failedSourceUpgradeSrcByIdRef.current
@@ -1995,19 +2143,29 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
       imageElementLoadTimeoutsRef.current.clear()
 
       hasDeferredImageVersionUpdateRef.current = false
+      initialLoadQueueRef.current = []
+      sourceUpgradeQueueRef.current = []
+      pendingLoadCancelByTokenRef.current.forEach((cancel) => cancel())
+      pendingLoadCancelByTokenRef.current.clear()
       pendingLoads.clear()
       pendingLoadSrcByIdRef.current.clear()
+      pendingLoadRequestTokenByIdRef.current.clear()
+      thumbnailLoadAbortByIdRef.current.forEach((controller) => controller.abort())
+      thumbnailLoadAbortByIdRef.current.clear()
       pendingThumbnailLoadSrcByIdRef.current.clear()
+      thumbnailLoadRevisionByIdRef.current.clear()
       thumbnailLoadGenerationByIdRef.current.clear()
       failedThumbnailLoadSrcByIdRef.current.clear()
+      failedThumbnailLoadRevisionByIdRef.current.clear()
       thumbnailLoadQueueRef.current = []
       activeThumbnailLoadCountRef.current = 0
       initialLoadQueueRef.current = []
       activeInitialLoadCountRef.current = 0
-      sourceUpgradeQueueRef.current = []
       sourceUpgradeEligibleIdsRef.current.clear()
       activeSourceUpgradeSrcByIdRef.current.clear()
+      activeSourceUpgradeRequestTokenByIdRef.current.clear()
       activeSourceUpgradeCountRef.current = 0
+      imageLoadRequestTokensRef.current.clear()
       failedLoadSrcById.clear()
       failedSourceUpgradeSrcById.clear()
       skippedSourceUpgradeSrcByIdRef.current.clear()
@@ -2015,11 +2173,19 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
       clearCachedImageRecords(thumbnailCacheRef.current, 'component-unmount')
       releaseManagerRef.current.releaseAll('component-unmount')
       spriteRecords.forEach((record) => {
-        destroyProjectCanvasSpriteRecord(record)
+        destroyProjectCanvasSpriteRecord(record, () => {
+          sharedTexturePoolRef.current.release(record.sharedTextureKey, (texture) =>
+            destroyProjectCanvasTexture(texture, true)
+          )
+        })
       })
       spriteRecords.clear()
+      sharedTexturePoolRef.current.clear((texture) => destroyProjectCanvasTexture(texture, true))
       itemReconcileSnapshotByIdRef.current.clear()
-      residentTextureByteTrackerRef.current.clear()
+      sharedTextureByteTrackerRef.current.clear()
+      sharedDecodeBudgetReservationsRef.current.clear((sharedDecodedKey) => {
+        resourceBudgetTrackerRef.current.remove(`project-canvas-webgl:decode:${sharedDecodedKey}`)
+      })
       resourceBudgetTrackerRef.current.clear()
       spriteUsageCounterRef.current = 0
       activeItemCountRef.current = 0
@@ -2126,6 +2292,9 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
 
     return () => {
       disposed = true
+      if (runtimeGenerationRef.current === runtimeGeneration) {
+        runtimeGenerationRef.current += 1
+      }
       runtimeFailureHandlerRef.current = null
       cleanupRuntime('cleanup')
     }
@@ -2264,11 +2433,18 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
     let suppressDenseSourceUpgrades = false
     let residentCandidateImageCountForThumbnailLod = 1
 
-    const clearPendingLoad = (itemId: string, src: string) => {
-      if (pendingLoadSrcByIdRef.current.get(itemId) === src) {
-        pendingLoadsRef.current.delete(itemId)
-        pendingLoadSrcByIdRef.current.delete(itemId)
+    const clearPendingLoad = (requestToken: CanvasImageRequestToken) => {
+      pendingLoadCancelByTokenRef.current.delete(requestToken.sequence)
+      if (pendingLoadRequestTokenByIdRef.current.get(requestToken.itemId) === requestToken) {
+        pendingLoadsRef.current.delete(requestToken.itemId)
+        pendingLoadSrcByIdRef.current.delete(requestToken.itemId)
+        pendingLoadRequestTokenByIdRef.current.delete(requestToken.itemId)
       }
+    }
+
+    const cancelPendingLoad = (requestToken: CanvasImageRequestToken) => {
+      pendingLoadCancelByTokenRef.current.get(requestToken.sequence)?.()
+      clearPendingLoad(requestToken)
     }
 
     const isSourceUpgradeIdleBlocked = () =>
@@ -2283,19 +2459,39 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
     const startImageLoad = (
       item: CanvasImageItem,
       mode: 'initial' | 'source-upgrade',
-      priority = 0
+      priority = 0,
+      requestToken?: CanvasImageRequestToken
     ) => {
       if (mode === 'initial') {
         queueInitialImageLoad(item, priority)
         return
       }
 
-      startImageLoadNow(item, mode)
+      const activeRequestToken = requestToken ?? beginImageLoadToken(item)
+      if (!requestToken) {
+        pendingLoadsRef.current.add(item.id)
+        pendingLoadSrcByIdRef.current.set(item.id, item.src)
+        pendingLoadRequestTokenByIdRef.current.set(item.id, activeRequestToken)
+      }
+      return startImageLoadNow(item, mode, activeRequestToken, priority)
     }
 
-    function startImageLoadNow(item: CanvasImageItem, mode: 'initial' | 'source-upgrade') {
+    function startImageLoadNow(
+      item: CanvasImageItem,
+      mode: 'initial' | 'source-upgrade',
+      requestToken: CanvasImageRequestToken,
+      priority: number
+    ) {
       if (!item.src) {
+        clearPendingLoad(requestToken)
         return
+      }
+      const requestRuntimeGeneration = runtimeGenerationRef.current
+      const sourceRevisionKey = requestToken.sourceRevisionKey
+      const isRequestCurrent = () => {
+        if (runtimeGenerationRef.current !== requestRuntimeGeneration) return false
+        const currentItem = currentItemByIdRef.current.get(item.id)
+        return Boolean(currentItem && isCurrentImageLoadToken(requestToken, currentItem))
       }
 
       const finishInitialLoad = () => {
@@ -2305,6 +2501,7 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
 
         activeInitialLoadCountRef.current = Math.max(0, activeInitialLoadCountRef.current - 1)
         pumpInitialImageLoadQueue()
+        pumpSourceUpgradeQueue()
       }
 
       const finishSourceUpgrade = () => {
@@ -2313,17 +2510,21 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
         }
 
         activeSourceUpgradeCountRef.current = Math.max(0, activeSourceUpgradeCountRef.current - 1)
-        if (activeSourceUpgradeSrcByIdRef.current.get(item.id) === item.src) {
+        if (activeSourceUpgradeRequestTokenByIdRef.current.get(item.id) === requestToken) {
           activeSourceUpgradeSrcByIdRef.current.delete(item.id)
+          activeSourceUpgradeRequestTokenByIdRef.current.delete(item.id)
         }
+        pumpInitialImageLoadQueue()
         pumpSourceUpgradeQueue()
       }
 
-      const markUnavailableSource = () => {
+      const markUnavailableSource = (outcome: 'skipped' | 'failed') => {
         const currentItem = currentItemByIdRef.current.get(item.id)
-        if (currentItem && currentItem.src === item.src) {
-          if (mode === 'source-upgrade' && item.image) {
+        if (currentItem && isRequestCurrent()) {
+          if (mode === 'source-upgrade' && outcome === 'skipped') {
             skippedSourceUpgradeSrcByIdRef.current.set(item.id, item.src)
+          } else if (mode === 'source-upgrade') {
+            failedSourceUpgradeSrcByIdRef.current.set(item.id, item.src)
           } else {
             failedLoadSrcByIdRef.current.set(item.id, item.src)
           }
@@ -2337,33 +2538,85 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
         sourceWidth: item.sourceWidth ?? item.width,
         sourceHeight: item.sourceHeight ?? item.height
       })
-      if (!canUploadProjectCanvasTexture(sourceDecodeByteSize)) {
-        if (mode === 'source-upgrade') {
-          activeSourceUpgradeCountRef.current += 1
-          activeSourceUpgradeSrcByIdRef.current.set(item.id, item.src)
+      const requiresBoundedDecode = !canUploadProjectCanvasTexture(sourceDecodeByteSize)
+      if (mode === 'source-upgrade') {
+        activeSourceUpgradeCountRef.current += 1
+        activeSourceUpgradeSrcByIdRef.current.set(item.id, item.src)
+        activeSourceUpgradeRequestTokenByIdRef.current.set(item.id, requestToken)
+      } else {
+        activeInitialLoadCountRef.current += 1
+        pendingLoadsRef.current.add(item.id)
+        pendingLoadSrcByIdRef.current.set(item.id, item.src)
+        pendingLoadRequestTokenByIdRef.current.set(item.id, requestToken)
+      }
+
+      const decodedVariant = requiresBoundedDecode
+        ? `bounded:${item.sourceWidth ?? item.width}x${item.sourceHeight ?? item.height}`
+        : mode === 'source-upgrade'
+          ? 'source-upgrade'
+          : 'source'
+      const sharedDecodedKey =
+        getCanvasImageSharedDecodedAssetKey({
+          source: getCanvasImageLoadSource(item),
+          variant: decodedVariant
+        }) ?? `request:${sourceRevisionKey}:${requestToken.sequence}:${decodedVariant}`
+      const releaseDecodeBudgetReservation = beginDecodeBudgetReservation(
+        sharedDecodedKey,
+        mode,
+        sourceDecodeByteSize
+      )
+      if (!releaseDecodeBudgetReservation) {
+        if (mode === 'initial') {
+          activeInitialLoadCountRef.current = Math.max(0, activeInitialLoadCountRef.current - 1)
+          insertProjectCanvasWebGLPriorityQueueEntry(initialLoadQueueRef.current, {
+            itemId: item.id,
+            src: item.src,
+            priority,
+            sourceRevisionKey,
+            requestToken
+          })
         } else {
-          activeInitialLoadCountRef.current += 1
-          pendingLoadsRef.current.add(item.id)
-          pendingLoadSrcByIdRef.current.set(item.id, item.src)
+          activeSourceUpgradeCountRef.current = Math.max(0, activeSourceUpgradeCountRef.current - 1)
+          activeSourceUpgradeSrcByIdRef.current.delete(item.id)
+          activeSourceUpgradeRequestTokenByIdRef.current.delete(item.id)
+          insertProjectCanvasWebGLPriorityQueueEntry(sourceUpgradeQueueRef.current, {
+            itemId: item.id,
+            src: item.src,
+            priority,
+            sourceRevisionKey,
+            requestToken
+          })
         }
-        const releaseDecodeBudgetReservation = beginDecodeBudgetReservation(
-          item,
+        return false
+      }
+      const loadDecodedAsset = async (signal: AbortSignal): Promise<CanvasImageAsset | null> => {
+        const releaseProducerDecodeBudgetReservation = beginDecodeBudgetReservation(
+          sharedDecodedKey,
           mode,
           sourceDecodeByteSize
         )
-
-        void (async () => {
-          try {
+        if (!releaseProducerDecodeBudgetReservation) {
+          throw new Error('Shared decode producer lost its budget reservation.')
+        }
+        const decodeController = new AbortController()
+        const abortDecode = () => decodeController.abort()
+        if (signal.aborted) abortDecode()
+        signal.addEventListener('abort', abortDecode, { once: true })
+        const decodeSignal = decodeController.signal
+        try {
+          if (requiresBoundedDecode) {
             let resolvedImage: CanvasImageAsset | null = null
             try {
               resolvedImage = await withProjectCanvasWebGLTimeout(
                 loadBoundedSourceTextureFromUrl({
                   src: item.src,
                   sourceWidth: item.sourceWidth ?? item.width,
-                  sourceHeight: item.sourceHeight ?? item.height
+                  sourceHeight: item.sourceHeight ?? item.height,
+                  signal: decodeSignal
                 }),
                 PROJECT_CANVAS_WEBGL_SOURCE_TEXTURE_LOAD_TIMEOUT_MS,
-                'Timed out loading bounded source texture.'
+                'Timed out loading bounded source texture.',
+                abortDecode
               )
             } catch {
               resolvedImage = null
@@ -2375,188 +2628,105 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
               resolvedImage = await withProjectCanvasWebGLTimeout(
                 loadBoundedSourceTextureViaImageElement({
                   src: item.src,
-                  useAnonymousCrossOrigin: shouldUseAnonymousCrossOrigin(item.src)
+                  useAnonymousCrossOrigin: shouldUseAnonymousCrossOrigin(item.src),
+                  signal: decodeSignal
                 }),
                 PROJECT_CANVAS_WEBGL_SOURCE_TEXTURE_LOAD_TIMEOUT_MS,
-                'Timed out loading bounded source texture through an image element.'
+                'Timed out loading bounded source texture through an image element.',
+                abortDecode
               )
             }
-            clearPendingLoad(item.id, item.src)
-            finishInitialLoad()
-            finishSourceUpgrade()
-            releaseDecodeBudgetReservation()
+            return resolvedImage
+          }
 
-            if (!resolvedImage) {
-              markUnavailableSource()
-              return
-            }
-
-            const currentItem = currentItemByIdRef.current.get(item.id)
-            if (currentItem && currentItem.src === item.src) {
-              failedLoadSrcByIdRef.current.delete(item.id)
-              failedSourceUpgradeSrcByIdRef.current.delete(item.id)
-              skippedSourceUpgradeSrcByIdRef.current.delete(item.id)
-              setCachedImageRecord({
-                cache: imageCacheRef.current,
-                cacheKind: 'source',
-                itemId: item.id,
-                image: resolvedImage,
-                src: item.src,
-                imageBitmapOwnership: 'owned'
-              })
-              scheduleImageVersionUpdate()
-            } else {
-              closeCanvasImageAssetIfPossible(resolvedImage)
-              if (currentItem) {
-                scheduleImageVersionUpdate()
-              }
-            }
+          const image = await withProjectCanvasWebGLTimeout(
+            loadImageElement(item.src, {
+              crossOrigin: shouldUseAnonymousCrossOrigin(item.src) ? 'anonymous' : null,
+              signal: decodeSignal
+            }),
+            PROJECT_CANVAS_WEBGL_SOURCE_TEXTURE_LOAD_TIMEOUT_MS,
+            'Timed out loading source texture through an image element.',
+            abortDecode
+          )
+          if (mode !== 'source-upgrade') {
+            return image
+          }
+          try {
+            return await withProjectCanvasWebGLTimeout(
+              downscaleSourceTextureForWebGL(image),
+              PROJECT_CANVAS_WEBGL_SOURCE_TEXTURE_LOAD_TIMEOUT_MS,
+              'Timed out downscaling source texture.',
+              abortDecode
+            )
           } catch {
-            clearPendingLoad(item.id, item.src)
-            finishInitialLoad()
-            finishSourceUpgrade()
-            releaseDecodeBudgetReservation()
-            markUnavailableSource()
+            return image
           }
-        })()
-        return
+        } finally {
+          signal.removeEventListener('abort', abortDecode)
+          releaseProducerDecodeBudgetReservation()
+        }
       }
 
-      if (mode === 'source-upgrade') {
-        activeSourceUpgradeCountRef.current += 1
-        activeSourceUpgradeSrcByIdRef.current.set(item.id, item.src)
-      } else {
-        activeInitialLoadCountRef.current += 1
-        pendingLoadsRef.current.add(item.id)
-        pendingLoadSrcByIdRef.current.set(item.id, item.src)
-      }
-      const releaseDecodeBudgetReservation = beginDecodeBudgetReservation(
-        item,
-        mode,
-        sourceDecodeByteSize
-      )
-
-      const handleImageLoad = (img: HTMLImageElement) => {
-        clearPendingLoad(item.id, item.src)
-        void (async () => {
-          let resolvedImage: CanvasImageAsset = img
-          if (mode === 'source-upgrade') {
-            try {
-              resolvedImage = await withProjectCanvasWebGLTimeout(
-                downscaleSourceTextureForWebGL(img),
-                PROJECT_CANVAS_WEBGL_SOURCE_TEXTURE_LOAD_TIMEOUT_MS,
-                'Timed out downscaling source texture.'
-              )
-            } catch {
-              resolvedImage = img
-            }
-          }
-
-          finishSourceUpgrade()
-          finishInitialLoad()
-          releaseDecodeBudgetReservation()
-
-          const currentItem = currentItemByIdRef.current.get(item.id)
-          if (currentItem && currentItem.src === item.src) {
-            failedLoadSrcByIdRef.current.delete(item.id)
-            failedSourceUpgradeSrcByIdRef.current.delete(item.id)
-            skippedSourceUpgradeSrcByIdRef.current.delete(item.id)
-            setCachedImageRecord({
-              cache: imageCacheRef.current,
-              cacheKind: 'source',
-              itemId: item.id,
-              image: resolvedImage,
-              src: item.src,
-              imageBitmapOwnership: resolvedImage === img ? 'borrowed' : 'owned'
-            })
-            scheduleImageVersionUpdate()
-          } else {
-            closeCanvasImageAssetIfPossible(resolvedImage)
-            if (currentItem) {
-              scheduleImageVersionUpdate()
-            }
-          }
-        })()
-      }
-
-      const handleImageError = () => {
-        clearPendingLoad(item.id, item.src)
+      let finalized = false
+      const finalizeRequest = () => {
+        if (finalized) return
+        finalized = true
+        pendingLoadCancelByTokenRef.current.delete(requestToken.sequence)
+        clearPendingLoad(requestToken)
+        releaseDecodeBudgetReservation()
         finishInitialLoad()
         finishSourceUpgrade()
-        releaseDecodeBudgetReservation()
-
-        const currentItem = currentItemByIdRef.current.get(item.id)
-        if (currentItem && currentItem.src === item.src) {
-          if (mode === 'source-upgrade' && item.image) {
-            failedSourceUpgradeSrcByIdRef.current.set(item.id, item.src)
-          } else {
-            failedLoadSrcByIdRef.current.set(item.id, item.src)
-          }
-          emitItemLoadMetricsSnapshot()
-        } else if (currentItem) {
-          scheduleImageVersionUpdate()
-        }
       }
 
-      const startImageElementLoad = (
-        resolvedSrc: string,
-        releaseResolvedObjectUrl?: (reason?: CanvasImageReleaseReason) => void
-      ) => {
-        const img = new Image()
-        let settled = false
-        const timeoutId = window.setTimeout(() => {
-          if (settled) {
-            return
-          }
+      const handleDecodedLease = ({
+        resource: resolvedImage,
+        release
+      }: CanvasImageSharedResourceLease<CanvasImageAsset | null>) => {
+        finalizeRequest()
 
-          settled = true
-          imageElementLoadTimeoutsRef.current.delete(timeoutId)
-          img.onload = null
-          img.onerror = null
-          releaseResolvedObjectUrl?.('error-cleanup')
-          handleImageError()
-        }, PROJECT_CANVAS_WEBGL_IMAGE_ELEMENT_LOAD_TIMEOUT_MS)
-        imageElementLoadTimeoutsRef.current.add(timeoutId)
-        const settleImageElementLoad = (callback: () => void) => {
-          if (settled) {
-            return
-          }
-
-          settled = true
-          window.clearTimeout(timeoutId)
-          imageElementLoadTimeoutsRef.current.delete(timeoutId)
-          img.onload = null
-          img.onerror = null
-          releaseResolvedObjectUrl?.('manual')
-          callback()
+        if (!resolvedImage) {
+          release()
+          markUnavailableSource('skipped')
+          return
         }
-        if (shouldUseAnonymousCrossOrigin(item.src)) {
-          img.crossOrigin = 'anonymous'
+        if (!isRequestCurrent()) {
+          release()
+          return
         }
-        img.onload = () => settleImageElementLoad(() => handleImageLoad(img))
-        img.onerror = () => settleImageElementLoad(handleImageError)
-        img.src = resolvedSrc
-      }
 
-      if (canReadCanvasLocalImageSource(item.src)) {
-        void createCanvasLocalImageObjectUrl(item.src)
-          .then((localObjectUrl) => {
-            if (!localObjectUrl) {
-              startImageElementLoad(item.src)
-              return
-            }
-
-            startImageElementLoad(
-              localObjectUrl,
-              trackTransientObjectUrl(item.id, item.src, localObjectUrl)
-            )
-          })
-          .catch(() => {
-            startImageElementLoad(item.src)
-          })
-      } else {
-        startImageElementLoad(item.src)
+        failedLoadSrcByIdRef.current.delete(item.id)
+        failedSourceUpgradeSrcByIdRef.current.delete(item.id)
+        skippedSourceUpgradeSrcByIdRef.current.delete(item.id)
+        setCachedImageRecord({
+          cache: imageCacheRef.current,
+          cacheKind: 'source',
+          itemId: item.id,
+          image: resolvedImage,
+          src: item.src,
+          sourceRevisionKey: getCanvasImageSourceRevisionKey(item),
+          providedImageIdentityKey: getCanvasImageAssetIdentityKey(item.image),
+          imageBitmapOwnership: 'borrowed',
+          decodedAssetRelease: release
+        })
+        scheduleImageVersionUpdate()
       }
+      const cancelSharedDecodeLease = sharedDecodedImagePoolRef.current.acquireWithCallback(
+        sharedDecodedKey,
+        loadDecodedAsset,
+        closeCanvasImageAssetIfPossible,
+        handleDecodedLease,
+        () => {
+          finalizeRequest()
+          markUnavailableSource('failed')
+        }
+      )
+      if (!finalized) {
+        pendingLoadCancelByTokenRef.current.set(requestToken.sequence, () => {
+          cancelSharedDecodeLease()
+          finalizeRequest()
+        })
+      }
+      return true
     }
 
     function pumpInitialImageLoadQueue() {
@@ -2575,14 +2745,16 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
         const currentItem = currentItemByIdRef.current.get(queued.itemId)
         if (
           !currentItem ||
-          currentItem.src !== queued.src ||
-          pendingLoadSrcByIdRef.current.get(queued.itemId) !== queued.src
+          pendingLoadRequestTokenByIdRef.current.get(queued.itemId) !== queued.requestToken ||
+          !isCurrentImageLoadToken(queued.requestToken, currentItem)
         ) {
-          clearPendingLoad(queued.itemId, queued.src)
+          cancelPendingLoad(queued.requestToken)
           continue
         }
 
-        startImageLoadNow(currentItem, 'initial')
+        if (!startImageLoadNow(currentItem, 'initial', queued.requestToken, queued.priority)) {
+          return
+        }
       }
     }
 
@@ -2591,8 +2763,8 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
         return
       }
 
-      const pendingSrc = pendingLoadSrcByIdRef.current.get(item.id)
-      if (pendingSrc === item.src) {
+      const pendingToken = pendingLoadRequestTokenByIdRef.current.get(item.id)
+      if (pendingToken && isCurrentImageLoadToken(pendingToken, item)) {
         reprioritizeProjectCanvasWebGLPriorityQueueEntry(
           initialLoadQueueRef.current,
           item.id,
@@ -2602,12 +2774,19 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
         return
       }
 
+      const requestToken = beginImageLoadToken(item)
+      initialLoadQueueRef.current = initialLoadQueueRef.current.filter(
+        (entry) => entry.itemId !== item.id
+      )
       pendingLoadsRef.current.add(item.id)
       pendingLoadSrcByIdRef.current.set(item.id, item.src)
+      pendingLoadRequestTokenByIdRef.current.set(item.id, requestToken)
       insertProjectCanvasWebGLPriorityQueueEntry(initialLoadQueueRef.current, {
         itemId: item.id,
         src: item.src,
-        priority
+        priority,
+        sourceRevisionKey: requestToken.sourceRevisionKey,
+        requestToken
       })
       pumpInitialImageLoadQueue()
     }
@@ -2626,7 +2805,9 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
           return
         }
 
-        if (activeSourceUpgradeSrcByIdRef.current.get(queued.itemId) === queued.src) {
+        if (
+          activeSourceUpgradeRequestTokenByIdRef.current.get(queued.itemId) === queued.requestToken
+        ) {
           continue
         }
 
@@ -2652,8 +2833,8 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
           : currentItem?.image
         if (
           !currentItem ||
-          currentItem.src !== queued.src ||
-          pendingLoadSrcByIdRef.current.get(queued.itemId) !== queued.src ||
+          pendingLoadRequestTokenByIdRef.current.get(queued.itemId) !== queued.requestToken ||
+          !isCurrentImageLoadToken(queued.requestToken, currentItem) ||
           !sourceUpgradeEligibleIdsRef.current.has(queued.itemId) ||
           !upgradePreviewImage ||
           shouldSuppressSourceUpgradeForItem(currentItem, forceSelectedSourceTexture) ||
@@ -2667,32 +2848,50 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
             residentTextureBudgetBytes: PROJECT_CANVAS_WEBGL_TEXTURE_BUDGET_BYTES
           })
         ) {
-          clearPendingLoad(queued.itemId, queued.src)
+          cancelPendingLoad(queued.requestToken)
           continue
         }
 
-        startImageLoad(currentItem, 'source-upgrade')
+        if (!startImageLoad(currentItem, 'source-upgrade', queued.priority, queued.requestToken)) {
+          return
+        }
       }
     }
 
     const queueSourceUpgrade = (item: CanvasImageItem, priority: number) => {
-      if (!item.src || pendingLoadSrcByIdRef.current.get(item.id) === item.src) {
+      if (!item.src) {
+        return
+      }
+      const pendingToken = pendingLoadRequestTokenByIdRef.current.get(item.id)
+      if (pendingToken && isCurrentImageLoadToken(pendingToken, item)) {
         return
       }
 
+      const requestToken = beginImageLoadToken(item)
+      sourceUpgradeQueueRef.current = sourceUpgradeQueueRef.current.filter(
+        (entry) => entry.itemId !== item.id
+      )
       pendingLoadsRef.current.add(item.id)
       pendingLoadSrcByIdRef.current.set(item.id, item.src)
+      pendingLoadRequestTokenByIdRef.current.set(item.id, requestToken)
       insertProjectCanvasWebGLPriorityQueueEntry(sourceUpgradeQueueRef.current, {
         itemId: item.id,
         src: item.src,
-        priority
+        priority,
+        sourceRevisionKey: requestToken.sourceRevisionKey,
+        requestToken
       })
       pumpSourceUpgradeQueue()
     }
 
-    const clearPendingThumbnailLoad = (itemId: string, src: string) => {
-      if (pendingThumbnailLoadSrcByIdRef.current.get(itemId) === src) {
+    const clearPendingThumbnailLoad = (itemId: string, src: string, sourceRevisionKey?: string) => {
+      if (
+        pendingThumbnailLoadSrcByIdRef.current.get(itemId) === src &&
+        (sourceRevisionKey === undefined ||
+          thumbnailLoadRevisionByIdRef.current.get(itemId) === sourceRevisionKey)
+      ) {
         pendingThumbnailLoadSrcByIdRef.current.delete(itemId)
+        thumbnailLoadRevisionByIdRef.current.delete(itemId)
       }
     }
 
@@ -2713,51 +2912,72 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
         const currentItem = currentItemByIdRef.current.get(queued.itemId)
         if (
           !currentItem ||
-          pendingThumbnailLoadSrcByIdRef.current.get(queued.itemId) !== queued.src
+          getCanvasImageSourceRevisionKey(currentItem) !== queued.sourceRevisionKey ||
+          pendingThumbnailLoadSrcByIdRef.current.get(queued.itemId) !== queued.src ||
+          thumbnailLoadRevisionByIdRef.current.get(queued.itemId) !== queued.sourceRevisionKey
         ) {
-          clearPendingThumbnailLoad(queued.itemId, queued.src)
+          clearPendingThumbnailLoad(queued.itemId, queued.src, queued.sourceRevisionKey)
           continue
         }
 
         activeThumbnailLoadCountRef.current += 1
         const requestGeneration = thumbnailLoadGenerationByIdRef.current.get(queued.itemId) ?? 0
+        const requestRevisionKey = queued.sourceRevisionKey
+        const abortController = new AbortController()
+        thumbnailLoadAbortByIdRef.current.get(queued.itemId)?.abort()
+        thumbnailLoadAbortByIdRef.current.set(queued.itemId, abortController)
         void loadImageElement(queued.src, {
-          crossOrigin: shouldUseAnonymousCrossOrigin(queued.src) ? 'anonymous' : null
+          crossOrigin: shouldUseAnonymousCrossOrigin(queued.src) ? 'anonymous' : null,
+          signal: abortController.signal
         })
           .then((image) => {
             if (thumbnailLoadGenerationByIdRef.current.get(queued.itemId) !== requestGeneration) {
               closeCanvasImageAssetIfPossible(image)
               return
             }
-            clearPendingThumbnailLoad(queued.itemId, queued.src)
+            clearPendingThumbnailLoad(queued.itemId, queued.src, requestRevisionKey)
             const nextItem = currentItemByIdRef.current.get(queued.itemId)
-            if (!nextItem?.thumbnailSet?.levels.some((level) => level.src === queued.src)) {
+            if (
+              !nextItem?.thumbnailSet?.levels.some((level) => level.src === queued.src) ||
+              getCanvasImageSourceRevisionKey(nextItem) !== requestRevisionKey
+            ) {
               closeCanvasImageAssetIfPossible(image)
               return
             }
             failedThumbnailLoadSrcByIdRef.current.delete(queued.itemId)
+            failedThumbnailLoadRevisionByIdRef.current.delete(queued.itemId)
             setCachedImageRecord({
               cache: thumbnailCacheRef.current,
               cacheKind: 'thumbnail',
               itemId: queued.itemId,
               image,
               src: queued.src,
+              sourceRevisionKey: requestRevisionKey,
+              providedImageIdentityKey: getCanvasImageAssetIdentityKey(nextItem.image),
               imageBitmapOwnership: 'borrowed'
             })
             scheduleImageVersionUpdate()
           })
           .catch(() => {
+            if (abortController.signal.aborted) return
             if (thumbnailLoadGenerationByIdRef.current.get(queued.itemId) !== requestGeneration) {
               return
             }
-            clearPendingThumbnailLoad(queued.itemId, queued.src)
+            clearPendingThumbnailLoad(queued.itemId, queued.src, requestRevisionKey)
             const nextItem = currentItemByIdRef.current.get(queued.itemId)
-            if (nextItem?.thumbnailSet?.levels.some((level) => level.src === queued.src)) {
+            if (
+              nextItem?.thumbnailSet?.levels.some((level) => level.src === queued.src) &&
+              getCanvasImageSourceRevisionKey(nextItem) === requestRevisionKey
+            ) {
               failedThumbnailLoadSrcByIdRef.current.set(queued.itemId, queued.src)
+              failedThumbnailLoadRevisionByIdRef.current.set(queued.itemId, requestRevisionKey)
               scheduleImageVersionUpdate()
             }
           })
           .finally(() => {
+            if (thumbnailLoadAbortByIdRef.current.get(queued.itemId) === abortController) {
+              thumbnailLoadAbortByIdRef.current.delete(queued.itemId)
+            }
             activeThumbnailLoadCountRef.current = Math.max(
               0,
               activeThumbnailLoadCountRef.current - 1
@@ -2772,12 +2992,20 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
         return false
       }
 
-      if (failedThumbnailLoadSrcByIdRef.current.get(item.id) === src) {
+      const sourceRevisionKey = getCanvasImageSourceRevisionKey(item)
+      const failedSrc = failedThumbnailLoadSrcByIdRef.current.get(item.id)
+      const failedRevisionKey = failedThumbnailLoadRevisionByIdRef.current.get(item.id)
+      if (failedSrc === src && failedRevisionKey === sourceRevisionKey) {
         return false
+      }
+      if (failedSrc && (failedSrc !== src || failedRevisionKey !== sourceRevisionKey)) {
+        failedThumbnailLoadSrcByIdRef.current.delete(item.id)
+        failedThumbnailLoadRevisionByIdRef.current.delete(item.id)
       }
 
       const pendingSrc = pendingThumbnailLoadSrcByIdRef.current.get(item.id)
-      if (pendingSrc === src) {
+      const pendingRevisionKey = thumbnailLoadRevisionByIdRef.current.get(item.id)
+      if (pendingSrc === src && pendingRevisionKey === sourceRevisionKey) {
         reprioritizeProjectCanvasWebGLPriorityQueueEntry(
           thumbnailLoadQueueRef.current,
           item.id,
@@ -2788,7 +3016,15 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
         return true
       }
 
+      if (pendingSrc || thumbnailLoadAbortByIdRef.current.has(item.id)) {
+        thumbnailLoadAbortByIdRef.current.get(item.id)?.abort()
+        thumbnailLoadAbortByIdRef.current.delete(item.id)
+        thumbnailLoadQueueRef.current = thumbnailLoadQueueRef.current.filter(
+          (entry) => entry.itemId !== item.id
+        )
+      }
       pendingThumbnailLoadSrcByIdRef.current.set(item.id, src)
+      thumbnailLoadRevisionByIdRef.current.set(item.id, sourceRevisionKey)
       thumbnailLoadGenerationByIdRef.current.set(
         item.id,
         (thumbnailLoadGenerationByIdRef.current.get(item.id) ?? 0) + 1
@@ -2796,7 +3032,8 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
       insertProjectCanvasWebGLPriorityQueueEntry(thumbnailLoadQueueRef.current, {
         itemId: item.id,
         src,
-        priority
+        priority,
+        sourceRevisionKey
       })
       pumpThumbnailLoadQueue()
       return true
@@ -2819,7 +3056,14 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
         return item.image
       }
 
-      const cached = imageCacheRef.current.get(item.id)
+      let cached = imageCacheRef.current.get(item.id)
+      if (
+        cached &&
+        !isCachedImageRecordCurrent(cached, item, getCanvasImageAssetIdentityKey(item.image))
+      ) {
+        deleteCachedImageRecord(imageCacheRef.current, item.id, 'replaced')
+        cached = undefined
+      }
       let fallbackImage = item.image
       const existingRecord = spriteRecordsRef.current.get(item.id)
       const forceSelectedSourceTexture = shouldForceSelectedSourceTextureUpgrade(
@@ -2830,6 +3074,11 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
       const cachedThumbnail = thumbnailCacheRef.current.get(item.id)
       const hasCurrentThumbnailCache =
         cachedThumbnail &&
+        isCachedImageRecordCurrent(
+          cachedThumbnail,
+          item,
+          getCanvasImageAssetIdentityKey(item.image)
+        ) &&
         isCanvasThumbnailSetFresh(item.thumbnailSet, item.sourceIdentity) &&
         item.thumbnailSet.levels.some((level) => level.src === cachedThumbnail.src)
       const currentThumbnail = hasCurrentThumbnailCache ? cachedThumbnail : null
@@ -2841,9 +3090,12 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
       const failedThumbnailSrc = failedThumbnailLoadSrcByIdRef.current.get(item.id)
       if (
         failedThumbnailSrc &&
-        !item.thumbnailSet?.levels.some((level) => level.src === failedThumbnailSrc)
+        (failedThumbnailLoadRevisionByIdRef.current.get(item.id) !==
+          getCanvasImageSourceRevisionKey(item) ||
+          !item.thumbnailSet?.levels.some((level) => level.src === failedThumbnailSrc))
       ) {
         failedThumbnailLoadSrcByIdRef.current.delete(item.id)
+        failedThumbnailLoadRevisionByIdRef.current.delete(item.id)
       }
       const thumbnailLevel = resolveCanvasImageThumbnailLodLevel(
         item,
@@ -2866,7 +3118,7 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
           )
         }
       }
-      if (cached && cached.src === item.src) {
+      if (cached) {
         failedLoadSrcByIdRef.current.delete(item.id)
         const cachedSourceDecision = resolveCanvasImageLodDecision({
           item,
@@ -2957,7 +3209,8 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
         return null
       }
 
-      if (!item.src || pendingLoadSrcByIdRef.current.get(item.id) === item.src) {
+      const pendingToken = pendingLoadRequestTokenByIdRef.current.get(item.id)
+      if (!item.src || (pendingToken && isCurrentImageLoadToken(pendingToken, item))) {
         return null
       }
 
@@ -2980,39 +3233,84 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
         skippedSourceUpgradeSrcByIdRef.current.delete(itemId)
       }
     })
-    pendingLoadSrcByIdRef.current.forEach((_src, itemId) => {
-      if (!nextIds.has(itemId)) {
-        pendingLoadSrcByIdRef.current.delete(itemId)
-        pendingLoadsRef.current.delete(itemId)
+    pendingLoadRequestTokenByIdRef.current.forEach((requestToken, itemId) => {
+      const currentItem = itemById.get(itemId)
+      if (!currentItem || !isCurrentImageLoadToken(requestToken, currentItem)) {
+        cancelPendingLoad(requestToken)
+        if (!currentItem) {
+          imageLoadRequestTokensRef.current.invalidate(itemId)
+        }
       }
     })
-    pendingThumbnailLoadSrcByIdRef.current.forEach((_src, itemId) => {
-      if (!nextIds.has(itemId)) {
+    pendingThumbnailLoadSrcByIdRef.current.forEach((pendingSrc, itemId) => {
+      const currentItem = itemById.get(itemId)
+      const pendingRevisionKey = thumbnailLoadRevisionByIdRef.current.get(itemId)
+      const isCurrentThumbnailSource = Boolean(
+        currentItem?.thumbnailSet &&
+        pendingRevisionKey === getCanvasImageSourceRevisionKey(currentItem) &&
+        isCanvasThumbnailSetFresh(currentItem.thumbnailSet, currentItem.sourceIdentity) &&
+        currentItem.thumbnailSet.levels.some((level) => level.src === pendingSrc)
+      )
+      if (!nextIds.has(itemId) || !isCurrentThumbnailSource) {
+        thumbnailLoadAbortByIdRef.current.get(itemId)?.abort()
+        thumbnailLoadAbortByIdRef.current.delete(itemId)
         pendingThumbnailLoadSrcByIdRef.current.delete(itemId)
+        thumbnailLoadRevisionByIdRef.current.delete(itemId)
+        thumbnailLoadQueueRef.current = thumbnailLoadQueueRef.current.filter(
+          (entry) => entry.itemId !== itemId
+        )
+        thumbnailLoadGenerationByIdRef.current.set(
+          itemId,
+          (thumbnailLoadGenerationByIdRef.current.get(itemId) ?? 0) + 1
+        )
       }
     })
-    failedThumbnailLoadSrcByIdRef.current.forEach((_src, itemId) => {
-      if (!nextIds.has(itemId)) {
+    failedThumbnailLoadSrcByIdRef.current.forEach((failedSrc, itemId) => {
+      const currentItem = itemById.get(itemId)
+      if (
+        !currentItem ||
+        failedThumbnailLoadRevisionByIdRef.current.get(itemId) !==
+          getCanvasImageSourceRevisionKey(currentItem) ||
+        !currentItem.thumbnailSet?.levels.some((level) => level.src === failedSrc)
+      ) {
         failedThumbnailLoadSrcByIdRef.current.delete(itemId)
+        failedThumbnailLoadRevisionByIdRef.current.delete(itemId)
       }
     })
     initialLoadQueueRef.current = initialLoadQueueRef.current.filter((entry) => {
-      const shouldKeep =
-        nextIds.has(entry.itemId) && pendingLoadSrcByIdRef.current.get(entry.itemId) === entry.src
+      const item = itemById.get(entry.itemId)
+      const shouldKeep = Boolean(
+        item &&
+        pendingLoadRequestTokenByIdRef.current.get(entry.itemId) === entry.requestToken &&
+        isCurrentImageLoadToken(entry.requestToken, item)
+      )
       if (!shouldKeep) {
-        clearPendingLoad(entry.itemId, entry.src)
+        cancelPendingLoad(entry.requestToken)
       }
       return shouldKeep
     })
-    sourceUpgradeQueueRef.current = sourceUpgradeQueueRef.current.filter(
-      (entry) =>
-        nextIds.has(entry.itemId) && pendingLoadSrcByIdRef.current.get(entry.itemId) === entry.src
-    )
-    thumbnailLoadQueueRef.current = thumbnailLoadQueueRef.current.filter(
-      (entry) =>
+    sourceUpgradeQueueRef.current = sourceUpgradeQueueRef.current.filter((entry) => {
+      const item = itemById.get(entry.itemId)
+      const shouldKeep = Boolean(
+        item &&
+        pendingLoadRequestTokenByIdRef.current.get(entry.itemId) === entry.requestToken &&
+        isCurrentImageLoadToken(entry.requestToken, item)
+      )
+      if (!shouldKeep) {
+        cancelPendingLoad(entry.requestToken)
+      }
+      return shouldKeep
+    })
+    thumbnailLoadQueueRef.current = thumbnailLoadQueueRef.current.filter((entry) => {
+      const item = itemById.get(entry.itemId)
+      return Boolean(
+        item &&
         nextIds.has(entry.itemId) &&
-        pendingThumbnailLoadSrcByIdRef.current.get(entry.itemId) === entry.src
-    )
+        pendingThumbnailLoadSrcByIdRef.current.get(entry.itemId) === entry.src &&
+        thumbnailLoadRevisionByIdRef.current.get(entry.itemId) === entry.sourceRevisionKey &&
+        getCanvasImageSourceRevisionKey(item) === entry.sourceRevisionKey
+      )
+    })
     const currentStageScale = stageScaleRef.current
     const currentStagePos = stagePosRef.current
     const currentStageSize = stageSizeRef.current
@@ -3069,10 +3367,24 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
       safeScale < PROJECT_CANVAS_WEBGL_DENSE_SOURCE_UPGRADE_MAX_SCALE
     sourceUpgradeEligibleIdsRef.current = residentCandidateIds
     residentCandidateIdsRef.current = residentCandidateIds
+    pendingThumbnailLoadSrcByIdRef.current.forEach((_pendingSrc, itemId) => {
+      if (residentCandidateIds.has(itemId)) return
+      thumbnailLoadAbortByIdRef.current.get(itemId)?.abort()
+      thumbnailLoadAbortByIdRef.current.delete(itemId)
+      pendingThumbnailLoadSrcByIdRef.current.delete(itemId)
+      thumbnailLoadRevisionByIdRef.current.delete(itemId)
+      thumbnailLoadQueueRef.current = thumbnailLoadQueueRef.current.filter(
+        (entry) => entry.itemId !== itemId
+      )
+      thumbnailLoadGenerationByIdRef.current.set(
+        itemId,
+        (thumbnailLoadGenerationByIdRef.current.get(itemId) ?? 0) + 1
+      )
+    })
     sourceUpgradeQueueRef.current = sourceUpgradeQueueRef.current.filter((entry) => {
       const item = itemById.get(entry.itemId)
       if (!item) {
-        clearPendingLoad(entry.itemId, entry.src)
+        cancelPendingLoad(entry.requestToken)
         return false
       }
       const forceSelectedSourceTexture = shouldForceSelectedSourceTextureUpgrade(
@@ -3081,13 +3393,13 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
         stageScaleRef.current
       )
       const shouldKeep =
-        item.src === entry.src &&
         residentCandidateIds.has(entry.itemId) &&
         nextIds.has(entry.itemId) &&
-        pendingLoadSrcByIdRef.current.get(entry.itemId) === entry.src &&
+        pendingLoadRequestTokenByIdRef.current.get(entry.itemId) === entry.requestToken &&
+        isCurrentImageLoadToken(entry.requestToken, item) &&
         !shouldSuppressSourceUpgradeForItem(item, forceSelectedSourceTexture)
       if (!shouldKeep) {
-        clearPendingLoad(entry.itemId, entry.src)
+        cancelPendingLoad(entry.requestToken)
       }
       return shouldKeep
     })
@@ -3162,14 +3474,18 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
     orderedItems.forEach((item) => addResidentTarget(item.id))
     thumbnailLoadQueueRef.current = thumbnailLoadQueueRef.current.filter((entry) => {
       const item = itemById.get(entry.itemId)
-      const shouldKeep =
-        Boolean(item?.thumbnailSet?.levels.some((level) => level.src === entry.src)) &&
+      const shouldKeep = Boolean(
+        item &&
+        item.thumbnailSet?.levels.some((level) => level.src === entry.src) &&
+        getCanvasImageSourceRevisionKey(item) === entry.sourceRevisionKey &&
         residentCandidateIds.has(entry.itemId) &&
         residentTargetIds.has(entry.itemId) &&
         nextIds.has(entry.itemId) &&
-        pendingThumbnailLoadSrcByIdRef.current.get(entry.itemId) === entry.src
+        pendingThumbnailLoadSrcByIdRef.current.get(entry.itemId) === entry.src &&
+        thumbnailLoadRevisionByIdRef.current.get(entry.itemId) === entry.sourceRevisionKey
+      )
       if (!shouldKeep) {
-        clearPendingThumbnailLoad(entry.itemId, entry.src)
+        clearPendingThumbnailLoad(entry.itemId, entry.src, entry.sourceRevisionKey)
       }
       return shouldKeep
     })
@@ -3244,10 +3560,12 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
             suppressDenseSourceUpgrades,
             pendingLoadSrcByIdRef.current.get(item.id),
             pendingThumbnailLoadSrcByIdRef.current.get(item.id),
+            thumbnailLoadRevisionByIdRef.current.get(item.id),
             failedLoadSrcByIdRef.current.get(item.id),
             failedSourceUpgradeSrcByIdRef.current.get(item.id),
             skippedSourceUpgradeSrcByIdRef.current.get(item.id),
             failedThumbnailLoadSrcByIdRef.current.get(item.id),
+            failedThumbnailLoadRevisionByIdRef.current.get(item.id),
             cachedSource?.src,
             getCanvasImageAssetIdentityKey(cachedSource?.image),
             cachedThumbnail?.src,
@@ -3304,6 +3622,7 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
           itemId: item.id,
           image: previousRenderItem.image,
           textureByteSize: existingRecord.textureByteSize,
+          sharedTextureKey: existingRecord.sharedTextureKey,
           selected: selectedIds?.has(item.id) === true,
           priority: getSourceUpgradePriority(item),
           lastAccessedAt: existingRecord.lastUsedAt
@@ -3358,7 +3677,24 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
       }
       residentCandidateTextureBytes += textureByteSize
 
-      const textureKey = getProjectCanvasRenderTextureKey(renderItem)
+      const sourceRevisionKey = getCanvasImageSourceRevisionKey(item)
+      const decodedVariantKey = isProjectCanvasCachedSourceImage(
+        renderItem.image,
+        imageCacheRef.current.get(item.id)
+      )
+        ? 'source'
+        : thumbnailCacheRef.current.get(item.id)?.image === renderItem.image
+          ? `thumbnail:${thumbnailCacheRef.current.get(item.id)?.src ?? ''}`
+          : getCanvasImageStableSourceKey(item)
+            ? 'provided-source'
+            : `provided-object:${getCanvasImageAssetIdentityKey(renderItem.image)}`
+      const sharedTextureKey = getCanvasImageSharedTextureKey(
+        item,
+        renderItem.image,
+        decodedVariantKey,
+        getCanvasImageAssetIdentityKey(renderItem.image)
+      )
+      const textureKey = `${getProjectCanvasRenderTextureKey(renderItem)}|${sourceRevisionKey}`
       const transformState = preview ?? renderItem
       const transformKey = getProjectCanvasRenderTransformKey(transformState)
       const preserveExistingRenderItem = () => {
@@ -3419,13 +3755,23 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
       protectedResidentIds.add(item.id)
 
       const currentResidentTextureBytes = () =>
-        Math.max(0, getResidentTextureBytes() - (existingRecord?.textureByteSize ?? 0))
+        Math.max(
+          0,
+          getResidentTextureBytes() -
+            (existingRecord
+              ? sharedTextureByteTrackerRef.current.getReleaseBytes(existingRecord.sharedTextureKey)
+              : 0)
+        )
+      const additionalTextureBytes = sharedTextureByteTrackerRef.current.getAdditionalBytes(
+        sharedTextureKey,
+        textureByteSize
+      )
 
       while (
         spriteRecordsRef.current.size - (existingRecord ? 1 : 0) >=
           PROJECT_CANVAS_WEBGL_IMAGE_RESIDENT_LIMIT ||
         (spriteRecordsRef.current.size > 0 &&
-          currentResidentTextureBytes() + textureByteSize >
+          currentResidentTextureBytes() + additionalTextureBytes >
             PROJECT_CANVAS_WEBGL_TEXTURE_BUDGET_BYTES)
       ) {
         const evictedItemId = evictOldestResidentSprite(protectedResidentIds)
@@ -3441,7 +3787,7 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
         PROJECT_CANVAS_WEBGL_IMAGE_RESIDENT_LIMIT
       const wouldExceedTextureBudget =
         spriteRecordsRef.current.size - (existingRecord ? 1 : 0) > 0 &&
-        residentTextureBytes + textureByteSize > PROJECT_CANVAS_WEBGL_TEXTURE_BUDGET_BYTES
+        residentTextureBytes + additionalTextureBytes > PROJECT_CANVAS_WEBGL_TEXTURE_BUDGET_BYTES
 
       if (wouldExceedResidentLimit || wouldExceedTextureBudget) {
         if (existingRecord) {
@@ -3453,7 +3799,10 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
       let baseTexture: Texture | null = null
       let texture: Texture | null = null
       try {
-        baseTexture = createProjectCanvasTexture(image)
+        baseTexture = sharedTexturePoolRef.current.acquire(sharedTextureKey, () =>
+          createProjectCanvasTexture(image)
+        )
+        sharedTextureByteTrackerRef.current.acquire(sharedTextureKey, textureByteSize)
         if (!baseTexture) {
           throw new Error('Pixi returned an empty texture.')
         }
@@ -3491,13 +3840,14 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
           textureHeight,
           textureByteSize,
           lastUsedAt: 0,
-          sawTinyPreview: isProjectCanvasTinyPreview(transformState, stageScaleRef.current)
+          sawTinyPreview: isProjectCanvasTinyPreview(transformState, stageScaleRef.current),
+          sharedTextureKey
         })
-        residentTextureByteTrackerRef.current.set(item.id, textureByteSize)
         setTextureBudgetReservation({
           itemId: item.id,
           image,
           textureByteSize,
+          sharedTextureKey,
           selected: selectedIds?.has(item.id) === true,
           priority: getSourceUpgradePriority(item),
           lastAccessedAt: spriteUsageCounterRef.current + 1
@@ -3526,7 +3876,15 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
         if (texture && texture !== baseTexture) {
           texture.destroy(false)
         }
-        baseTexture?.destroy(true)
+        if (baseTexture) {
+          sharedTexturePoolRef.current.release(sharedTextureKey, (sharedTexture) =>
+            destroyProjectCanvasTexture(sharedTexture, true)
+          )
+          const releasedBytes = sharedTextureByteTrackerRef.current.release(sharedTextureKey)
+          if (releasedBytes > 0) {
+            removeTextureBudgetReservation(sharedTextureKey)
+          }
+        }
         console.warn(
           '[Canvas WebGL] Failed to create image texture, skipping item:',
           item.id,
@@ -3616,25 +3974,28 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
     }
   }, [
     beginDecodeBudgetReservation,
+    beginImageLoadToken,
     destroySpriteRecord,
     collectImageHealthCounts,
     deleteCachedImageRecord,
     emitItemLoadMetricsSnapshot,
     evictOldestResidentSprite,
     imageVersion,
+    isCurrentImageLoadToken,
     isInitialized,
     itemSpatialIndex,
     items,
     markSpriteRecordUsed,
     pruneDecodedImageCacheForResidentTargets,
+    removeTextureBudgetReservation,
     cancelScheduledRender,
     scheduleRender,
     scheduleImageVersionUpdate,
     getCanvasImageAssetIdentityKey,
+    getCanvasImageLoadSource,
     getResidentTextureBytes,
     setCachedImageRecord,
     setTextureBudgetReservation,
-    trackTransientObjectUrl,
     selectedIds,
     viewportVersion
   ])

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/canvas3DStagePreviewTextureCache.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/canvas3DStagePreviewTextureCache.ts
@@ -7,7 +7,10 @@ import {
   measureSceneDataLayout,
   tuneLoadedModelSceneForDisplay
 } from './modelLoaders/shared'
-import { readCachedSceneInstanceClone } from './modelLoaders/sceneInstanceCloneCache'
+import {
+  disposeSceneInstanceMaterials,
+  readCachedSceneInstanceClone
+} from './modelLoaders/sceneInstanceCloneCache'
 import {
   CANVAS_3D_STAGE_PREVIEW_LIGHTING_CONFIG,
   CANVAS_3D_STAGE_PREVIEW_MODEL_ROTATION
@@ -144,6 +147,8 @@ const createPreviewRenderable = (
   if (!sceneLayout) {
     if (sceneAsset instanceof THREE.BufferGeometry) {
       sceneAsset.dispose()
+    } else {
+      disposeSceneInstanceMaterials(sceneAsset)
     }
     return null
   }
@@ -181,7 +186,7 @@ const createPreviewRenderable = (
     object: renderObject,
     size: sceneLayout.bounds.size,
     radius: sceneLayout.bounds.radius,
-    dispose: () => {}
+    dispose: () => disposeSceneInstanceMaterials(sceneAsset)
   }
 }
 

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/modelLoaders/sceneInstanceCloneCache.test.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/modelLoaders/sceneInstanceCloneCache.test.ts
@@ -1,89 +1,200 @@
 import * as THREE from 'three'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import {
   clearCachedSceneInstanceClones,
+  cloneSceneInstanceAsset,
+  disposeSceneInstanceMaterials,
   getCachedSceneInstanceCloneCount,
+  hasCachedSceneInstanceClone,
+  peekCachedSceneInstanceCloneTemplate,
   readCachedSceneInstanceClone,
+  retainSceneInstanceMaterials,
   writeCachedSceneInstanceClone
 } from './sceneInstanceCloneCache'
+
+const flushFinalRelease = async (): Promise<void> => {
+  await Promise.resolve()
+}
+
+const objectMaterials = (object: THREE.Object3D): THREE.Material[] => {
+  const materials: THREE.Material[] = []
+  object.traverse((child) => {
+    if (
+      !(child as THREE.Mesh).isMesh &&
+      !(child as THREE.Line).isLine &&
+      !(child as THREE.Points).isPoints &&
+      !(child as THREE.Sprite).isSprite
+    ) {
+      return
+    }
+    const childMaterials = (child as THREE.Mesh).material
+    materials.push(...(Array.isArray(childMaterials) ? childMaterials : [childMaterials]))
+  })
+  return materials
+}
 
 describe('sceneInstanceCloneCache', () => {
   afterEach(() => {
     clearCachedSceneInstanceClones()
   })
 
-  it('returns a fresh clone for the same cache key and cached template object', () => {
-    const renderSceneData = new THREE.Group()
-    renderSceneData.name = 'template-group'
+  it('shares borrowed geometry and textures while isolating Mesh, Line, Points, and Sprite materials', () => {
+    const geometry = new THREE.BufferGeometry()
+    const texture = new THREE.Texture()
+    const sharedMaterial = new THREE.MeshBasicMaterial({ map: texture })
+    const spriteMaterial = new THREE.SpriteMaterial({ map: texture })
+    const template = new THREE.Group()
+    template.add(new THREE.Mesh(geometry, sharedMaterial))
+    template.add(new THREE.Line(geometry, sharedMaterial))
+    template.add(new THREE.Points(geometry, sharedMaterial))
+    template.add(new THREE.Sprite(spriteMaterial))
 
-    writeCachedSceneInstanceClone({
-      cacheKey: 'stage:model-1',
-      renderSceneData
+    const first = cloneSceneInstanceAsset(template)
+    const second = cloneSceneInstanceAsset(template)
+    const firstMaterials = objectMaterials(first)
+    const secondMaterials = objectMaterials(second)
+
+    expect(firstMaterials).toHaveLength(4)
+    expect(new Set(firstMaterials).size).toBe(2)
+    expect(firstMaterials[0]).not.toBe(sharedMaterial)
+    expect(firstMaterials[3]).not.toBe(spriteMaterial)
+    expect(secondMaterials[0]).not.toBe(firstMaterials[0])
+    expect(secondMaterials[3]).not.toBe(firstMaterials[3])
+    expect((firstMaterials[0] as THREE.MeshBasicMaterial).map).toBe(texture)
+    expect((firstMaterials[3] as THREE.SpriteMaterial).map).toBe(texture)
+    first.traverse((child) => {
+      if (
+        (child as THREE.Mesh).isMesh ||
+        (child as THREE.Line).isLine ||
+        (child as THREE.Points).isPoints
+      ) {
+        expect((child as THREE.Mesh).geometry).toBe(geometry)
+      }
     })
-
-    const firstRead = readCachedSceneInstanceClone('stage:model-1')
-    const secondRead = readCachedSceneInstanceClone('stage:model-1')
-
-    expect(firstRead).toBeInstanceOf(THREE.Group)
-    expect(firstRead).not.toBe(renderSceneData)
-    expect(secondRead).toBeInstanceOf(THREE.Group)
-    expect(secondRead).not.toBe(renderSceneData)
-    expect(secondRead).not.toBe(firstRead)
-    expect(firstRead?.name).toBe('template-group')
-    expect(secondRead?.name).toBe('template-group')
   })
 
-  it('reuses the cached template across separate scene requests that share the cache key', () => {
-    writeCachedSceneInstanceClone({
-      cacheKey: 'stage:model-1',
-      renderSceneData: new THREE.Group()
+  it('keeps ShaderMaterial texture uniforms shared while cloning mutable uniform containers', () => {
+    const geometry = new THREE.BoxGeometry()
+    const texture = new THREE.Texture()
+    const material = new THREE.ShaderMaterial({
+      uniforms: {
+        colorMap: { value: texture },
+        nested: { value: { texture } }
+      }
     })
+    const clone = cloneSceneInstanceAsset(new THREE.Mesh(geometry, material)) as THREE.Mesh
+    const clonedMaterial = clone.material as THREE.ShaderMaterial
 
-    const firstRead = readCachedSceneInstanceClone('stage:model-1')
-    const secondRead = readCachedSceneInstanceClone('stage:model-1')
-
-    expect(firstRead).toBeInstanceOf(THREE.Group)
-    expect(secondRead).toBeInstanceOf(THREE.Group)
-    expect(secondRead).not.toBe(firstRead)
+    expect(clonedMaterial).not.toBe(material)
+    expect(clonedMaterial.uniforms).not.toBe(material.uniforms)
+    expect(clonedMaterial.uniforms.colorMap.value).toBe(texture)
+    expect(clonedMaterial.uniforms.nested.value.texture).toBe(texture)
   })
 
-  it('returns cloned geometries for cached buffer geometry assets', () => {
-    const renderSceneData = new THREE.BoxGeometry(2, 4, 6)
+  it('isolates every material-array entry while retaining intra-instance sharing', () => {
+    const geometry = new THREE.BoxGeometry()
+    const sharedMaterial = new THREE.MeshStandardMaterial()
+    const secondMaterial = new THREE.MeshStandardMaterial()
+    const template = new THREE.Group()
+    template.add(new THREE.Mesh(geometry, [sharedMaterial, secondMaterial]))
+    template.add(new THREE.Mesh(geometry, sharedMaterial))
 
-    writeCachedSceneInstanceClone({
-      cacheKey: 'stage:model-geometry',
-      renderSceneData
+    const clone = cloneSceneInstanceAsset(template)
+    const meshes: THREE.Mesh[] = []
+    clone.traverse((child) => {
+      if ((child as THREE.Mesh).isMesh) meshes.push(child as THREE.Mesh)
     })
+    const firstMaterials = meshes[0].material as THREE.Material[]
 
-    const firstRead = readCachedSceneInstanceClone('stage:model-geometry')
-    const secondRead = readCachedSceneInstanceClone('stage:model-geometry')
-
-    expect(firstRead).toBeInstanceOf(THREE.BufferGeometry)
-    expect(secondRead).toBeInstanceOf(THREE.BufferGeometry)
-    expect(firstRead).not.toBe(renderSceneData)
-    expect(secondRead).not.toBe(renderSceneData)
-    expect(secondRead).not.toBe(firstRead)
+    expect(firstMaterials[0]).not.toBe(sharedMaterial)
+    expect(firstMaterials[1]).not.toBe(secondMaterial)
+    expect(meshes[1].material).toBe(firstMaterials[0])
   })
 
-  it('evicts the oldest entries when the cache limit is exceeded', () => {
-    writeCachedSceneInstanceClone({
-      cacheKey: 'entry-a',
-      renderSceneData: new THREE.Group(),
-      maxEntries: 2
-    })
-    writeCachedSceneInstanceClone({
-      cacheKey: 'entry-b',
-      renderSceneData: new THREE.Group(),
-      maxEntries: 2
-    })
-    writeCachedSceneInstanceClone({
-      cacheKey: 'entry-c',
-      renderSceneData: new THREE.Group(),
-      maxEntries: 2
-    })
+  it('does not cache, clone, or dispose standalone borrowed BufferGeometry', () => {
+    const geometry = new THREE.BoxGeometry()
+    const clone = vi.spyOn(geometry, 'clone')
+    const dispose = vi.spyOn(geometry, 'dispose')
 
+    writeCachedSceneInstanceClone({ cacheKey: 'geometry', renderSceneData: geometry })
+
+    expect(hasCachedSceneInstanceClone('geometry')).toBe(false)
+    expect(readCachedSceneInstanceClone('geometry')).toBeNull()
+    expect(clone).not.toHaveBeenCalled()
+    clearCachedSceneInstanceClones()
+    expect(dispose).not.toHaveBeenCalled()
+  })
+
+  it('keeps a memoized instance live across a StrictMode-style cleanup/setup probe', async () => {
+    const instance = cloneSceneInstanceAsset(
+      new THREE.Mesh(new THREE.BoxGeometry(), new THREE.MeshStandardMaterial())
+    )
+    const material = objectMaterials(instance)[0]
+    const dispose = vi.spyOn(material, 'dispose')
+
+    const firstRelease = retainSceneInstanceMaterials(instance)
+    firstRelease()
+    const secondRelease = retainSceneInstanceMaterials(instance)
+    await flushFinalRelease()
+    expect(dispose).not.toHaveBeenCalled()
+
+    secondRelease()
+    secondRelease()
+    await flushFinalRelease()
+    expect(dispose).toHaveBeenCalledOnce()
+  })
+
+  it('disposes shared instance materials exactly once without owning geometry or textures', () => {
+    const geometry = new THREE.BoxGeometry()
+    const texture = new THREE.Texture()
+    const material = new THREE.MeshStandardMaterial({ map: texture })
+    const instance = cloneSceneInstanceAsset(new THREE.Mesh(geometry, material))
+    const instanceMaterial = objectMaterials(instance)[0]
+    const materialDispose = vi.spyOn(instanceMaterial, 'dispose')
+    const geometryDispose = vi.spyOn(geometry, 'dispose')
+    const textureDispose = vi.spyOn(texture, 'dispose')
+
+    disposeSceneInstanceMaterials(instance)
+    disposeSceneInstanceMaterials(instance)
+
+    expect(materialDispose).toHaveBeenCalledOnce()
+    expect(geometryDispose).not.toHaveBeenCalled()
+    expect(textureDispose).not.toHaveBeenCalled()
+  })
+
+  it('disposes replaced, evicted, and finally cleared cache templates exactly once', () => {
+    const makeTemplate = () =>
+      new THREE.Mesh(new THREE.BoxGeometry(), new THREE.MeshStandardMaterial())
+    const first = makeTemplate()
+    writeCachedSceneInstanceClone({ cacheKey: 'a', renderSceneData: first, maxEntries: 2 })
+    const firstCachedMaterial = objectMaterials(
+      peekCachedSceneInstanceCloneTemplate('a') as THREE.Object3D
+    )[0]
+    const firstDispose = vi.spyOn(firstCachedMaterial, 'dispose')
+
+    writeCachedSceneInstanceClone({ cacheKey: 'a', renderSceneData: makeTemplate(), maxEntries: 2 })
+    expect(firstDispose).toHaveBeenCalledOnce()
+
+    const replacementMaterial = objectMaterials(
+      peekCachedSceneInstanceCloneTemplate('a') as THREE.Object3D
+    )[0]
+    const replacementDispose = vi.spyOn(replacementMaterial, 'dispose')
+    writeCachedSceneInstanceClone({ cacheKey: 'b', renderSceneData: makeTemplate(), maxEntries: 2 })
+    writeCachedSceneInstanceClone({ cacheKey: 'c', renderSceneData: makeTemplate(), maxEntries: 2 })
+    expect(replacementDispose).toHaveBeenCalledOnce()
+    expect(readCachedSceneInstanceClone('a')).toBeNull()
     expect(getCachedSceneInstanceCloneCount()).toBe(2)
-    expect(readCachedSceneInstanceClone('entry-a')).toBeNull()
+
+    const remainingDisposes = ['b', 'c'].map((key) =>
+      vi.spyOn(
+        objectMaterials(peekCachedSceneInstanceCloneTemplate(key) as THREE.Object3D)[0],
+        'dispose'
+      )
+    )
+    clearCachedSceneInstanceClones()
+    clearCachedSceneInstanceClones()
+    remainingDisposes.forEach((dispose) => expect(dispose).toHaveBeenCalledOnce())
+    expect(getCachedSceneInstanceCloneCount()).toBe(0)
   })
 })

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/modelLoaders/sceneInstanceCloneCache.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/modelLoaders/sceneInstanceCloneCache.ts
@@ -6,47 +6,177 @@ export const DEFAULT_SCENE_INSTANCE_CLONE_CACHE_LIMIT = 48
 export type CachedSceneInstanceAsset = THREE.Object3D | THREE.BufferGeometry
 
 type SceneInstanceCloneCacheEntry = {
-  renderSceneData: CachedSceneInstanceAsset
+  renderSceneData: THREE.Object3D
 }
 
 const sceneInstanceCloneCache = new Map<string, SceneInstanceCloneCacheEntry>()
+const disposedSceneInstanceMaterials = new WeakSet<THREE.Material>()
+const sceneInstanceMaterialLeases = new WeakMap<
+  THREE.Object3D,
+  { count: number; generation: number }
+>()
 
-const cloneSceneInstanceTemplate = (sceneData: CachedSceneInstanceAsset) =>
-  sceneData instanceof THREE.BufferGeometry ? sceneData.clone() : SkeletonUtils.clone(sceneData)
+const getSceneObjectMaterials = (
+  object: THREE.Object3D
+): THREE.Material | THREE.Material[] | null => {
+  if (
+    !(object as THREE.Mesh).isMesh &&
+    !(object as THREE.Line).isLine &&
+    !(object as THREE.Points).isPoints &&
+    !(object as THREE.Sprite).isSprite
+  ) {
+    return null
+  }
+  return (object as THREE.Mesh).material
+}
+
+export function cloneSceneInstanceAsset(sceneData: THREE.BufferGeometry): THREE.BufferGeometry
+export function cloneSceneInstanceAsset(sceneData: THREE.Object3D): THREE.Object3D
+export function cloneSceneInstanceAsset(
+  sceneData: CachedSceneInstanceAsset
+): CachedSceneInstanceAsset {
+  if (sceneData instanceof THREE.BufferGeometry) return sceneData
+
+  const clone = SkeletonUtils.clone(sceneData)
+  const materialClones = new Map<THREE.Material, THREE.Material>()
+  const restoreSharedTextureReferences = (
+    originalValue: unknown,
+    clonedValue: unknown,
+    visited = new WeakSet<object>()
+  ): void => {
+    if (
+      !originalValue ||
+      !clonedValue ||
+      typeof originalValue !== 'object' ||
+      typeof clonedValue !== 'object'
+    ) {
+      return
+    }
+    if (visited.has(originalValue)) return
+    visited.add(originalValue)
+
+    const originalRecord = originalValue as Record<string, unknown>
+    const clonedRecord = clonedValue as Record<string, unknown>
+    Object.keys(originalRecord).forEach((key) => {
+      const originalChild = originalRecord[key]
+      if ((originalChild as THREE.Texture | undefined)?.isTexture) {
+        clonedRecord[key] = originalChild
+        return
+      }
+      const clonedChild = clonedRecord[key]
+      if (
+        originalChild &&
+        clonedChild &&
+        typeof originalChild === 'object' &&
+        typeof clonedChild === 'object'
+      ) {
+        restoreSharedTextureReferences(originalChild, clonedChild, visited)
+      }
+    })
+  }
+  const cloneMaterial = (material: THREE.Material): THREE.Material => {
+    const existingClone = materialClones.get(material)
+    if (existingClone) return existingClone
+    const materialClone = material.clone()
+    restoreSharedTextureReferences(material, materialClone)
+    materialClones.set(material, materialClone)
+    return materialClone
+  }
+
+  clone.traverse((child) => {
+    const materials = getSceneObjectMaterials(child)
+    if (!materials) return
+    ;(child as THREE.Mesh).material = Array.isArray(materials)
+      ? materials.map(cloneMaterial)
+      : cloneMaterial(materials)
+  })
+
+  return clone
+}
+
+export const disposeSceneInstanceMaterials = (sceneData: CachedSceneInstanceAsset): void => {
+  if (sceneData instanceof THREE.BufferGeometry) return
+
+  const visitedMaterials = new Set<THREE.Material>()
+  sceneData.traverse((child) => {
+    const childMaterials = getSceneObjectMaterials(child)
+    if (!childMaterials) return
+
+    const materials = Array.isArray(childMaterials) ? childMaterials : [childMaterials]
+    materials.forEach((material) => {
+      if (
+        !material ||
+        visitedMaterials.has(material) ||
+        disposedSceneInstanceMaterials.has(material)
+      ) {
+        return
+      }
+      visitedMaterials.add(material)
+      disposedSceneInstanceMaterials.add(material)
+      material.dispose()
+    })
+  })
+}
+
+/**
+ * Retains an instance across React effect lifetimes. Final disposal is deferred by one microtask,
+ * so StrictMode's setup/cleanup/setup probe cannot dispose a memoized instance that immediately
+ * becomes live again. Geometry and textures are borrowed from Three/useLoader and are never
+ * disposed here; only materials cloned by cloneSceneInstanceAsset are owned by this boundary.
+ */
+export const retainSceneInstanceMaterials = (sceneData: CachedSceneInstanceAsset): (() => void) => {
+  if (sceneData instanceof THREE.BufferGeometry) return () => undefined
+
+  const lease = sceneInstanceMaterialLeases.get(sceneData) ?? { count: 0, generation: 0 }
+  lease.count += 1
+  lease.generation += 1
+  sceneInstanceMaterialLeases.set(sceneData, lease)
+  let released = false
+
+  return () => {
+    if (released) return
+    released = true
+    lease.count -= 1
+    const releaseGeneration = ++lease.generation
+    queueMicrotask(() => {
+      if (lease.count !== 0 || lease.generation !== releaseGeneration) return
+      sceneInstanceMaterialLeases.delete(sceneData)
+      disposeSceneInstanceMaterials(sceneData)
+    })
+  }
+}
 
 const touchSceneInstanceCloneCacheEntry = (
   cacheKey: string,
   entry: SceneInstanceCloneCacheEntry
-) => {
+): void => {
   sceneInstanceCloneCache.delete(cacheKey)
   sceneInstanceCloneCache.set(cacheKey, entry)
 }
 
-export const readCachedSceneInstanceClone = (cacheKey: string | undefined) => {
+export const readCachedSceneInstanceClone = (
+  cacheKey: string | undefined
+): THREE.Object3D | null => {
   if (!cacheKey) return null
-
   const cacheEntry = sceneInstanceCloneCache.get(cacheKey)
-  if (!cacheEntry) {
-    return null
-  }
+  if (!cacheEntry) return null
 
   touchSceneInstanceCloneCacheEntry(cacheKey, cacheEntry)
-  return cloneSceneInstanceTemplate(cacheEntry.renderSceneData)
+  return cloneSceneInstanceAsset(cacheEntry.renderSceneData)
 }
 
-export const peekCachedSceneInstanceCloneTemplate = (cacheKey: string | undefined) => {
+export const peekCachedSceneInstanceCloneTemplate = (
+  cacheKey: string | undefined
+): THREE.Object3D | null => {
   if (!cacheKey) return null
-
   const cacheEntry = sceneInstanceCloneCache.get(cacheKey)
-  if (!cacheEntry) {
-    return null
-  }
+  if (!cacheEntry) return null
 
   touchSceneInstanceCloneCacheEntry(cacheKey, cacheEntry)
   return cacheEntry.renderSceneData
 }
 
-export const hasCachedSceneInstanceClone = (cacheKey: string | undefined) =>
+export const hasCachedSceneInstanceClone = (cacheKey: string | undefined): boolean =>
   Boolean(cacheKey && sceneInstanceCloneCache.has(cacheKey))
 
 export const writeCachedSceneInstanceClone = ({
@@ -57,22 +187,32 @@ export const writeCachedSceneInstanceClone = ({
   cacheKey: string | undefined
   renderSceneData: CachedSceneInstanceAsset
   maxEntries?: number
-}) => {
+}): void => {
   if (!cacheKey) return
 
+  // Standalone geometry is borrowed loader state and has no owned material state to cache.
+  if (renderSceneData instanceof THREE.BufferGeometry) return
+
+  const previousEntry = sceneInstanceCloneCache.get(cacheKey)
+  if (previousEntry) disposeSceneInstanceMaterials(previousEntry.renderSceneData)
   touchSceneInstanceCloneCacheEntry(cacheKey, {
-    renderSceneData
+    renderSceneData: cloneSceneInstanceAsset(renderSceneData)
   })
 
   while (sceneInstanceCloneCache.size > maxEntries) {
     const oldestCacheKey = sceneInstanceCloneCache.keys().next().value
     if (oldestCacheKey === undefined) break
+    const evictedEntry = sceneInstanceCloneCache.get(oldestCacheKey)
     sceneInstanceCloneCache.delete(oldestCacheKey)
+    if (evictedEntry) disposeSceneInstanceMaterials(evictedEntry.renderSceneData)
   }
 }
 
-export const clearCachedSceneInstanceClones = () => {
+export const clearCachedSceneInstanceClones = (): void => {
+  sceneInstanceCloneCache.forEach(({ renderSceneData }) =>
+    disposeSceneInstanceMaterials(renderSceneData)
+  )
   sceneInstanceCloneCache.clear()
 }
 
-export const getCachedSceneInstanceCloneCount = () => sceneInstanceCloneCache.size
+export const getCachedSceneInstanceCloneCount = (): number => sceneInstanceCloneCache.size

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/modelLoaders/shared.test.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/modelLoaders/shared.test.ts
@@ -1,12 +1,82 @@
-import { describe, expect, it } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
 import * as THREE from 'three'
 
 import {
+  clearSceneInstanceForBufferGeometry,
   configureTextureAwareLoader,
   dummyTextureUrl,
   measureSceneDataLayout,
-  tuneLoadedModelSceneForDisplay
+  tuneLoadedModelSceneForDisplay,
+  useGeometrySceneMaterial
 } from './shared'
+
+describe('useGeometrySceneMaterial', () => {
+  it('owns and disposes its material without disposing borrowed geometry on unmount', () => {
+    const borrowedGeometry = new THREE.BoxGeometry()
+    const geometryDispose = vi.spyOn(borrowedGeometry, 'dispose')
+    const { result, unmount } = renderHook(({ sceneData }) => useGeometrySceneMaterial(sceneData), {
+      initialProps: {
+        sceneData: borrowedGeometry as THREE.Object3D | THREE.BufferGeometry
+      }
+    })
+    const material = result.current
+    const materialDispose = vi.spyOn(material as THREE.MeshStandardMaterial, 'dispose')
+
+    expect(material).toBeInstanceOf(THREE.MeshStandardMaterial)
+    unmount()
+
+    expect(materialDispose).toHaveBeenCalledOnce()
+    expect(geometryDispose).not.toHaveBeenCalled()
+  })
+
+  it('creates an owned material on Object3D to geometry switch and releases it on unmount', () => {
+    const objectScene = new THREE.Group()
+    const borrowedGeometry = new THREE.BoxGeometry()
+    const geometryDispose = vi.spyOn(borrowedGeometry, 'dispose')
+    const { result, rerender, unmount } = renderHook(
+      ({ sceneData }) => useGeometrySceneMaterial(sceneData),
+      { initialProps: { sceneData: objectScene as THREE.Object3D | THREE.BufferGeometry } }
+    )
+
+    expect(result.current).toBeNull()
+    act(() => {
+      rerender({ sceneData: borrowedGeometry })
+    })
+    const material = result.current
+    const materialDispose = vi.spyOn(material as THREE.MeshStandardMaterial, 'dispose')
+
+    expect(material).toBeInstanceOf(THREE.MeshStandardMaterial)
+    unmount()
+
+    expect(materialDispose).toHaveBeenCalledOnce()
+    expect(geometryDispose).not.toHaveBeenCalled()
+  })
+})
+
+describe('clearSceneInstanceForBufferGeometry', () => {
+  it('drops the previous object instance without disposing borrowed geometry', () => {
+    const borrowedGeometry = new THREE.BoxGeometry()
+    const geometryDispose = vi.spyOn(borrowedGeometry, 'dispose')
+    let retainedInstance: THREE.Object3D | null = new THREE.Group()
+
+    const cleared = clearSceneInstanceForBufferGeometry(borrowedGeometry, () => {
+      retainedInstance = null
+    })
+
+    expect(cleared).toBe(true)
+    expect(retainedInstance).toBeNull()
+    expect(geometryDispose).not.toHaveBeenCalled()
+  })
+
+  it('leaves the current object instance intact for Object3D input', () => {
+    const retainedInstance = new THREE.Group()
+    const clear = vi.fn()
+
+    expect(clearSceneInstanceForBufferGeometry(retainedInstance, clear)).toBe(false)
+    expect(clear).not.toHaveBeenCalled()
+  })
+})
 
 describe('measureSceneDataLayout', () => {
   it('derives centered bounds for off-origin object scenes', () => {

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/modelLoaders/shared.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/modelLoaders/shared.tsx
@@ -1,12 +1,13 @@
 /* eslint-disable react/no-unknown-property */
 /* eslint-disable react-refresh/only-export-components */
-import React, { useEffect, useLayoutEffect, useMemo, useRef } from 'react'
+import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useThree } from '@react-three/fiber'
 import * as THREE from 'three'
 import { RoomEnvironment, SkeletonUtils } from 'three-stdlib'
 import {
-  hasCachedSceneInstanceClone,
+  cloneSceneInstanceAsset,
   readCachedSceneInstanceClone,
+  retainSceneInstanceMaterials,
   writeCachedSceneInstanceClone
 } from './sceneInstanceCloneCache'
 import { resolveModelInspectionMetadata } from './modelInspectionMetadata'
@@ -467,6 +468,34 @@ export const ModelSceneCanvasSetup: React.FC<{ enableEnvironment?: boolean }> = 
   return null
 }
 
+export const clearSceneInstanceForBufferGeometry = (
+  sceneData: THREE.Object3D | THREE.BufferGeometry,
+  clearSceneInstance: () => void
+): sceneData is THREE.BufferGeometry => {
+  if (!(sceneData instanceof THREE.BufferGeometry)) return false
+  clearSceneInstance()
+  return true
+}
+
+export const useGeometrySceneMaterial = (
+  sceneData: THREE.Object3D | THREE.BufferGeometry
+): THREE.MeshStandardMaterial | null => {
+  const [geometryMaterial, setGeometryMaterial] = useState<THREE.MeshStandardMaterial | null>(null)
+
+  useLayoutEffect(() => {
+    if (!(sceneData instanceof THREE.BufferGeometry)) {
+      setGeometryMaterial(null)
+      return
+    }
+
+    const material = new THREE.MeshStandardMaterial({ color: '#cccccc' })
+    setGeometryMaterial(material)
+    return () => material.dispose()
+  }, [sceneData])
+
+  return sceneData instanceof THREE.BufferGeometry ? geometryMaterial : null
+}
+
 export const BaseScene: React.FC<{
   sceneData: THREE.Object3D | THREE.BufferGeometry
   initialRotation?: [number, number, number]
@@ -485,56 +514,57 @@ export const BaseScene: React.FC<{
   const rootRef = useRef<THREE.Group>(null)
   const contentRef = useRef<THREE.Group>(null)
   const { gl, scene, invalidate } = useThree()
-  const renderSceneData = useMemo(() => {
-    if (sceneData instanceof THREE.BufferGeometry) {
-      if (instanceCacheKey && !hasCachedSceneInstanceClone(instanceCacheKey)) {
-        const cachedGeometry = sceneData.clone()
-        resolveModelInspectionMetadata(cachedGeometry, { animationCount })
-        writeCachedSceneInstanceClone({
-          cacheKey: instanceCacheKey,
-          renderSceneData: cachedGeometry
-        })
-      }
-
-      resolveModelInspectionMetadata(sceneData, { animationCount })
-      return sceneData
-    }
+  const geometryMaterial = useGeometrySceneMaterial(sceneData)
+  const [sceneInstance, setSceneInstance] = useState<{
+    sceneData: THREE.Object3D
+    instanceCacheKey: string | undefined
+    renderSceneData: THREE.Object3D
+  } | null>(null)
+  useLayoutEffect(() => {
+    if (clearSceneInstanceForBufferGeometry(sceneData, () => setSceneInstance(null))) return
 
     const maxAnisotropy = gl.capabilities.getMaxAnisotropy()
+    let nextRenderSceneData: THREE.Object3D
 
     if (!instanceCacheKey) {
-      const sceneClone = tuneLoadedModelSceneForDisplay(cloneObject3D(sceneData), {
-        maxAnisotropy
-      })
-      resolveModelInspectionMetadata(sceneClone, { animationCount })
-      return sceneClone
-    }
-    const cachedSceneClone = readCachedSceneInstanceClone(instanceCacheKey)
-    if (cachedSceneClone instanceof THREE.Object3D) {
-      const renderedSceneClone = tuneLoadedModelSceneForDisplay(cachedSceneClone, {
-        maxAnisotropy
-      })
-      resolveModelInspectionMetadata(renderedSceneClone, { animationCount })
-      return renderedSceneClone
+      nextRenderSceneData = cloneSceneInstanceAsset(sceneData)
+    } else {
+      const cachedSceneClone = readCachedSceneInstanceClone(instanceCacheKey)
+      if (cachedSceneClone) {
+        nextRenderSceneData = cachedSceneClone
+      } else {
+        const sceneTemplate = cloneObject3D(sceneData)
+        resolveModelInspectionMetadata(sceneTemplate, { animationCount })
+        writeCachedSceneInstanceClone({
+          cacheKey: instanceCacheKey,
+          renderSceneData: sceneTemplate
+        })
+        nextRenderSceneData = readCachedSceneInstanceClone(instanceCacheKey) as THREE.Object3D
+      }
     }
 
-    const sceneTemplate = tuneLoadedModelSceneForDisplay(cloneObject3D(sceneData), {
-      maxAnisotropy
+    tuneLoadedModelSceneForDisplay(nextRenderSceneData, { maxAnisotropy })
+    resolveModelInspectionMetadata(nextRenderSceneData, { animationCount })
+    const releaseMaterials = retainSceneInstanceMaterials(nextRenderSceneData)
+    setSceneInstance({
+      sceneData,
+      instanceCacheKey,
+      renderSceneData: nextRenderSceneData
     })
-    resolveModelInspectionMetadata(sceneTemplate, { animationCount })
-    writeCachedSceneInstanceClone({
-      cacheKey: instanceCacheKey,
-      renderSceneData: sceneTemplate
-    })
-    const renderedSceneClone = tuneLoadedModelSceneForDisplay(cloneObject3D(sceneTemplate), {
-      maxAnisotropy
-    })
-    resolveModelInspectionMetadata(renderedSceneClone, { animationCount })
-    return renderedSceneClone
+
+    return releaseMaterials
   }, [animationCount, gl, instanceCacheKey, sceneData])
+  const renderSceneData =
+    sceneData instanceof THREE.BufferGeometry
+      ? sceneData
+      : sceneInstance?.sceneData === sceneData &&
+          sceneInstance.instanceCacheKey === instanceCacheKey
+        ? sceneInstance.renderSceneData
+        : null
+  const inspectionSceneData = renderSceneData ?? sceneData
   const modelInspectionMetadata = useMemo(
-    () => resolveModelInspectionMetadata(renderSceneData, { animationCount }),
-    [animationCount, renderSceneData]
+    () => resolveModelInspectionMetadata(inspectionSceneData, { animationCount }),
+    [animationCount, inspectionSceneData]
   )
   const precomputedLayout = useMemo(() => {
     const cachedLayout = readSceneLayoutCache(sceneData, initialRotation)
@@ -557,7 +587,7 @@ export const BaseScene: React.FC<{
   }, [initialRotation, sceneData])
 
   useLayoutEffect(() => {
-    if (!rootRef.current || !contentRef.current || !sceneData) return
+    if (!rootRef.current || !contentRef.current || !renderSceneData) return
     let cancelled = false
     let rafId = 0
     let retryFrameCount = 0
@@ -669,20 +699,22 @@ export const BaseScene: React.FC<{
     )
   }, [instanceCacheKey, modelInspectionMetadata])
 
+  if (!renderSceneData) return null
+
   if (renderSceneData instanceof THREE.BufferGeometry) {
+    if (!geometryMaterial) return null
+
     return (
-      <group ref={rootRef}>
+      <group ref={rootRef} dispose={null}>
         <group ref={contentRef}>
-          <mesh geometry={renderSceneData}>
-            <meshStandardMaterial color="#cccccc" />
-          </mesh>
+          <mesh geometry={renderSceneData} material={geometryMaterial} />
         </group>
       </group>
     )
   }
 
   return (
-    <group ref={rootRef}>
+    <group ref={rootRef} dispose={null}>
       <group ref={contentRef}>
         <primitive object={renderSceneData} rotation={initialRotation} />
       </group>

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/projectCanvasPageShared.test.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/projectCanvasPageShared.test.ts
@@ -5,6 +5,7 @@ import {
   EXPORT_IMAGE_MAX_SIDE,
   resolveCanvasExportRasterConfig
 } from './canvasExportRasterUtils'
+import { AGENT_IMAGE_DRAG_MIME } from '@renderer/utils/droppedImageUtils'
 import { getCanvasItemBounds, resolveDroppedAgentImageDataUrl } from './projectCanvasPageShared'
 
 describe('resolveCanvasExportRasterConfig', () => {
@@ -90,6 +91,36 @@ describe('getCanvasItemBounds', () => {
 })
 
 describe('resolveDroppedAgentImageDataUrl', () => {
+  it('keeps remote agent image URLs on the remote loading path', async () => {
+    const dataTransfer = {
+      files: [],
+      getData: (type: string) =>
+        type === AGENT_IMAGE_DRAG_MIME ? 'https://cdn.example.com/output/generated.png' : ''
+    } as unknown as Pick<DataTransfer, 'getData' | 'files'>
+
+    await expect(resolveDroppedAgentImageDataUrl(dataTransfer)).resolves.toEqual({
+      src: 'https://cdn.example.com/output/generated.png',
+      fileName: 'generated.png'
+    })
+  })
+
+  it('falls back to a validated remote agent URL when a synthetic file cannot be authorized', async () => {
+    const placeholderFile = new File([], 'generated.png', { type: 'image/png' })
+    const dataTransfer = {
+      files: [placeholderFile],
+      getData: (type: string) =>
+        type === AGENT_IMAGE_DRAG_MIME ? 'https://cdn.example.com/output/generated.png' : ''
+    } as unknown as Pick<DataTransfer, 'getData' | 'files'>
+
+    await expect(resolveDroppedAgentImageDataUrl(dataTransfer)).resolves.toEqual({
+      src: 'https://cdn.example.com/output/generated.png',
+      fileName: 'generated.png',
+      sizeBytes: undefined,
+      sourceWidthHint: undefined,
+      sourceHeightHint: undefined
+    })
+  })
+
   it('prefers the internal quick-app image payload over placeholder files', async () => {
     const placeholderFile = new File(['x'], 'placeholder.png', { type: 'image/png' })
     const createObjectURL = vi.fn(() => 'blob:placeholder-file')

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/projectCanvasPageShared.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/projectCanvasPageShared.tsx
@@ -4,7 +4,10 @@ import SvgIcon from '@mui/material/SvgIcon'
 import type { SvgIconProps } from '@mui/material/SvgIcon'
 import type { AdobeBridgeTarget } from '@shared/api/svcAdobeBridge'
 import { getDownloadFileNameFromUrl, normalizeLocalMediaUrl } from '../ChatPage/chatPageShared'
-import { getCanvasLocalMediaSourceUrl } from './canvasLocalFileSource'
+import {
+  authorizeCanvasLocalMediaSourceUrl,
+  resolveAuthorizedCanvasLocalMediaSourceUrl
+} from './canvasLocalFileSource'
 import { AGENT_IMAGE_DRAG_MIME } from '@renderer/utils/droppedImageUtils'
 import type { OfficeFileNodeData } from './officePreviewUtils'
 export {
@@ -402,6 +405,15 @@ const resolveQuickAppImageDragData = (rawPayload: string): ResolvedDroppedAgentI
   }
 }
 
+function normalizeRemoteAgentImageUrl(value: string): string | null {
+  try {
+    const parsed = new URL(value.trim())
+    return parsed.protocol === 'https:' || parsed.protocol === 'http:' ? parsed.toString() : null
+  } catch {
+    return null
+  }
+}
+
 export async function resolveDroppedAgentImageDataUrl(
   dataTransfer: Pick<DataTransfer, 'getData' | 'files'>
 ): Promise<ResolvedDroppedAgentImageData | null> {
@@ -410,35 +422,71 @@ export async function resolveDroppedAgentImageDataUrl(
   if (!agentImageUrl && !quickAppImagePayload) return null
 
   const quickAppImageData = resolveQuickAppImageDragData(quickAppImagePayload)
+  const normalizedAgentWebUrl = normalizeRemoteAgentImageUrl(agentImageUrl)
   const droppedImageFile = resolveDroppedImageFile(dataTransfer, quickAppImageData?.fileName)
   if (droppedImageFile) {
-    const normalizedAgentUrl = normalizeLocalMediaUrl(agentImageUrl)
-    return {
-      src:
-        quickAppImageData?.src ||
-        normalizedAgentUrl ||
-        getCanvasLocalMediaSourceUrl(droppedImageFile) ||
-        '',
-      fileName: droppedImageFile.name || quickAppImageData?.fileName,
-      sizeBytes:
-        Number.isFinite(droppedImageFile.size) && droppedImageFile.size >= 0
-          ? droppedImageFile.size
-          : undefined,
-      sourceWidthHint: quickAppImageData?.sourceWidthHint,
-      sourceHeightHint: quickAppImageData?.sourceHeightHint,
-      sourceFile: droppedImageFile
+    const authorizedFileUrl = await authorizeCanvasLocalMediaSourceUrl(droppedImageFile)
+    if (authorizedFileUrl) {
+      return {
+        src: authorizedFileUrl,
+        fileName: droppedImageFile.name || quickAppImageData?.fileName,
+        sizeBytes:
+          Number.isFinite(droppedImageFile.size) && droppedImageFile.size >= 0
+            ? droppedImageFile.size
+            : undefined,
+        sourceWidthHint: quickAppImageData?.sourceWidthHint,
+        sourceHeightHint: quickAppImageData?.sourceHeightHint,
+        sourceFile: droppedImageFile
+      }
+    }
+
+    const safeFallbackSrc =
+      quickAppImageData && !/^local-media:|^file:/i.test(quickAppImageData.src)
+        ? quickAppImageData.src
+        : normalizedAgentWebUrl || ''
+    if (safeFallbackSrc) {
+      const hasUsableDroppedFileBytes =
+        Number.isFinite(droppedImageFile.size) && droppedImageFile.size > 0
+      return {
+        src: safeFallbackSrc,
+        fileName:
+          quickAppImageData?.fileName ||
+          droppedImageFile.name ||
+          getDownloadFileNameFromUrl(safeFallbackSrc, 'dropped-image.png'),
+        sizeBytes:
+          quickAppImageData?.sizeBytes ??
+          (hasUsableDroppedFileBytes ? droppedImageFile.size : undefined),
+        sourceWidthHint: quickAppImageData?.sourceWidthHint,
+        sourceHeightHint: quickAppImageData?.sourceHeightHint,
+        sourceFile: hasUsableDroppedFileBytes ? droppedImageFile : undefined
+      }
     }
   }
 
-  const normalizedAgentUrl = normalizeLocalMediaUrl(agentImageUrl)
-  if (normalizedAgentUrl) {
+  const normalizedAgentLocalCandidate = normalizeLocalMediaUrl(agentImageUrl)
+  const normalizedAgentLocalUrl = /^local-media:|^file:/i.test(normalizedAgentLocalCandidate)
+    ? normalizedAgentLocalCandidate
+    : ''
+  if (normalizedAgentLocalUrl) {
+    const authorizedSrc = await resolveAuthorizedCanvasLocalMediaSourceUrl(normalizedAgentLocalUrl)
+    if (!authorizedSrc) return null
     return {
-      src: normalizedAgentUrl,
-      fileName: getDownloadFileNameFromUrl(normalizedAgentUrl, 'dropped-image.png')
+      src: authorizedSrc,
+      fileName: getDownloadFileNameFromUrl(authorizedSrc, 'dropped-image.png')
+    }
+  }
+  if (normalizedAgentWebUrl) {
+    return {
+      src: normalizedAgentWebUrl,
+      fileName: getDownloadFileNameFromUrl(normalizedAgentWebUrl, 'dropped-image.png')
     }
   }
 
   if (quickAppImageData) {
+    if (/^local-media:|^file:/i.test(quickAppImageData.src)) {
+      const authorizedSrc = await resolveAuthorizedCanvasLocalMediaSourceUrl(quickAppImageData.src)
+      return authorizedSrc ? { ...quickAppImageData, src: authorizedSrc } : null
+    }
     return quickAppImageData
   }
 

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/projectCanvasRenderBoundary.test.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/projectCanvasRenderBoundary.test.ts
@@ -206,9 +206,11 @@ describe('projectCanvasRenderBoundary', () => {
     const renderImage = buildProjectCanvasRenderableImage(createItem(), image)!
 
     expect(getProjectCanvasRenderTransformKey(renderImage)).toBe('12|34|100|80|1.5|0.75|15')
-    expect(getProjectCanvasRenderTextureKey(renderImage)).toBe(
-      'https://example.com/image.png|200|100|10|20|30|40'
+    const textureKey = getProjectCanvasRenderTextureKey(renderImage)
+    expect(textureKey).toMatch(
+      /^https:\/\/example\.com\/image\.png\|\d+\|200\|100\|10\|20\|30\|40$/
     )
+    expect(getProjectCanvasRenderTextureKey(renderImage)).toBe(textureKey)
   })
 
   it('resolves image runtime routes from crop and WebGL load state', () => {

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/projectCanvasRenderBoundary.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/projectCanvasRenderBoundary.ts
@@ -14,28 +14,15 @@ import { isCanvasItemTransientlyHidden } from './canvasTransientVisibility'
 
 export type ProjectCanvasRenderableMediaKind = 'image' | 'video' | 'model3d' | 'html'
 export type ProjectCanvasRenderableSurface =
-  | 'webgl-image'
-  | 'webgl-model3d-stage'
-  | 'html-video-overlay'
-  | 'html-overlay'
+  'webgl-image' | 'webgl-model3d-stage' | 'html-video-overlay' | 'html-overlay'
 export type ProjectCanvasImageRuntimeRoute =
-  | 'webgl-primary'
-  | 'budget-image-proxy'
-  | 'fallback-image-proxy'
-  | 'crop-excluded'
+  'webgl-primary' | 'budget-image-proxy' | 'fallback-image-proxy' | 'crop-excluded'
 export type ProjectCanvasImageInteractionMode =
-  | 'dom-image-overlay'
-  | 'placeholder-hit-proxy'
-  | 'crop-excluded'
+  'dom-image-overlay' | 'placeholder-hit-proxy' | 'crop-excluded'
 export type ProjectCanvasVideoBudgetMode =
-  | 'active-playing'
-  | 'visible-paused'
-  | 'poster-frame'
-  | 'unmounted'
+  'active-playing' | 'visible-paused' | 'poster-frame' | 'unmounted'
 export type ProjectCanvasInteractionProxy =
-  | 'canvas-image-node'
-  | 'canvas-placeholder'
-  | 'html-overlay'
+  'canvas-image-node' | 'canvas-placeholder' | 'html-overlay'
 
 export type ProjectCanvasBudgetedVideoItem = {
   item: CanvasVideoItem
@@ -54,11 +41,7 @@ export type ProjectCanvasVideoBudgetSummary = {
 export type ProjectCanvasResolvedRenderSurface = ProjectCanvasRenderableSurface | 'fallback-image'
 
 export type ProjectCanvasImageFallbackReason =
-  | 'unloaded'
-  | 'failed'
-  | 'unsupported'
-  | 'webgl-unavailable'
-  | 'generated-cooldown'
+  'unloaded' | 'failed' | 'unsupported' | 'webgl-unavailable' | 'generated-cooldown'
 
 export type ProjectCanvasResolvedRenderItem = ProjectCanvasRenderableItem & {
   runtimeSurface: ProjectCanvasResolvedRenderSurface
@@ -1000,13 +983,23 @@ export function getProjectCanvasRenderTransformKey(renderState: ProjectCanvasIma
   ].join('|')
 }
 
+const projectCanvasDecodedImageIdentities = new WeakMap<object, number>()
+
+let nextProjectCanvasDecodedImageIdentity = 1
+
 export function getProjectCanvasRenderTextureKey(
   item: Pick<ProjectCanvasRenderableImage, 'src' | 'image' | 'crop'>
 ): string {
   const { width: imageWidth, height: imageHeight } = getCanvasImageAssetSize(item.image)
+  let imageIdentity = projectCanvasDecodedImageIdentities.get(item.image as object)
+  if (imageIdentity === undefined) {
+    imageIdentity = nextProjectCanvasDecodedImageIdentity++
+    projectCanvasDecodedImageIdentities.set(item.image as object, imageIdentity)
+  }
 
   return [
     item.src,
+    imageIdentity,
     imageWidth,
     imageHeight,
     item.crop?.x ?? 0,

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/useCanvasAssetIntake.test.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/useCanvasAssetIntake.test.tsx
@@ -31,12 +31,17 @@ const hydrateCanvasImageItemForCanvasMock = vi.fn(async (itemOrArgs: unknown) =>
   return itemOrArgs
 })
 const authorizeCanvasLocalMediaSourceUrlMock = vi.fn<(file: File) => Promise<string | null>>()
+const resolveAuthorizedCanvasLocalMediaSourceUrlMock =
+  vi.fn<(sourceUrl: string) => Promise<string | null>>()
 
 vi.mock('./canvasLocalFileSource', async (importOriginal) => {
   const actual = await importOriginal<typeof import('./canvasLocalFileSource')>()
   return {
     ...actual,
-    authorizeCanvasLocalMediaSourceUrl: (file: File) => authorizeCanvasLocalMediaSourceUrlMock(file)
+    authorizeCanvasLocalMediaSourceUrl: (file: File) =>
+      authorizeCanvasLocalMediaSourceUrlMock(file),
+    resolveAuthorizedCanvasLocalMediaSourceUrl: (sourceUrl: string) =>
+      resolveAuthorizedCanvasLocalMediaSourceUrlMock(sourceUrl)
   }
 })
 
@@ -256,6 +261,7 @@ function SingleImageHarness({
 }
 
 afterEach(() => {
+  vi.unstubAllGlobals()
   vi.clearAllMocks()
 })
 
@@ -269,6 +275,17 @@ beforeEach(() => {
     return itemOrArgs
   })
   authorizeCanvasLocalMediaSourceUrlMock.mockResolvedValue(null)
+  resolveAuthorizedCanvasLocalMediaSourceUrlMock.mockImplementation(async (sourceUrl) => sourceUrl)
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL) => {
+      const sourceUrl = String(input)
+      if (sourceUrl.startsWith('local-media:')) {
+        return new Response(new Blob([new Uint8Array([1, 2, 3, 4])], { type: 'image/png' }))
+      }
+      return new Response(new Blob([new Uint8Array([1, 2, 3, 4])], { type: 'image/png' }))
+    }) as typeof fetch
+  )
   importCanvasFileMock.mockResolvedValue({
     items: [
       {
@@ -393,14 +410,18 @@ describe('useCanvasAssetIntake', () => {
       const source = {
         src: 'local-media:///C:/incoming/path-image.png',
         fileName: 'path-image.png',
-        sizeBytes: 4
-      } satisfies CanvasImageSourceInput
+        sizeBytes: 4,
+        sourcePath: String.raw`C:\incoming\hash#query?\literal%2F-%25-图像.png`
+      } satisfies CanvasImageSourceInput & { sourcePath: string }
       const onComplete = vi.fn()
       render(<LargeImageBatchHarness sources={[source]} onComplete={onComplete} />)
       await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1))
 
+      expect(resolveAuthorizedCanvasLocalMediaSourceUrlMock).toHaveBeenCalledWith(
+        'local-media:///C:/incoming/hash%23query%3F/literal%252F-%2525-%E5%9B%BE%E5%83%8F.png'
+      )
       expect(importFile).toHaveBeenCalledWith({
-        sourcePath: 'C:/incoming/path-image.png',
+        sourcePath: 'C:/incoming/hash#query?/literal%2F-%25-图像.png',
         mimeType: 'image/png',
         originalFileName: 'path-image.png'
       })
@@ -1168,7 +1189,7 @@ describe('useCanvasAssetIntake', () => {
       expect(result).toHaveLength(1)
       expect(imageItems).toHaveLength(1)
       expect(loadedSources).toHaveLength(0)
-      expect(fetchMock).toHaveBeenCalledWith(hugeSource.src)
+      expect(fetchMock).toHaveBeenCalledWith(hugeSource.src, { signal: undefined })
       expect(createImageBitmapMock).toHaveBeenCalledWith(previewBlob, {
         resizeWidth: 2048,
         resizeHeight: 1255,
@@ -1198,14 +1219,10 @@ describe('useCanvasAssetIntake', () => {
     }
   })
 
-  it('reads local-media deferred previews through svcFs when the file bridge is available', async () => {
-    const originalApi = window.api
+  it('streams authorized local-media deferred previews without svcFs byte IPC', async () => {
     const originalCreateImageBitmap = globalThis.createImageBitmap
     const originalFetch = globalThis.fetch
-    const readImageFromPath = vi.fn(async () => ({
-      image: new Uint8Array([1, 2, 3, 4]),
-      filename: 'huge-from-bridge.png'
-    }))
+    const previewBlob = new Blob([new Uint8Array([1, 2, 3, 4])], { type: 'image/png' })
     const previewBitmap = {
       width: 2048,
       height: 1255,
@@ -1214,17 +1231,8 @@ describe('useCanvasAssetIntake', () => {
     const createImageBitmapMock = vi.fn(
       async () => previewBitmap
     ) as unknown as typeof createImageBitmap
-    const fetchMock = vi.fn()
+    const fetchMock = vi.fn(async () => new Response(previewBlob))
 
-    Object.defineProperty(window, 'api', {
-      configurable: true,
-      writable: true,
-      value: {
-        svcFs: {
-          readImageFromPath
-        }
-      }
-    })
     Object.defineProperty(globalThis, 'createImageBitmap', {
       configurable: true,
       value: createImageBitmapMock
@@ -1255,11 +1263,9 @@ describe('useCanvasAssetIntake', () => {
 
       const [items] = onComplete.mock.calls[0] as [CanvasItem[], CanvasImageItem[]]
       const imageItems = items.filter((item): item is CanvasImageItem => item.type === 'image')
-      expect(readImageFromPath).toHaveBeenCalledWith({
-        fullPath: 'C:/real-board/huge-from-bridge.png'
-      })
-      expect(fetchMock).not.toHaveBeenCalled()
-      expect(createImageBitmapMock).toHaveBeenCalledWith(expect.any(Blob), {
+      expect(resolveAuthorizedCanvasLocalMediaSourceUrlMock).toHaveBeenCalledWith(hugeSource.src)
+      expect(fetchMock).toHaveBeenCalledWith(hugeSource.src, { signal: undefined })
+      expect(createImageBitmapMock).toHaveBeenCalledWith(expect.anything(), {
         resizeWidth: 2048,
         resizeHeight: 1255,
         resizeQuality: 'high',
@@ -1267,11 +1273,6 @@ describe('useCanvasAssetIntake', () => {
       })
       expect(imageItems[0].image).toBe(previewBitmap)
     } finally {
-      Object.defineProperty(window, 'api', {
-        configurable: true,
-        writable: true,
-        value: originalApi
-      })
       if (originalCreateImageBitmap) {
         Object.defineProperty(globalThis, 'createImageBitmap', {
           configurable: true,

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/useCanvasAssetIntake.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/useCanvasAssetIntake.ts
@@ -20,7 +20,8 @@ import { importCanvasFile } from './canvasStorage'
 import { resolveCanvas3DRenderActivationDelay } from './canvas3DRenderActivation'
 import {
   authorizeCanvasLocalMediaSourceUrl,
-  getCanvasLocalMediaSourceUrl
+  resolveAuthorizedCanvasLocalMediaSourceUrl,
+  toLocalMediaUrl
 } from './canvasLocalFileSource'
 import { readCanvasLocalImageBlobFromSource } from './canvasLocalImageSource'
 import {
@@ -202,7 +203,15 @@ async function importCanvasImageSourceToManagedMedia(
   source: NormalizedCanvasImageSource
 ): Promise<NormalizedCanvasImageSource> {
   const sourceFile = source.sourceFile
-  const sourcePath = source.sourcePath || resolveLocalMediaPathFromUrl(source.src) || ''
+  const requestedSourceUrl = source.sourcePath
+    ? toLocalMediaUrl(source.sourcePath) || ''
+    : source.src
+  const requestedSourcePath = resolveLocalMediaPathFromUrl(requestedSourceUrl) || ''
+  const sourcePath = requestedSourcePath
+    ? resolveLocalMediaPathFromUrl(
+        (await resolveAuthorizedCanvasLocalMediaSourceUrl(requestedSourceUrl)) || ''
+      ) || ''
+    : ''
   const managedMedia = typeof window !== 'undefined' ? window.api?.svcManagedMedia : undefined
   if ((!sourceFile && !sourcePath) || !managedMedia) return source
 
@@ -233,10 +242,7 @@ async function importCanvasImageSourceToManagedMedia(
 }
 
 export type CanvasImageBatchImportProgressPhase =
-  | 'preparing'
-  | 'loading'
-  | 'committing'
-  | 'complete'
+  'preparing' | 'loading' | 'committing' | 'complete'
 
 export type CanvasImageBatchImportProgress = {
   phase: CanvasImageBatchImportProgressPhase
@@ -875,15 +881,17 @@ export function useCanvasAssetIntake({
   const isMountedRef = useRef(true)
 
   useEffect(() => {
+    const transientHiddenCanvasItemIds = transientHiddenCanvasItemIdsRef.current
+    const ownedCanvasImageObjectUrls = ownedCanvasImageObjectUrlsRef.current
     isMountedRef.current = true
     return () => {
       isMountedRef.current = false
-      showCanvasItemsTransiently(transientHiddenCanvasItemIdsRef.current)
-      transientHiddenCanvasItemIdsRef.current.clear()
-      for (const objectUrl of ownedCanvasImageObjectUrlsRef.current) {
+      showCanvasItemsTransiently(transientHiddenCanvasItemIds)
+      transientHiddenCanvasItemIds.clear()
+      for (const objectUrl of ownedCanvasImageObjectUrls) {
         URL.revokeObjectURL(objectUrl)
       }
-      ownedCanvasImageObjectUrlsRef.current.clear()
+      ownedCanvasImageObjectUrls.clear()
     }
   }, [])
 
@@ -1957,7 +1965,15 @@ export function useCanvasAssetIntake({
         reportBundleManifestUrl?: CanvasFileItem['reportBundleManifestUrl']
       }
     ) => {
-      const src = getCanvasLocalMediaSourceUrl(file) || URL.createObjectURL(file)
+      const src = await authorizeCanvasLocalMediaSourceUrl(file)
+      if (!src) {
+        notifyError(
+          t('canvas.file_add_failed', {
+            defaultValue: 'This local file could not be authorized for persistent canvas use.'
+          })
+        )
+        return null
+      }
 
       try {
         const { resolveOfficeFileNodeData } = await import('./officePreviewUtils')
@@ -2267,7 +2283,8 @@ export function useCanvasAssetIntake({
           console.log('[Canvas] Resolved 3D source file:', file.name, '=>', extracted.sourcePath)
         }
 
-        const src = getCanvasLocalMediaSourceUrl(sourceFile) || URL.createObjectURL(sourceFile)
+        const src =
+          (await authorizeCanvasLocalMediaSourceUrl(sourceFile)) || URL.createObjectURL(sourceFile)
         const defaultSize = 400
         const pos = resolvePlacement({
           width: defaultSize,

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/useCanvasAssetIntake.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/useCanvasAssetIntake.ts
@@ -1965,15 +1965,7 @@ export function useCanvasAssetIntake({
         reportBundleManifestUrl?: CanvasFileItem['reportBundleManifestUrl']
       }
     ) => {
-      const src = await authorizeCanvasLocalMediaSourceUrl(file)
-      if (!src) {
-        notifyError(
-          t('canvas.file_add_failed', {
-            defaultValue: 'This local file could not be authorized for persistent canvas use.'
-          })
-        )
-        return null
-      }
+      const src = (await authorizeCanvasLocalMediaSourceUrl(file)) || URL.createObjectURL(file)
 
       try {
         const { resolveOfficeFileNodeData } = await import('./officePreviewUtils')

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/useCanvasCustomAddEvents.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/useCanvasCustomAddEvents.ts
@@ -93,13 +93,10 @@ export function useCanvasCustomAddEvents({
   handleAppendGenerationTraceCandidate
 }: UseCanvasCustomAddEventsOptions) {
   useEffect(() => {
-    const removeIpc = window.electron?.ipcRenderer?.on?.(
-      'canvas:add-image',
-      (_event: unknown, dataUrl: string) => {
-        console.log('[Canvas] Received image from floating window')
-        void addImageToCanvas(dataUrl)
-      }
-    )
+    const removeIpc = window.canvasScreenshot?.onAddImage((dataUrl) => {
+      console.log('[Canvas] Received image from floating window')
+      void addImageToCanvas(dataUrl)
+    })
 
     const handleCustomAdd = (event: Event) => {
       const detail = (

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/useCanvasFileIntake.test.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/useCanvasFileIntake.test.tsx
@@ -297,6 +297,15 @@ afterEach(() => {
 })
 
 beforeEach(() => {
+  Object.defineProperty(window, 'electronFile', {
+    configurable: true,
+    value: {
+      getPathForFile: (file: File) => (file as File & { path?: string }).path ?? '',
+      authorizeLocalMediaFile: async (file: File) => (file as File & { path?: string }).path ?? '',
+      resolveAuthorizedLocalMediaPath: async (filePath: string) => filePath
+    }
+  })
+
   const clipboardMock: ClipboardMock = {
     read: vi.fn().mockResolvedValue([]),
     readText: vi.fn().mockResolvedValue('')
@@ -1329,7 +1338,11 @@ describe('useCanvasFileIntake', () => {
 
     Object.defineProperty(window, 'electronFile', {
       configurable: true,
-      value: { getPathForFile }
+      value: {
+        getPathForFile,
+        authorizeLocalMediaFile: async (file: File) => getPathForFile(file),
+        resolveAuthorizedLocalMediaPath: async (filePath: string) => filePath
+      }
     })
 
     render(

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/useCanvasMediaAssetIntake.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/useCanvasMediaAssetIntake.ts
@@ -85,22 +85,6 @@ const VIDEO_FALLBACK_WIDTH = 480
 const VIDEO_FALLBACK_HEIGHT = 270
 const VIDEO_MAX_SIDE = 600
 
-type ElectronCanvasFile = File & {
-  path?: string
-}
-
-function getCanvasLocalMediaSourceUrl(file: File): string | null {
-  const filePath =
-    typeof (file as ElectronCanvasFile).path === 'string'
-      ? (file as ElectronCanvasFile).path!.replace(/\\/g, '/')
-      : ''
-  if (!filePath) {
-    return null
-  }
-
-  return normalizeLocalMediaUrl(`file://${filePath}`)
-}
-
 function measureCanvasTextBox(text: string): { width: number; height: number } {
   return measureCanvasTextBoxSize({
     text,
@@ -185,7 +169,8 @@ export function useCanvasMediaAssetIntake({
           console.log('[Canvas] Resolved 3D source file:', file.name, '=>', extracted.sourcePath)
         }
 
-        const src = getCanvasLocalMediaSourceUrl(sourceFile) || URL.createObjectURL(sourceFile)
+        const src =
+          (await authorizeCanvasLocalMediaSourceUrl(sourceFile)) || URL.createObjectURL(sourceFile)
         const pos = getCenterPosition(MODEL_DEFAULT_SIZE, MODEL_DEFAULT_SIZE)
         const assetCount = linkedAssets ? Object.keys(linkedAssets).length : 0
 
@@ -193,6 +178,7 @@ export function useCanvasMediaAssetIntake({
           id: createCanvasItemId('model'),
           src,
           fileName: sourceFile.name,
+          sourceFile,
           ...(assetCount > 0 ? { textures: linkedAssets } : {}),
           x: pos.x,
           y: pos.y,

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/useCanvasScreenshotShortcutSync.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/useCanvasScreenshotShortcutSync.ts
@@ -22,7 +22,15 @@ export type UseCanvasScreenshotShortcutSyncOptions = {
 }
 
 function getDefaultScreenshotShortcutInvoke(): ScreenshotShortcutInvoke | undefined {
-  return window.electron?.ipcRenderer?.invoke as ScreenshotShortcutInvoke | undefined
+  const bridge = window.canvasScreenshot
+  if (!bridge) return undefined
+
+  return (channel, ...args) => {
+    if (channel === 'screenshot:getShortcut') {
+      return bridge.getShortcut()
+    }
+    return bridge.setShortcut(String(args[0] ?? ''), args[1])
+  }
 }
 
 export function useCanvasScreenshotShortcutSync({
@@ -39,8 +47,7 @@ export function useCanvasScreenshotShortcutSync({
     void (async () => {
       try {
         const result = (await invoke('screenshot:getShortcut')) as
-          | { shortcut?: unknown }
-          | undefined
+          { shortcut?: unknown } | undefined
         const activeShortcut = toDisplayShortcut(
           typeof result?.shortcut === 'string' ? result.shortcut : DEFAULT_SCREENSHOT_SHORTCUT
         )

--- a/packages/app/src/renderer/src/pages/QuickAppPage/components/QAppMenu.tsx
+++ b/packages/app/src/renderer/src/pages/QuickAppPage/components/QAppMenu.tsx
@@ -1040,25 +1040,12 @@ export default function QAppMenu({
     window.addEventListener('qapp:refresh-list', handleRefreshList)
 
     // 监听主进程文件系统变更通知（用户在资源管理器中删除/添加快应用文件时触发）
-    const ipc = (
-      window as {
-        electron?: {
-          ipcRenderer?: {
-            on?: (channel: string, listener: () => void) => void
-            removeListener?: (channel: string, listener: () => void) => void
-          }
-        }
-      }
-    ).electron?.ipcRenderer
-    if (typeof ipc?.on === 'function') {
-      ipc.on('qapp:dir-changed', handleRefreshList)
-    }
+    const removeDirectoryChangedListener =
+      window.appEvents?.onQAppDirectoryChanged(handleRefreshList)
 
     return () => {
       window.removeEventListener('qapp:refresh-list', handleRefreshList)
-      if (typeof ipc?.removeListener === 'function') {
-        ipc.removeListener('qapp:dir-changed', handleRefreshList)
-      }
+      removeDirectoryChangedListener?.()
     }
   }, [refreshTabs])
 

--- a/packages/app/src/renderer/src/utils/droppedImageUtils.test.ts
+++ b/packages/app/src/renderer/src/utils/droppedImageUtils.test.ts
@@ -8,6 +8,7 @@ const { loadImageFromSrcMock } = vi.hoisted(() => ({
 }))
 const originalGetContext = HTMLCanvasElement.prototype.getContext
 const originalToDataURL = HTMLCanvasElement.prototype.toDataURL
+const originalElectronFile = window.electronFile
 
 vi.mock('./windowUtils', () => ({
   api: () => ({
@@ -56,6 +57,13 @@ describe('droppedImageUtils', () => {
     loadImageFromSrcMock.mockReset()
     HTMLCanvasElement.prototype.getContext = originalGetContext
     HTMLCanvasElement.prototype.toDataURL = originalToDataURL
+    Object.defineProperty(window, 'electronFile', {
+      configurable: true,
+      value: {
+        authorizeLocalMediaFile: vi.fn(async () => ''),
+        resolveAuthorizedLocalMediaPath: vi.fn(async (filePath: string) => filePath)
+      }
+    })
     vi.unstubAllGlobals()
     vi.stubGlobal(
       'FileReader',
@@ -522,7 +530,12 @@ describe('droppedImageUtils', () => {
     expect(file?.size).toBe(4)
   })
 
-  it('loads agent local-media drags through the fs service', async () => {
+  it('loads agent local-media drags only after the preload bridge revalidates the path', async () => {
+    const resolveAuthorizedLocalMediaPath = vi.fn(async () => 'C:/demo/agent.png')
+    Object.defineProperty(window, 'electronFile', {
+      configurable: true,
+      value: { resolveAuthorizedLocalMediaPath }
+    })
     readImageFromPathMock.mockResolvedValue({
       image: new Uint8Array([9, 8, 7]),
       filename: 'agent.png'
@@ -534,11 +547,55 @@ describe('droppedImageUtils', () => {
       })
     )
 
+    expect(resolveAuthorizedLocalMediaPath).toHaveBeenCalledWith('C:/demo/agent.png')
     expect(readImageFromPathMock).toHaveBeenCalledWith({
       fullPath: 'C:/demo/agent.png'
     })
     expect(file?.name).toBe('agent.png')
     expect(file?.type).toBe('image/png')
+  })
+
+  it('rejects persisted external local paths when preload cannot revalidate them', async () => {
+    const resolveAuthorizedLocalMediaPath = vi.fn(async () => '')
+    Object.defineProperty(window, 'electronFile', {
+      configurable: true,
+      value: { resolveAuthorizedLocalMediaPath }
+    })
+
+    await expect(
+      getDroppedImageFile(
+        createDataTransfer({
+          [AGENT_IMAGE_DRAG_MIME]: 'local-media:///C:/external/legacy.png'
+        })
+      )
+    ).rejects.toThrow('Local image path is not authorized')
+    expect(resolveAuthorizedLocalMediaPath).toHaveBeenCalledWith('C:/external/legacy.png')
+    expect(readImageFromPathMock).not.toHaveBeenCalled()
+  })
+
+  it('revalidates persisted app-root local paths after restart before reading them', async () => {
+    const resolveAuthorizedLocalMediaPath = vi.fn(
+      async () => 'C:/MagicPot/Data/.chat_media/legacy.png'
+    )
+    Object.defineProperty(window, 'electronFile', {
+      configurable: true,
+      value: { resolveAuthorizedLocalMediaPath }
+    })
+    readImageFromPathMock.mockResolvedValue({
+      image: new Uint8Array([4, 5, 6]),
+      filename: 'legacy.png'
+    })
+
+    const file = await getDroppedImageFile(
+      createDataTransfer({
+        [AGENT_IMAGE_DRAG_MIME]: 'local-media:///C:/MagicPot/Data/.chat_media/legacy.png'
+      })
+    )
+
+    expect(readImageFromPathMock).toHaveBeenCalledWith({
+      fullPath: 'C:/MagicPot/Data/.chat_media/legacy.png'
+    })
+    expect(file?.name).toBe('legacy.png')
   })
 
   it('recrops lightweight internal canvas image attachments from the original source', async () => {
@@ -897,12 +954,18 @@ describe('droppedImageUtils', () => {
     ).toBeNull()
   })
 
-  it('accepts OS file drops whose image file has an empty MIME type', async () => {
+  it('authorizes native OS image Files through preload without requiring a renderer path', async () => {
+    const authorizeLocalMediaFile = vi.fn(async () => 'C:/drop/folder-photo.JPG')
+    Object.defineProperty(window, 'electronFile', {
+      configurable: true,
+      value: { authorizeLocalMediaFile }
+    })
     const file = new File(['image-bytes'], 'folder-photo.JPG', { type: '' })
     const dataTransfer = createDataTransfer({}, [file])
 
     expect(getDroppedImageDropError(dataTransfer)).toBeNull()
     await expect(getDroppedImageFile(dataTransfer)).resolves.toBe(file)
+    expect(authorizeLocalMediaFile).toHaveBeenCalledWith(file)
   })
 
   it('rejects unsupported files for image-only drops with a specific message', () => {

--- a/packages/app/src/renderer/src/utils/droppedImageUtils.ts
+++ b/packages/app/src/renderer/src/utils/droppedImageUtils.ts
@@ -13,6 +13,7 @@ import {
   normalizeLocalMediaUrl
 } from '@renderer/pages/ChatPage/chatPageShared'
 import { loadImageFromSrc } from '@renderer/pages/ProjectCanvasPage/canvasAssetIntakeHelpers'
+import { resolveCanvasLocalFilePathFromSource } from '@renderer/pages/ProjectCanvasPage/canvasLocalImageSource'
 import { stripHtmlToText } from './htmlText'
 
 export const QAPP_IMAGE_DRAG_MIME = 'application/x-qapp-image'
@@ -472,25 +473,8 @@ export const getDroppedImageUrl = (dataTransfer: DragDataReader): string | null 
   return null
 }
 
-const decodeLocalImagePath = (url: string): string | null => {
-  if (url.startsWith('local-media:///')) {
-    return decodeURIComponent(url.slice('local-media:///'.length))
-  }
-
-  if (url.startsWith('local-media://')) {
-    return decodeURIComponent(url.slice('local-media://'.length).replace(/^\/+/, ''))
-  }
-
-  if (url.startsWith('file:///')) {
-    return decodeURIComponent(url.slice('file:///'.length))
-  }
-
-  if (url.startsWith('file://')) {
-    return decodeURIComponent(url.slice('file://'.length).replace(/^\/+/, ''))
-  }
-
-  return null
-}
+const decodeLocalImagePath = (url: string): string | null =>
+  resolveCanvasLocalFilePathFromSource(url)
 
 const inferMimeTypeFromFileName = (fileName: string): string =>
   getImageMimeTypeFromFileName(fileName) || 'image/png'
@@ -516,10 +500,34 @@ const inferFileNameFromUrl = (url: string, fallback: string): string => {
   }
 }
 
+const resolveAuthorizedDroppedLocalPath = async (url: string): Promise<string | null> => {
+  const localPath = decodeLocalImagePath(url)
+  if (!localPath || typeof window === 'undefined') return null
+
+  try {
+    return (await window.electronFile?.resolveAuthorizedLocalMediaPath?.(localPath)) || null
+  } catch {
+    return null
+  }
+}
+
+const authorizeNativeDroppedImageFile = async (file: File): Promise<void> => {
+  if (typeof window === 'undefined') return
+  try {
+    await window.electronFile?.authorizeLocalMediaFile?.(file)
+  } catch {
+    // The File payload remains usable in browser-only and degraded preload environments.
+  }
+}
+
 const loadImageFileFromUrl = async (url: string, fallbackFileName: string): Promise<File> => {
   const localPath = decodeLocalImagePath(url)
   if (localPath) {
-    const { image, filename } = await api().svcFs.readImageFromPath({ fullPath: localPath })
+    const authorizedPath = await resolveAuthorizedDroppedLocalPath(url)
+    if (!authorizedPath) {
+      throw new Error('Local image path is not authorized')
+    }
+    const { image, filename } = await api().svcFs.readImageFromPath({ fullPath: authorizedPath })
     const fileName = filename || fallbackFileName
     return new File([image as BlobPart], fileName, {
       type: inferMimeTypeFromFileName(fileName)
@@ -828,7 +836,10 @@ export const getDroppedImageFile = async (
 ): Promise<File | null> => {
   const droppedFiles = Array.from(dataTransfer.files ?? [])
   const imageFile = droppedFiles.find((file) => isSupportedImageDropFile(file, options))
-  if (imageFile) return imageFile
+  if (imageFile) {
+    await authorizeNativeDroppedImageFile(imageFile)
+    return imageFile
+  }
 
   const internalPayload = parseInternalImageDragPayload(dataTransfer)
   if (internalPayload) {

--- a/packages/app/src/shared/agent/dispatchContracts.ts
+++ b/packages/app/src/shared/agent/dispatchContracts.ts
@@ -1,0 +1,190 @@
+export type JsonPrimitive = string | number | boolean | null
+
+export type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue }
+
+export type AgentProvenance = {
+  source: string
+  requestedBy?: string
+  channel?: string
+  traceId?: string
+}
+
+export type AgentDispatchContext = {
+  correlationId?: string
+  sessionId?: string
+  agentId?: string
+  provenance?: AgentProvenance
+}
+
+export type AgentEvent<TPayload extends JsonValue = JsonValue> = AgentDispatchContext & {
+  eventId: string
+  type: string
+  payload: TPayload
+  createdAt: number
+}
+
+export type AgentAction<TPayload extends JsonValue = JsonValue> = AgentDispatchContext & {
+  actionId: string
+  type: string
+  payload: TPayload
+}
+
+export type JsonObject = { [key: string]: JsonValue }
+
+export type ToolInvokePayload = {
+  invocationId: string
+  toolName: string
+  args: JsonObject
+  requestedAt: number
+  idempotencyKey: string
+}
+export type ToolInvokeAction = AgentAction<ToolInvokePayload> & { type: 'tool.invoke' }
+
+export type ToolResultPayload = {
+  invocationId: string
+  toolName: string
+  ok: boolean
+  content?: string
+  metadata?: JsonObject
+  error?: { message: string; code?: string }
+  startedAt: number
+  finishedAt: number
+  durationMs: number
+}
+export type ToolResultAction = AgentAction<ToolResultPayload> & { type: 'tool.result' }
+
+export type ReplyEmitPayload<TResponse extends JsonValue = JsonValue> = { response: TResponse }
+export type ReplyEmitAction<TResponse extends JsonValue = JsonValue> = AgentAction<
+  ReplyEmitPayload<TResponse>
+> & { type: 'reply.emit' }
+
+export type DriveProgressEvidence = {
+  kind: 'session' | 'run' | 'artifact' | 'url' | 'text'
+  ref: string
+  digest?: string
+}
+export type DriveProgressPayload = {
+  driveId: string
+  expectedRevision: number
+  summary: string
+  evidence: DriveProgressEvidence[]
+  reportedAt: number
+  idempotencyKey: string
+}
+export type DriveProgressAction = AgentAction<DriveProgressPayload> & { type: 'drive.progress' }
+
+export type MessagePublishPayload = {
+  channelId: string
+  publisherMemberId: string
+  messageId: string
+  payload: JsonValue
+  priority: number
+  publishedAt: number
+  expiresAt?: number
+  expectedChannelRevision: number
+  idempotencyKey: string
+}
+export type MessagePublishAction = AgentAction<MessagePublishPayload> & {
+  type: 'message.publish'
+}
+
+type ChildStartInstance = {
+  id: string
+  name: string
+  definitionId: string
+  ownerId?: string
+  configVersion: string
+  pendingConfigVersion?: string
+  previousConfigVersion?: string
+  configActivatedAt?: number
+  limits: {
+    maxChildren: number
+    maxDepth: number
+    maxConcurrency: number
+    maxRuntimeMs: number
+    allowedToolNames: string[]
+    workspaceRoots: string[]
+  }
+  runtimeTopologyAttribution?: JsonValue
+}
+
+export type ChildStartPayload = {
+  parentInstanceId: string
+  parentExpectedRevision: number
+  child: ChildStartInstance
+  createdAt: number
+  idempotencyKey: string
+}
+export type ChildStartAction = AgentAction<ChildStartPayload> & { type: 'child.start' }
+
+export const createReplyEmitAction = <TResponse extends JsonValue>(
+  action: Omit<ReplyEmitAction<TResponse>, 'type'>
+): ReplyEmitAction<TResponse> => ({ ...action, type: 'reply.emit' })
+
+export const createDriveProgressAction = (
+  action: Omit<DriveProgressAction, 'type'>
+): DriveProgressAction => ({ ...action, type: 'drive.progress' })
+
+export const createMessagePublishAction = (
+  action: Omit<MessagePublishAction, 'type'>
+): MessagePublishAction => ({ ...action, type: 'message.publish' })
+
+export const createChildStartAction = (
+  action: Omit<ChildStartAction, 'type'>
+): ChildStartAction => ({ ...action, type: 'child.start' })
+
+const assertJsonObject: (value: unknown, label: string) => asserts value is JsonObject = (
+  value,
+  label
+) => {
+  if (!isJsonValue(value) || Array.isArray(value) || value === null) {
+    throw new TypeError(`${label} must be a JSON object.`)
+  }
+}
+
+export const createToolInvokeAction = (
+  action: Omit<ToolInvokeAction, 'type'>
+): ToolInvokeAction => {
+  assertJsonObject(action.payload.args, 'Tool invocation args')
+  return { ...action, type: 'tool.invoke' }
+}
+
+export const createToolResultAction = (
+  action: Omit<ToolResultAction, 'type'>
+): ToolResultAction => {
+  if (action.payload.metadata !== undefined) {
+    assertJsonObject(action.payload.metadata, 'Tool result metadata')
+  }
+  return { ...action, type: 'tool.result' }
+}
+
+export type AgentActionHandlerContext = {
+  signal: AbortSignal
+}
+
+export type AgentActionHandler = (
+  event: AgentEvent,
+  context: AgentActionHandlerContext
+) => AsyncIterable<AgentAction>
+
+export const actionsFromArray = (
+  actions: readonly AgentAction[] | Promise<readonly AgentAction[]>
+): AsyncIterable<AgentAction> => ({
+  async *[Symbol.asyncIterator]() {
+    yield* await actions
+  }
+})
+
+export const isJsonValue = (value: unknown, seen = new Set<object>()): value is JsonValue => {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') return true
+  if (typeof value === 'number') return Number.isFinite(value)
+  if (typeof value !== 'object' || seen.has(value)) return false
+
+  seen.add(value)
+  const valid = Array.isArray(value)
+    ? value.every((entry) => isJsonValue(entry, seen))
+    : Object.getPrototypeOf(value) === Object.prototype &&
+      Object.values(value).every((entry) => isJsonValue(entry, seen))
+  seen.delete(value)
+  return valid
+}

--- a/packages/app/src/shared/agent/index.ts
+++ b/packages/app/src/shared/agent/index.ts
@@ -1,4 +1,5 @@
 export * from './capabilityRegistry'
+export * from './dispatchContracts'
 export * from './orchestrationContracts'
 export * from './sessionIdentity'
 export * from './toolContracts'

--- a/packages/app/src/shared/utils/utilWindow.ts
+++ b/packages/app/src/shared/utils/utilWindow.ts
@@ -58,6 +58,23 @@ export type UnsavedSaveResult = {
   error?: string
 }
 
+export type CanvasScreenshotBridge = {
+  capture: () => Promise<unknown>
+  getShortcut: () => Promise<unknown>
+  setShortcut: (accelerator: string, reservedShortcuts?: unknown) => Promise<unknown>
+  selectRegion: (region: { x: number; y: number; w: number; h: number }) => void
+  cancelSelection: () => void
+  setFloatingOpacity: (windowId: string, opacity: number) => void
+  closeFloatingWindow: (windowId: string) => void
+  sendFloatingToCanvas: (windowId: string) => void
+  onAddImage: (cb: (dataUrl: string) => void) => () => void
+}
+
+export type AppEventBridge = {
+  onCloseActiveTab: (cb: () => void) => () => void
+  onQAppDirectoryChanged: (cb: () => void) => () => void
+}
+
 export type WinBridge = {
   minimize: () => Promise<void>
   toggleMaximize: () => Promise<void>


### PR DESCRIPTION
## Summary

- add replayable agent-kernel dispatch contracts and controlled assistant actions
- validate trusted dispatch contexts across agent platform lifecycle work
- expose narrow local-media bridges and consume granted media sources in canvas flows
- share decoded/GPU image resources and clone 3D scenes with explicit shared ownership
- preserve pathless file imports and align renderer resource lifecycle regression coverage
- serialize overlapping ComfyUI startup requests to prevent duplicate process spawning

## Commit structure

The agent and media implementation remains split into focused, reviewable commits. Follow-up fixes and regression tests are separate commits; the original eight split commits were not rewritten.

## Verification

- `npm run typecheck`
- affected Node and Web test suites
- focused canvas CI regressions
- `packages/app/src/main/api/svcHyperImpl.test.ts`
- GitHub build, security, CodeQL, lint, typecheck, and full tests are the merge gate
