### PR TITLE
fix(canvas): guard scene clone prototype keys

### DIFF
--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/modelLoaders/sceneInstanceCloneCache.test.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/modelLoaders/sceneInstanceCloneCache.test.ts
@@ -92,6 +92,27 @@ describe('sceneInstanceCloneCache', () => {
     expect(clonedMaterial.uniforms.nested.value.texture).toBe(texture)
   })
 
+  it('does not copy prototype-mutating material keys while restoring shared textures', () => {
+    const texture = new THREE.Texture()
+    const material = new THREE.MeshBasicMaterial()
+    const expectedPrototype = THREE.MeshBasicMaterial.prototype
+    vi.spyOn(material, 'clone').mockReturnValue(new THREE.MeshBasicMaterial())
+    Object.defineProperties(material, {
+      __proto__: { value: texture, enumerable: true, configurable: true },
+      constructor: { value: texture, enumerable: true, configurable: true },
+      prototype: { value: texture, enumerable: true, configurable: true }
+    })
+
+    const clone = cloneSceneInstanceAsset(
+      new THREE.Mesh(new THREE.BoxGeometry(), material)
+    ) as THREE.Mesh
+    const clonedMaterial = clone.material as THREE.MeshBasicMaterial
+
+    expect(Object.getPrototypeOf(clonedMaterial)).toBe(expectedPrototype)
+    expect(Object.prototype.hasOwnProperty.call(clonedMaterial, 'constructor')).toBe(false)
+    expect(Object.prototype.hasOwnProperty.call(clonedMaterial, 'prototype')).toBe(false)
+  })
+
   it('isolates every material-array entry while retaining intra-instance sharing', () => {
     const geometry = new THREE.BoxGeometry()
     const sharedMaterial = new THREE.MeshStandardMaterial()

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/modelLoaders/sceneInstanceCloneCache.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/modelLoaders/sceneInstanceCloneCache.ts
@@ -58,6 +58,8 @@ export function cloneSceneInstanceAsset(
     const originalRecord = originalValue as Record<string, unknown>
     const clonedRecord = clonedValue as Record<string, unknown>
     Object.keys(originalRecord).forEach((key) => {
+      if (key === '__proto__' || key === 'constructor' || key === 'prototype') return
+
       const originalChild = originalRecord[key]
       if ((originalChild as THREE.Texture | undefined)?.isTexture) {
         clonedRecord[key] = originalChild


### PR DESCRIPTION
## Summary

- skip `__proto__`, `constructor`, and `prototype` while restoring shared texture references
- add a regression test with hostile enumerable material properties
- address CodeQL alert #54 from PR #80

## Verification

- `npx vitest run --config config/vitest/vitest.web.config.mjs packages/app/src/renderer/src/pages/ProjectCanvasPage/components/modelLoaders/sceneInstanceCloneCache.test.ts --pool=forks --maxWorkers=1`
- `npm run typecheck:web`
- targeted ESLint
- `git diff --check`

Co-Authored-By: KohakuTerrarium <noreply@kohaku-lab.org>