### PR TITLE
fix(release): validate current Hono runtime entry

### DIFF
--- a/scripts/verify-packaged-runtime-dependencies.mjs
+++ b/scripts/verify-packaged-runtime-dependencies.mjs
@@ -20,7 +20,7 @@ export const requiredRuntimeFiles = [
   'node_modules/@modelcontextprotocol/sdk/dist/cjs/server/stdio.js',
   'node_modules/@modelcontextprotocol/sdk/dist/cjs/server/streamableHttp.js',
   'node_modules/@hono/node-server/package.json',
-  'node_modules/@hono/node-server/dist/index.js',
+  'node_modules/@hono/node-server/dist/index.mjs',
   'node_modules/hono/package.json',
   'node_modules/hono/dist/cjs/index.js',
   'node_modules/ajv-formats/package.json',

--- a/scripts/verify-packaged-runtime-dependencies.test.js
+++ b/scripts/verify-packaged-runtime-dependencies.test.js
@@ -57,12 +57,16 @@ describe('verify-packaged-runtime-dependencies', () => {
       'node_modules/@modelcontextprotocol/sdk': {
         name: '@modelcontextprotocol/sdk',
         dependencies: {
-          '@hono/node-server': '1.19.13',
+          '@hono/node-server': '2.1.0',
           hono: '4.12.26',
           'zod-to-json-schema': '3.25.2'
         }
       },
-      'node_modules/@hono/node-server': { name: '@hono/node-server' },
+      'node_modules/@hono/node-server': {
+        name: '@hono/node-server',
+        version: '2.1.0',
+        main: 'dist/index.mjs'
+      },
       'node_modules/hono': { name: 'hono' },
       'node_modules/zod-to-json-schema': { name: 'zod-to-json-schema' }
     })


### PR DESCRIPTION
## Summary
- update packaged runtime validation for `@hono/node-server@2.1.0`
- exercise the current ESM entry in the verifier fixture

## Root cause
The nightly candidate uses a clean `npm ci`, where `@hono/node-server@2.1.0` contains `dist/index.mjs` and `dist/index.cjs`. The verifier still required the removed legacy `dist/index.js`, causing `afterPack` to reject an otherwise valid package. A stale local `node_modules` had masked the mismatch.

## Verification
- `npm run test:packaged-runtime-dependencies` (4 tests passed)
- verifier passed against the failed candidate’s real `app.asar` (99 runtime packages)
- clean electron-builder Embedded package stage passed in `dist/embedded-fixed`
