### PR TITLE
fix(release): validate nightly candidate packaging

### DIFF
--- a/.github/workflows/call-embedded-candidate.yml
+++ b/.github/workflows/call-embedded-candidate.yml
@@ -1,0 +1,135 @@
+name: Embedded Candidate
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: The exact release candidate ref to validate
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  validate-windows-embedded:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout candidate
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          submodules: recursive
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.node-version'
+          cache: 'npm'
+
+      - name: Cache Electron
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/AppData/Local/electron/
+            ~/AppData/Local/electron-builder/
+          key: ${{ runner.os }}-electron-cache-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-electron-cache-
+
+      - name: Install dependencies
+        run: npm ci --prefer-offline --no-audit
+
+      - name: Cache embedded Python downloads
+        uses: actions/cache@v4
+        with:
+          path: .cache/embedded-python
+          key: ${{ runner.os }}-embedded-python-${{ hashFiles('scripts/prepare-embedded-python.mjs') }}
+          restore-keys: |
+            ${{ runner.os }}-embedded-python-
+
+      - name: Build embedded candidate
+        env:
+          PIP_NO_CACHE_DIR: '1'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
+
+          Get-PSDrive -Name C | Select-Object Name,Used,Free
+          Write-Host '::group::Build embedded app'
+          npm run build:embedded
+          Write-Host '::endgroup::'
+          Write-Host '::group::Prepare embedded runtime'
+          npm run prepare:embedded
+          Write-Host '::endgroup::'
+          Write-Host '::group::Build image worker'
+          npm run build:image-worker
+          Write-Host '::endgroup::'
+
+          $env:PACKAGE_MODE = 'embedded'
+          Remove-Item Env:GH_TOKEN -ErrorAction SilentlyContinue
+          Remove-Item Env:GITHUB_TOKEN -ErrorAction SilentlyContinue
+          npx electron-builder --config config/electron/electron-builder.config.js --win --x64 --publish never
+
+          $portableRoot = Join-Path $PWD 'dist\embedded\win-unpacked\ComfyUI_windows_portable'
+          $requiredPortableFiles = @(
+            'advanced\run_nvidia_gpu_disable_api_nodes.bat',
+            'update\current_requirements.txt',
+            'update\update.py',
+            'update\update_comfyui.bat',
+            'update\update_comfyui_and_python_dependencies.bat',
+            'update\update_comfyui_stable.bat',
+            'run_cpu.bat',
+            'run_nvidia_gpu.bat',
+            'run_nvidia_gpu_fast_fp16_accumulation.bat'
+          )
+          $missingPortableFiles = @(
+            $requiredPortableFiles | Where-Object {
+              -not (Test-Path -LiteralPath (Join-Path $portableRoot $_) -PathType Leaf)
+            }
+          )
+          if ($missingPortableFiles.Count -gt 0) {
+            throw "Embedded package is missing required ComfyUI portable files: $($missingPortableFiles -join ', ')"
+          }
+
+      - name: Collect embedded candidate diagnostics
+        if: ${{ always() }}
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Continue'
+          $diagnosticsDir = 'dist/embedded-candidate-diagnostics'
+          New-Item -ItemType Directory -Force -Path $diagnosticsDir | Out-Null
+
+          Get-PSDrive -Name C |
+            Select-Object Name,Used,Free |
+            Format-List |
+            Out-File (Join-Path $diagnosticsDir 'disk-usage.txt')
+
+          foreach ($source in @(
+            '.staging/embedded/custom-node-requirements.json',
+            '.staging/embedded/constraints.txt'
+          )) {
+            if (Test-Path -LiteralPath $source) {
+              Copy-Item -LiteralPath $source -Destination $diagnosticsDir
+            }
+          }
+
+          $python = '.staging/embedded/python_embeded/python.exe'
+          if (Test-Path -LiteralPath $python) {
+            & $python -s -m pip list --format=freeze 2>&1 |
+              Out-File (Join-Path $diagnosticsDir 'pip-list.txt')
+            $global:LASTEXITCODE = 0
+            & $python -s -m pip check 2>&1 |
+              Out-File (Join-Path $diagnosticsDir 'pip-check.txt')
+            $global:LASTEXITCODE = 0
+          }
+
+      - name: Upload embedded candidate diagnostics
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: embedded-candidate-diagnostics
+          path: dist/embedded-candidate-diagnostics
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/call-release.yml
+++ b/.github/workflows/call-release.yml
@@ -60,13 +60,22 @@ jobs:
             ${{ runner.os }}-embedded-python-
 
       - name: Build embedded package
+        env:
+          PIP_NO_CACHE_DIR: '1'
         run: |
           $ErrorActionPreference = 'Stop'
           $PSNativeCommandUseErrorActionPreference = $true
 
+          Get-PSDrive -Name C | Select-Object Name,Used,Free
+          Write-Host '::group::Build embedded app'
           npm run build:embedded
+          Write-Host '::endgroup::'
+          Write-Host '::group::Prepare embedded runtime'
           npm run prepare:embedded
+          Write-Host '::endgroup::'
+          Write-Host '::group::Build image worker'
           npm run build:image-worker
+          Write-Host '::endgroup::'
           $env:PACKAGE_MODE = 'embedded'
           # Keep electron-builder in package-only mode even when Actions exposes repository tokens.
           Remove-Item Env:GH_TOKEN -ErrorAction SilentlyContinue
@@ -93,6 +102,48 @@ jobs:
           if ($missingPortableFiles.Count -gt 0) {
             throw "Embedded package is missing required ComfyUI portable files: $($missingPortableFiles -join ', ')"
           }
+
+      - name: Collect embedded build diagnostics
+        if: ${{ always() }}
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Continue'
+          $diagnosticsDir = 'dist/embedded-diagnostics'
+          New-Item -ItemType Directory -Force -Path $diagnosticsDir | Out-Null
+
+          Get-PSDrive -Name C |
+            Select-Object Name,Used,Free |
+            Format-List |
+            Out-File (Join-Path $diagnosticsDir 'disk-usage.txt')
+
+          $requirementsManifest = '.staging/embedded/custom-node-requirements.json'
+          if (Test-Path -LiteralPath $requirementsManifest) {
+            Copy-Item -LiteralPath $requirementsManifest -Destination $diagnosticsDir
+          }
+
+          $constraints = '.staging/embedded/constraints.txt'
+          if (Test-Path -LiteralPath $constraints) {
+            Copy-Item -LiteralPath $constraints -Destination $diagnosticsDir
+          }
+
+          $python = '.staging/embedded/python_embeded/python.exe'
+          if (Test-Path -LiteralPath $python) {
+            & $python -s -m pip list --format=freeze 2>&1 |
+              Out-File (Join-Path $diagnosticsDir 'pip-list.txt')
+            $global:LASTEXITCODE = 0
+            & $python -s -m pip check 2>&1 |
+              Out-File (Join-Path $diagnosticsDir 'pip-check.txt')
+            $global:LASTEXITCODE = 0
+          }
+
+      - name: Upload embedded build diagnostics
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: embedded-build-diagnostics
+          path: dist/embedded-diagnostics
+          if-no-files-found: warn
+          retention-days: 14
 
       - name: Build pure package
         run: |

--- a/.github/workflows/nightly-bump-version.yml
+++ b/.github/workflows/nightly-bump-version.yml
@@ -53,7 +53,7 @@ jobs:
                 echo "release_mode=retry" >> "$GITHUB_OUTPUT"
                 echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
                 echo "release_name=$RELEASE_NAME" >> "$GITHUB_OUTPUT"
-                echo "ref=refs/heads/master" >> "$GITHUB_OUTPUT"
+                echo "ref=$LAST_RELEASE_COMMIT" >> "$GITHUB_OUTPUT"
                 exit 0
               else
                 IS_DRAFT=$(echo "$RELEASE_JSON" | jq -r '.isDraft')
@@ -73,7 +73,7 @@ jobs:
                   echo "release_mode=retry" >> "$GITHUB_OUTPUT"
                   echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
                   echo "release_name=$RELEASE_NAME" >> "$GITHUB_OUTPUT"
-                  echo "ref=refs/heads/master" >> "$GITHUB_OUTPUT"
+                  echo "ref=$LAST_RELEASE_COMMIT" >> "$GITHUB_OUTPUT"
                   exit 0
                 fi
               fi
@@ -225,9 +225,44 @@ jobs:
 
           echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
 
-  release:
+  candidate-ci:
     needs: bump-version
     if: needs.bump-version.result == 'success'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/call-ci.yml
+    with:
+      ref: ${{ needs.bump-version.outputs.ref }}
+
+  candidate-build:
+    needs: bump-version
+    if: needs.bump-version.result == 'success'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/call-build.yml
+    with:
+      ref: ${{ needs.bump-version.outputs.ref }}
+
+  candidate-embedded:
+    needs: bump-version
+    if: needs.bump-version.result == 'success'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/call-embedded-candidate.yml
+    with:
+      ref: ${{ needs.bump-version.outputs.ref }}
+
+  release:
+    needs:
+      - bump-version
+      - candidate-ci
+      - candidate-build
+      - candidate-embedded
+    if: >-
+      needs.bump-version.result == 'success' &&
+      needs.candidate-ci.result == 'success' &&
+      needs.candidate-build.result == 'success' &&
+      needs.candidate-embedded.result == 'success'
     uses: ./.github/workflows/call-release.yml
     with:
       tag_name: ${{ needs.bump-version.outputs.tag_name }}
@@ -259,9 +294,22 @@ jobs:
             --subject "${{ needs.bump-version.outputs.commit_message }}" \
             --body ""
 
-  release-existing:
+  retry-candidate-embedded:
     needs: check-commits
     if: needs.check-commits.outputs.release_mode == 'retry'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/call-embedded-candidate.yml
+    with:
+      ref: ${{ needs.check-commits.outputs.ref }}
+
+  release-existing:
+    needs:
+      - check-commits
+      - retry-candidate-embedded
+    if: >-
+      needs.check-commits.outputs.release_mode == 'retry' &&
+      needs.retry-candidate-embedded.result == 'success'
     uses: ./.github/workflows/call-release.yml
     with:
       tag_name: ${{ needs.check-commits.outputs.tag_name }}


### PR DESCRIPTION
## Summary

- validate the exact generated release commit with CI, pure build, and Windows embedded packaging before publishing
- pin retry releases to the original release commit instead of a moving `master` ref
- collect disk, constraints, custom-node requirements, `pip list`, and `pip check` diagnostics after embedded builds
- disable pip caching during hosted Windows embedded builds to reduce peak disk pressure

## Context

Addresses the release workflow gap exposed by [Nightly Bump Version run 31331533079](https://github.com/MagicPotTeam/MagicPot-Terrarium/actions/runs/31331533079): the workflow validated `master`, then updated embedded submodules and first exercised that new candidate during publication.

This PR does not trigger or merge the existing Nightly 1.0.113 release PR.

## Verification

- workflow YAML parsed with the repository `yaml` package
- Prettier check passed for all changed workflows
- `npm run check:text-encoding`
- `npm run typecheck:node`
- `git diff --check`
- independent workflow review found no remaining correctness or security blockers

`actionlint` was unavailable locally.

Co-Authored-By: KohakuTerrarium <noreply@kohaku-lab.org>