### PR TITLE
fix(canvas): unblock local image intake

### DIFF
--- a/.github/workflows/call-embedded-candidate.yml
+++ b/.github/workflows/call-embedded-candidate.yml
@@ -1,0 +1,135 @@
+name: Embedded Candidate
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: The exact release candidate ref to validate
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  validate-windows-embedded:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout candidate
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          submodules: recursive
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.node-version'
+          cache: 'npm'
+
+      - name: Cache Electron
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/AppData/Local/electron/
+            ~/AppData/Local/electron-builder/
+          key: ${{ runner.os }}-electron-cache-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-electron-cache-
+
+      - name: Install dependencies
+        run: npm ci --prefer-offline --no-audit
+
+      - name: Cache embedded Python downloads
+        uses: actions/cache@v4
+        with:
+          path: .cache/embedded-python
+          key: ${{ runner.os }}-embedded-python-${{ hashFiles('scripts/prepare-embedded-python.mjs') }}
+          restore-keys: |
+            ${{ runner.os }}-embedded-python-
+
+      - name: Build embedded candidate
+        env:
+          PIP_NO_CACHE_DIR: '1'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
+
+          Get-PSDrive -Name C | Select-Object Name,Used,Free
+          Write-Host '::group::Build embedded app'
+          npm run build:embedded
+          Write-Host '::endgroup::'
+          Write-Host '::group::Prepare embedded runtime'
+          npm run prepare:embedded
+          Write-Host '::endgroup::'
+          Write-Host '::group::Build image worker'
+          npm run build:image-worker
+          Write-Host '::endgroup::'
+
+          $env:PACKAGE_MODE = 'embedded'
+          Remove-Item Env:GH_TOKEN -ErrorAction SilentlyContinue
+          Remove-Item Env:GITHUB_TOKEN -ErrorAction SilentlyContinue
+          npx electron-builder --config config/electron/electron-builder.config.js --win --x64 --publish never
+
+          $portableRoot = Join-Path $PWD 'dist\embedded\win-unpacked\ComfyUI_windows_portable'
+          $requiredPortableFiles = @(
+            'advanced\run_nvidia_gpu_disable_api_nodes.bat',
+            'update\current_requirements.txt',
+            'update\update.py',
+            'update\update_comfyui.bat',
+            'update\update_comfyui_and_python_dependencies.bat',
+            'update\update_comfyui_stable.bat',
+            'run_cpu.bat',
+            'run_nvidia_gpu.bat',
+            'run_nvidia_gpu_fast_fp16_accumulation.bat'
+          )
+          $missingPortableFiles = @(
+            $requiredPortableFiles | Where-Object {
+              -not (Test-Path -LiteralPath (Join-Path $portableRoot $_) -PathType Leaf)
+            }
+          )
+          if ($missingPortableFiles.Count -gt 0) {
+            throw "Embedded package is missing required ComfyUI portable files: $($missingPortableFiles -join ', ')"
+          }
+
+      - name: Collect embedded candidate diagnostics
+        if: ${{ always() }}
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Continue'
+          $diagnosticsDir = 'dist/embedded-candidate-diagnostics'
+          New-Item -ItemType Directory -Force -Path $diagnosticsDir | Out-Null
+
+          Get-PSDrive -Name C |
+            Select-Object Name,Used,Free |
+            Format-List |
+            Out-File (Join-Path $diagnosticsDir 'disk-usage.txt')
+
+          foreach ($source in @(
+            '.staging/embedded/custom-node-requirements.json',
+            '.staging/embedded/constraints.txt'
+          )) {
+            if (Test-Path -LiteralPath $source) {
+              Copy-Item -LiteralPath $source -Destination $diagnosticsDir
+            }
+          }
+
+          $python = '.staging/embedded/python_embeded/python.exe'
+          if (Test-Path -LiteralPath $python) {
+            & $python -s -m pip list --format=freeze 2>&1 |
+              Out-File (Join-Path $diagnosticsDir 'pip-list.txt')
+            $global:LASTEXITCODE = 0
+            & $python -s -m pip check 2>&1 |
+              Out-File (Join-Path $diagnosticsDir 'pip-check.txt')
+            $global:LASTEXITCODE = 0
+          }
+
+      - name: Upload embedded candidate diagnostics
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: embedded-candidate-diagnostics
+          path: dist/embedded-candidate-diagnostics
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/call-release.yml
+++ b/.github/workflows/call-release.yml
@@ -60,13 +60,22 @@ jobs:
             ${{ runner.os }}-embedded-python-
 
       - name: Build embedded package
+        env:
+          PIP_NO_CACHE_DIR: '1'
         run: |
           $ErrorActionPreference = 'Stop'
           $PSNativeCommandUseErrorActionPreference = $true
 
+          Get-PSDrive -Name C | Select-Object Name,Used,Free
+          Write-Host '::group::Build embedded app'
           npm run build:embedded
+          Write-Host '::endgroup::'
+          Write-Host '::group::Prepare embedded runtime'
           npm run prepare:embedded
+          Write-Host '::endgroup::'
+          Write-Host '::group::Build image worker'
           npm run build:image-worker
+          Write-Host '::endgroup::'
           $env:PACKAGE_MODE = 'embedded'
           # Keep electron-builder in package-only mode even when Actions exposes repository tokens.
           Remove-Item Env:GH_TOKEN -ErrorAction SilentlyContinue
@@ -93,6 +102,48 @@ jobs:
           if ($missingPortableFiles.Count -gt 0) {
             throw "Embedded package is missing required ComfyUI portable files: $($missingPortableFiles -join ', ')"
           }
+
+      - name: Collect embedded build diagnostics
+        if: ${{ always() }}
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Continue'
+          $diagnosticsDir = 'dist/embedded-diagnostics'
+          New-Item -ItemType Directory -Force -Path $diagnosticsDir | Out-Null
+
+          Get-PSDrive -Name C |
+            Select-Object Name,Used,Free |
+            Format-List |
+            Out-File (Join-Path $diagnosticsDir 'disk-usage.txt')
+
+          $requirementsManifest = '.staging/embedded/custom-node-requirements.json'
+          if (Test-Path -LiteralPath $requirementsManifest) {
+            Copy-Item -LiteralPath $requirementsManifest -Destination $diagnosticsDir
+          }
+
+          $constraints = '.staging/embedded/constraints.txt'
+          if (Test-Path -LiteralPath $constraints) {
+            Copy-Item -LiteralPath $constraints -Destination $diagnosticsDir
+          }
+
+          $python = '.staging/embedded/python_embeded/python.exe'
+          if (Test-Path -LiteralPath $python) {
+            & $python -s -m pip list --format=freeze 2>&1 |
+              Out-File (Join-Path $diagnosticsDir 'pip-list.txt')
+            $global:LASTEXITCODE = 0
+            & $python -s -m pip check 2>&1 |
+              Out-File (Join-Path $diagnosticsDir 'pip-check.txt')
+            $global:LASTEXITCODE = 0
+          }
+
+      - name: Upload embedded build diagnostics
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: embedded-build-diagnostics
+          path: dist/embedded-diagnostics
+          if-no-files-found: warn
+          retention-days: 14
 
       - name: Build pure package
         run: |

--- a/.github/workflows/nightly-bump-version.yml
+++ b/.github/workflows/nightly-bump-version.yml
@@ -53,7 +53,7 @@ jobs:
                 echo "release_mode=retry" >> "$GITHUB_OUTPUT"
                 echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
                 echo "release_name=$RELEASE_NAME" >> "$GITHUB_OUTPUT"
-                echo "ref=refs/heads/master" >> "$GITHUB_OUTPUT"
+                echo "ref=$LAST_RELEASE_COMMIT" >> "$GITHUB_OUTPUT"
                 exit 0
               else
                 IS_DRAFT=$(echo "$RELEASE_JSON" | jq -r '.isDraft')
@@ -73,7 +73,7 @@ jobs:
                   echo "release_mode=retry" >> "$GITHUB_OUTPUT"
                   echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
                   echo "release_name=$RELEASE_NAME" >> "$GITHUB_OUTPUT"
-                  echo "ref=refs/heads/master" >> "$GITHUB_OUTPUT"
+                  echo "ref=$LAST_RELEASE_COMMIT" >> "$GITHUB_OUTPUT"
                   exit 0
                 fi
               fi
@@ -225,9 +225,44 @@ jobs:
 
           echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
 
-  release:
+  candidate-ci:
     needs: bump-version
     if: needs.bump-version.result == 'success'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/call-ci.yml
+    with:
+      ref: ${{ needs.bump-version.outputs.ref }}
+
+  candidate-build:
+    needs: bump-version
+    if: needs.bump-version.result == 'success'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/call-build.yml
+    with:
+      ref: ${{ needs.bump-version.outputs.ref }}
+
+  candidate-embedded:
+    needs: bump-version
+    if: needs.bump-version.result == 'success'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/call-embedded-candidate.yml
+    with:
+      ref: ${{ needs.bump-version.outputs.ref }}
+
+  release:
+    needs:
+      - bump-version
+      - candidate-ci
+      - candidate-build
+      - candidate-embedded
+    if: >-
+      needs.bump-version.result == 'success' &&
+      needs.candidate-ci.result == 'success' &&
+      needs.candidate-build.result == 'success' &&
+      needs.candidate-embedded.result == 'success'
     uses: ./.github/workflows/call-release.yml
     with:
       tag_name: ${{ needs.bump-version.outputs.tag_name }}
@@ -259,9 +294,22 @@ jobs:
             --subject "${{ needs.bump-version.outputs.commit_message }}" \
             --body ""
 
-  release-existing:
+  retry-candidate-embedded:
     needs: check-commits
     if: needs.check-commits.outputs.release_mode == 'retry'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/call-embedded-candidate.yml
+    with:
+      ref: ${{ needs.check-commits.outputs.ref }}
+
+  release-existing:
+    needs:
+      - check-commits
+      - retry-candidate-embedded
+    if: >-
+      needs.check-commits.outputs.release_mode == 'retry' &&
+      needs.retry-candidate-embedded.result == 'success'
     uses: ./.github/workflows/call-release.yml
     with:
       tag_name: ${{ needs.check-commits.outputs.tag_name }}

--- a/packages/app/src/main/index.test.ts
+++ b/packages/app/src/main/index.test.ts
@@ -25,7 +25,8 @@ const {
   isAppUpdateInstallInProgressMock,
   startLauncherSmokeTestMock,
   confirmLauncherHealthMock,
-  flushLocalMediaAccessGrantsMock
+  flushLocalMediaAccessGrantsMock,
+  registerLocalMediaFileIntakeIpcMock
 } = vi.hoisted(() => {
   const listeners = new Map<string, (...args: unknown[]) => unknown>()
   const appMock = {
@@ -66,7 +67,8 @@ const {
     isAppUpdateInstallInProgressMock: vi.fn(() => false),
     startLauncherSmokeTestMock: vi.fn(() => false),
     confirmLauncherHealthMock: vi.fn(() => Promise.resolve(false)),
-    flushLocalMediaAccessGrantsMock: vi.fn()
+    flushLocalMediaAccessGrantsMock: vi.fn(),
+    registerLocalMediaFileIntakeIpcMock: vi.fn()
   }
 })
 
@@ -87,6 +89,9 @@ vi.mock('./config/userDataDirectory', () => ({
 
 vi.mock('./localMediaAccess', () => ({
   flushLocalMediaAccessGrants: flushLocalMediaAccessGrantsMock
+}))
+vi.mock('./localMediaFileIntakeIpc', () => ({
+  registerLocalMediaFileIntakeIpc: registerLocalMediaFileIntakeIpcMock
 }))
 
 vi.mock('./lifeCycle', () => ({
@@ -167,6 +172,7 @@ describe('main process startup window opening', () => {
     beforeShowMock.mockResolvedValue(undefined)
     beforeQuitMock.mockClear()
     flushLocalMediaAccessGrantsMock.mockClear()
+    registerLocalMediaFileIntakeIpcMock.mockClear()
     startQAppWatcherMock.mockClear()
     stopQAppWatcherMock.mockClear()
     initScreenshotManagerMock.mockClear()
@@ -208,6 +214,10 @@ describe('main process startup window opening', () => {
     beforeShowMock.mockRejectedValueOnce(new Error('beforeShow failed'))
 
     await loadModule()
+
+    expect(registerLocalMediaFileIntakeIpcMock).toHaveBeenCalledTimes(1)
+    const getRegisteredMainWindow = registerLocalMediaFileIntakeIpcMock.mock.calls[0]?.[0]
+    expect(getRegisteredMainWindow()).toBe(fallbackWindow)
 
     expect(createMainWindowMock).toHaveBeenCalledTimes(1)
     expect(initScreenshotManagerMock).toHaveBeenCalledTimes(1)

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -18,6 +18,7 @@ import { confirmLauncherHealth, startLauncherSmokeTest } from './appUpdate/appLa
 import { initializeAppUpdateManager, isAppUpdateInstallInProgress } from './appUpdate/updateManager'
 import { winController } from './winControls'
 import { flushLocalMediaAccessGrants } from './localMediaAccess'
+import { registerLocalMediaFileIntakeIpc } from './localMediaFileIntakeIpc'
 
 const startupUserData = resolveStartupUserDataDirectory()
 fs.mkdirSync(startupUserData.path, { recursive: true })
@@ -54,7 +55,10 @@ if (startupUserData.source === 'env') {
 let mainWindow: BrowserWindow | null = null
 const launcherSmokeTest = startLauncherSmokeTest({ app })
 
-if (!launcherSmokeTest) initializeMainProcessRuntime(() => mainWindow)
+if (!launcherSmokeTest) {
+  initializeMainProcessRuntime(() => mainWindow)
+  registerLocalMediaFileIntakeIpc(() => mainWindow)
+}
 
 function createWindow(onCreated: (window: BrowserWindow) => void): BrowserWindow {
   const startupPolicy = getAppStartupTestWindowPolicy()

--- a/packages/app/src/main/localMediaFileIntakeIpc.test.ts
+++ b/packages/app/src/main/localMediaFileIntakeIpc.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { handleMock, authorizeMock, resolveMock } = vi.hoisted(() => ({
+  handleMock: vi.fn(),
+  authorizeMock: vi.fn(),
+  resolveMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  app: { getPath: vi.fn((name: string) => `C:/${name}`) },
+  ipcMain: { handle: handleMock }
+}))
+vi.mock('./config/userDataDirectory', () => ({
+  getCurrentUserDataDirectoryState: () => ({
+    projectRoot: 'C:/project',
+    autoSaveRoot: 'C:/autosave'
+  })
+}))
+vi.mock('./localMediaAccess', () => ({
+  authorizeScopedLocalMediaPath: authorizeMock,
+  resolveAuthorizedLocalMediaPath: resolveMock
+}))
+
+import {
+  registerLocalMediaFileIntakeIpc,
+  resetLocalMediaFileIntakeIpcForTest
+} from './localMediaFileIntakeIpc'
+
+describe('local media file intake IPC', () => {
+  beforeEach(() => {
+    resetLocalMediaFileIntakeIpcForTest()
+    handleMock.mockReset()
+    authorizeMock.mockReset()
+    resolveMock.mockReset()
+  })
+
+  it('registers async handlers before a window exists and trusts only the current main renderer', () => {
+    let mainWindow: any = null
+    registerLocalMediaFileIntakeIpc(() => mainWindow)
+
+    expect(handleMock.mock.calls.map(([channel]) => channel)).toEqual([
+      'local-media:authorize-picker-path',
+      'local-media:resolve-scoped-path'
+    ])
+
+    const authorizeHandler = handleMock.mock.calls[0]?.[1]
+    const resolveHandler = handleMock.mock.calls[1]?.[1]
+    const trustedSender = { isDestroyed: () => false }
+    const untrustedSender = { isDestroyed: () => false }
+    authorizeMock.mockReturnValue(true)
+    resolveMock.mockReturnValue('C:/picked/image.png')
+
+    expect(authorizeHandler({ sender: trustedSender }, 'C:/picked/image.png')).toBe(false)
+    expect(authorizeMock).not.toHaveBeenCalled()
+
+    mainWindow = {
+      isDestroyed: () => false,
+      webContents: trustedSender
+    }
+    expect(authorizeHandler({ sender: untrustedSender }, 'C:/picked/image.png')).toBe(false)
+    expect(authorizeHandler({ sender: trustedSender }, 'C:/picked/image.png')).toBe(true)
+    expect(resolveHandler({ sender: untrustedSender }, 'C:/picked/image.png')).toBe('')
+    expect(resolveHandler({ sender: trustedSender }, 'C:/picked/image.png')).toBe(
+      'C:/picked/image.png'
+    )
+    expect(resolveMock).toHaveBeenCalledWith('C:/picked/image.png', [
+      expect.stringMatching(/C:[\\/]userData/),
+      expect.stringMatching(/C:[\\/]temp[\\/]magicpot-local-media/),
+      expect.stringMatching(/C:[\\/]project/),
+      expect.stringMatching(/C:[\\/]autosave/)
+    ])
+  })
+})

--- a/packages/app/src/main/localMediaFileIntakeIpc.ts
+++ b/packages/app/src/main/localMediaFileIntakeIpc.ts
@@ -1,0 +1,48 @@
+import { app, ipcMain, type BrowserWindow, type IpcMainInvokeEvent } from 'electron'
+import path from 'node:path'
+import { getCurrentUserDataDirectoryState } from './config/userDataDirectory'
+import { authorizeScopedLocalMediaPath, resolveAuthorizedLocalMediaPath } from './localMediaAccess'
+
+let localMediaFileIntakeIpcRegistered = false
+
+function isTrustedRenderer(
+  event: IpcMainInvokeEvent,
+  getMainWindow: () => BrowserWindow | null
+): boolean {
+  const mainWindow = getMainWindow()
+  return Boolean(
+    mainWindow &&
+    !mainWindow.isDestroyed() &&
+    !mainWindow.webContents.isDestroyed() &&
+    event.sender === mainWindow.webContents
+  )
+}
+
+function getLocalMediaAllowedRoots(): string[] {
+  const storageState = getCurrentUserDataDirectoryState()
+  return [
+    app.getPath('userData'),
+    path.join(app.getPath('temp'), 'magicpot-local-media'),
+    storageState.projectRoot,
+    storageState.autoSaveRoot
+  ].map((root) => path.resolve(root))
+}
+
+export function registerLocalMediaFileIntakeIpc(getMainWindow: () => BrowserWindow | null): void {
+  if (localMediaFileIntakeIpcRegistered) return
+
+  ipcMain.handle('local-media:authorize-picker-path', (event, filePath: string): boolean => {
+    return isTrustedRenderer(event, getMainWindow) && authorizeScopedLocalMediaPath(filePath)
+  })
+
+  ipcMain.handle('local-media:resolve-scoped-path', (event, filePath: string): string => {
+    if (!isTrustedRenderer(event, getMainWindow)) return ''
+    return resolveAuthorizedLocalMediaPath(filePath, getLocalMediaAllowedRoots()) ?? ''
+  })
+
+  localMediaFileIntakeIpcRegistered = true
+}
+
+export function resetLocalMediaFileIntakeIpcForTest(): void {
+  localMediaFileIntakeIpcRegistered = false
+}

--- a/packages/app/src/main/mainWindow.ts
+++ b/packages/app/src/main/mainWindow.ts
@@ -1,6 +1,6 @@
 import { app, BrowserWindow, ipcMain, nativeImage, screen, shell } from 'electron'
 import * as fs from 'fs'
-import { basename, extname, join, resolve } from 'path'
+import { basename, extname, join } from 'path'
 import { pathToFileURL } from 'url'
 import icon from '../../../runtime-assets/resources/icon.png?asset'
 import { isDev } from './config/buildEnv'
@@ -14,8 +14,7 @@ import { attachRendererDiagnostics } from './rendererDiagnostics'
 import { winController } from './winControls'
 import { attachWindowStatePersistence, readWindowState, type WindowState } from './windowState'
 import { normalizeAllowedExternalUrl } from './utils/externalUrl'
-import { authorizeScopedLocalMediaPath, resolveAuthorizedLocalMediaPath } from './localMediaAccess'
-import { getCurrentUserDataDirectoryState } from './config/userDataDirectory'
+import { authorizeScopedLocalMediaPath } from './localMediaAccess'
 import {
   registerMagicAgentTrustedRouteBinding,
   unregisterMagicAgentTrustedRouteBinding
@@ -31,7 +30,6 @@ type CanvasStartSystemDragPayload = {
 
 const testUiPolicy = getTestWindowPolicy()
 let canvasStartSystemDragRegistered = false
-let trustedCanvasRendererWebContentsId: number | null = null
 
 function sanitizeDragFileName(fileName: string): string {
   const trimmed = (fileName || '').trim()
@@ -55,25 +53,6 @@ function registerCanvasStartSystemDrag(): void {
   if (canvasStartSystemDragRegistered) {
     return
   }
-
-  ipcMain.on('local-media:authorize-picker-path', (event, filePath: string) => {
-    event.returnValue =
-      event.sender.id === trustedCanvasRendererWebContentsId &&
-      authorizeScopedLocalMediaPath(filePath)
-  })
-
-  ipcMain.handle('local-media:resolve-scoped-path', (event, filePath: string): string => {
-    if (event.sender.id !== trustedCanvasRendererWebContentsId) return ''
-    const storageState = getCurrentUserDataDirectoryState()
-    return (
-      resolveAuthorizedLocalMediaPath(filePath, [
-        resolve(app.getPath('userData')),
-        resolve(join(app.getPath('temp'), 'magicpot-local-media')),
-        resolve(storageState.projectRoot),
-        resolve(storageState.autoSaveRoot)
-      ]) ?? ''
-    )
-  })
 
   ipcMain.handle(
     'canvas:start-system-drag',
@@ -175,7 +154,6 @@ export function createMainWindow(onCreated?: (window: BrowserWindow) => void): B
     }
   })
 
-  trustedCanvasRendererWebContentsId = mainWindow.webContents.id
   onCreated?.(mainWindow)
   ;(mainWindow as BrowserWindow & { [key: symbol]: boolean | undefined })[
     Symbol.for('magicpot.testWindowRuntime.skipTaskbar')
@@ -189,9 +167,6 @@ export function createMainWindow(onCreated?: (window: BrowserWindow) => void): B
     trustedWebContents: mainWindow.webContents
   })
   mainWindow.on('closed', () => {
-    if (trustedCanvasRendererWebContentsId === mainWindow.webContents.id) {
-      trustedCanvasRendererWebContentsId = null
-    }
     unregisterMagicAgentTrustedRouteBinding(mainWindow.webContents.id)
   })
 

--- a/packages/app/src/preload/index.d.ts
+++ b/packages/app/src/preload/index.d.ts
@@ -9,7 +9,7 @@ import type {
 
 export type ElectronFileBridge = {
   getPathForFile(file: File): string
-  authorizeLocalMediaFile(file: File): string | Promise<string>
+  authorizeLocalMediaFile(file: File): Promise<string>
   resolveAuthorizedLocalMediaPath(filePath: string): Promise<string>
 }
 

--- a/packages/app/src/preload/index.test.ts
+++ b/packages/app/src/preload/index.test.ts
@@ -63,18 +63,19 @@ describe('preload capability boundary', () => {
     )
   })
 
-  it('authorizes picker files only through webUtils.getPathForFile', () => {
+  it('authorizes picker files only through webUtils.getPathForFile and async IPC', async () => {
     const file = { name: 'selected.png' }
     getPathForFileMock.mockReturnValue('/picked/selected.png')
-    sendSyncMock.mockReturnValue(true)
+    invokeMock.mockResolvedValue(true)
     const electronFile = exposeMock.mock.calls.find(([name]) => name === 'electronFile')?.[1]
 
-    expect(electronFile.authorizeLocalMediaFile(file)).toBe('/picked/selected.png')
+    await expect(electronFile.authorizeLocalMediaFile(file)).resolves.toBe('/picked/selected.png')
     expect(getPathForFileMock).toHaveBeenCalledWith(file)
-    expect(sendSyncMock).toHaveBeenCalledWith(
+    expect(invokeMock).toHaveBeenCalledWith(
       'local-media:authorize-picker-path',
       '/picked/selected.png'
     )
+    expect(sendSyncMock).not.toHaveBeenCalled()
   })
 
   it('exposes only named main-process event subscriptions', () => {

--- a/packages/app/src/preload/index.ts
+++ b/packages/app/src/preload/index.ts
@@ -17,10 +17,10 @@ const electronFile = {
       return ''
     }
   },
-  authorizeLocalMediaFile(file: unknown): string {
+  async authorizeLocalMediaFile(file: unknown): Promise<string> {
     try {
       const filePath = (webUtils.getPathForFile as (target: unknown) => string)(file) || ''
-      return authorizeLocalMediaFilePath(filePath) ? filePath : ''
+      return (await authorizeLocalMediaFilePath(filePath)) ? filePath : ''
     } catch {
       return ''
     }
@@ -104,12 +104,12 @@ const appEvents: AppEventBridge = {
   onQAppDirectoryChanged: (cb) => subscribeToMainEvent('qapp:dir-changed', cb)
 }
 
-function authorizeLocalMediaFilePath(filePath: string): boolean {
+async function authorizeLocalMediaFilePath(filePath: string): Promise<boolean> {
   if (!filePath) return false
   try {
     // The picker/drag File object is validated in preload with webUtils, so the renderer
     // cannot manufacture an arbitrary absolute path for this capability.
-    return ipcRenderer.sendSync('local-media:authorize-picker-path', filePath) === true
+    return (await ipcRenderer.invoke('local-media:authorize-picker-path', filePath)) === true
   } catch {
     return false
   }


### PR DESCRIPTION
## Summary

- replace synchronous local-media file authorization with asynchronous IPC
- register trusted drag, paste, and picker intake handlers before main-window creation
- preserve blob/data fallback for pathless clipboard and temporary files
- add main-process and preload regression coverage

## Root cause

The preload called `ipcRenderer.sendSync('local-media:authorize-picker-path')`, while the listener was installed lazily during window setup. Missing or slow path authorization blocked the renderer event loop and caused drag/drop and clipboard paste failures.

## Verification

- focused Main/Preload tests: 14 passed
- focused Canvas intake tests: 48 passed
- `typecheck:node`
- `typecheck:web`
- targeted Main/Preload lint
- `git diff --check`
- commit hooks: encoding, ESLint, Prettier

Co-Authored-By: KohakuTerrarium <noreply@kohaku-lab.org>