### PR TITLE
fix(release): avoid scoped package audit false positive

### DIFF
--- a/scripts/create-open-candidate.mjs
+++ b/scripts/create-open-candidate.mjs
@@ -285,7 +285,7 @@ const addContentIssues = ({ file, relativeFile, text, issues }) => {
       rule: 'private-path-reference',
       skip: isTestFixture(relativeFile),
       pattern:
-        /(?:[A-Za-z]:[\\/][^\r\n"'`]*(?:private|internal|premium|open-private)[\\/][^\r\n"'`]*)|(?:(?:^|[\\/"'`\s])(?:private|internal|premium|open-private)[\\/][^\r\n"'`\s)]+)/gi
+        /(?:[A-Za-z]:[\\/][^\r\n"'`]*[\\/](?:private|internal|premium|open-private)[\\/][^\r\n"'`]*)|(?:(?:^|[\\/"'`\s])(?:private|internal|premium|open-private)[\\/][^\r\n"'`\s)]+)/gi
     },
     {
       rule: 'high-confidence-secret',

--- a/scripts/create-open-candidate.test.js
+++ b/scripts/create-open-candidate.test.js
@@ -172,7 +172,11 @@ describe('create-open-candidate policy', () => {
     ].join('\n')
 
     writeFile(candidate, 'packages/app/src/example.test.ts', "const fixture = '/private/path'\n")
-    writeFile(candidate, 'packages/app/src/example.ts', "const marker = '-----BEGIN PRIVATE KEY-----'\n")
+    writeFile(
+      candidate,
+      'packages/app/src/example.ts',
+      "const marker = '-----BEGIN PRIVATE KEY-----'\n"
+    )
 
     expect(auditOpenCandidate(candidate)).toEqual([])
 
@@ -189,7 +193,14 @@ describe('create-open-candidate policy', () => {
 
   it('continues to reject private paths outside test fixtures', () => {
     const candidate = makeCandidate()
-    writeFile(candidate, 'packages/app/src/runtime.ts', "const path = '/private/path'\n")
+    const windowsPath = ['C:', 'workspace', 'internal', 'config.json'].join(String.fromCharCode(92))
+    writeFile(
+      candidate,
+      'packages/app/src/runtime.ts',
+      `const posixPath = '/private/path'
+const windowsPath = '${windowsPath}'
+`
+    )
 
     expect(auditOpenCandidate(candidate)).toEqual([
       {
@@ -197,8 +208,25 @@ describe('create-open-candidate policy', () => {
         line: 1,
         rule: 'private-path-reference',
         message: '/private/path'
+      },
+      {
+        file: 'packages/app/src/runtime.ts',
+        line: 2,
+        rule: 'private-path-reference',
+        message: windowsPath
       }
     ])
+  })
+
+  it('allows scoped package names containing internal in lockfile URLs', () => {
+    const candidate = makeCandidate()
+    writeFile(
+      candidate,
+      'package-lock.json',
+      '{"resolved":"https://registry.npmjs.org/@electron-internal/extract-zip/-/extract-zip-1.0.5.tgz"}'
+    )
+
+    expect(auditOpenCandidate(candidate)).toEqual([])
   })
 
   it('verifies an already-generated candidate even when it is not a git repository', () => {


### PR DESCRIPTION
## Summary
- require private markers in absolute paths to be complete directory segments
- allow official scoped package URLs such as `@electron-internal/extract-zip`
- retain POSIX and Windows private path rejection coverage

## Verification
- focused candidate policy tests: 3 passed
- current source candidate audit: passed
- `git diff --check`: passed
