### PR TITLE
feat: add minimal multi-Comfy batches and canvas tuning

### DIFF
--- a/.vscode/QAppCfg.json
+++ b/.vscode/QAppCfg.json
@@ -19,14 +19,6 @@
           "additionalProperties": false,
           "description": "批量处理配置 启用后，快应用会显示\"批量处理\"按钮",
           "properties": {
-            "batchImageInputSlot": {
-              "$ref": "#/definitions/JsonPath",
-              "description": "批量工作流中图片输入的 JSON Path（可选） 如果 batchWorkflow 使用了不同的节点 ID，需要指定这个字段 如果未指定，将使用 imageInputSlot"
-            },
-            "batchWorkflow": {
-              "description": "批量处理专用工作流文件名（可选） 如果指定，批量处理时会使用这个工作流而不是默认工作流 这对于需要编译时间的工作流很有用（如 TorchCompile） 文件名相对于当前快应用所在目录",
-              "type": "string"
-            },
             "enabled": {
               "description": "是否启用批量处理",
               "type": "boolean"

--- a/.vscode/QAppCfg.schema.json
+++ b/.vscode/QAppCfg.schema.json
@@ -19,14 +19,6 @@
           "additionalProperties": false,
           "description": "批量处理配置 启用后，快应用会显示\"批量处理\"按钮",
           "properties": {
-            "batchImageInputSlot": {
-              "$ref": "#/definitions/JsonPath",
-              "description": "批量工作流中图片输入的 JSON Path（可选） 如果 batchWorkflow 使用了不同的节点 ID，需要指定这个字段 如果未指定，将使用 imageInputSlot"
-            },
-            "batchWorkflow": {
-              "description": "批量处理专用工作流文件名（可选） 如果指定，批量处理时会使用这个工作流而不是默认工作流 这对于需要编译时间的工作流很有用（如 TorchCompile） 文件名相对于当前快应用所在目录",
-              "type": "string"
-            },
             "enabled": {
               "description": "是否启用批量处理",
               "type": "boolean"

--- a/packages/app/src/main/api/serverIpc.test.ts
+++ b/packages/app/src/main/api/serverIpc.test.ts
@@ -52,6 +52,7 @@ vi.mock('electron', () => ({
 vi.mock('./svcAdobeBridgeImpl', () => ({ AdobeBridgeSvcImpl: createServiceClass() }))
 vi.mock('./svcStateImpl', () => ({ StateSvcImpl: createServiceClass() }))
 vi.mock('./svcComfyImpl', () => ({ ComfySvcImpl: createServiceClass() }))
+vi.mock('./svcComfyBatchImpl', () => ({ ComfyBatchSvcImpl: createServiceClass() }))
 vi.mock('./svcCanvasThumbnailImpl', () => ({ CanvasThumbnailSvcImpl: createServiceClass() }))
 vi.mock('./svcTargetSchemeImpl', () => ({ TargetSchemeSvcImpl: createServiceClass() }))
 vi.mock('./svcProjectTraceImpl', () => ({ ProjectTraceSvcImpl: createServiceClass() }))
@@ -89,6 +90,8 @@ describe('serverIpc createServer', () => {
     expect(apiDef.svcMagicAgentPlatform).toBeDefined()
     expect(api.svcManagedMedia).toBeDefined()
     expect(apiDef.svcManagedMedia.ensureDerivative.type).toBe('unary')
+    expect(api.svcComfyBatch).toBeDefined()
+    expect(apiDef.svcComfyBatch.start.type).toBe('unary')
   })
 
   it('registers svcManagedMedia on ipcMain', () => {

--- a/packages/app/src/main/api/serverIpc.ts
+++ b/packages/app/src/main/api/serverIpc.ts
@@ -2,6 +2,7 @@ import { Api, BaseApi, apiDef } from '@shared/api'
 import { AdobeBridgeSvcImpl } from './svcAdobeBridgeImpl'
 import { StateSvcImpl } from './svcStateImpl'
 import { ComfySvcImpl } from './svcComfyImpl'
+import { ComfyBatchSvcImpl } from './svcComfyBatchImpl'
 import { CanvasThumbnailSvcImpl } from './svcCanvasThumbnailImpl'
 import { ProjectTraceSvcImpl } from './svcProjectTraceImpl'
 import { TargetSchemeSvcImpl } from './svcTargetSchemeImpl'
@@ -32,6 +33,7 @@ export const createServer = (managedMediaCleanupScheduler?: ManagedMediaCleanupS
     svcState: new StateSvcImpl(),
     svcHyper: new HyperSvcImpl(),
     svcComfy: new ComfySvcImpl(),
+    svcComfyBatch: new ComfyBatchSvcImpl(),
     svcQApp: new QAppSvcImpl(),
     svcTargetScheme: new TargetSchemeSvcImpl(),
     svcProjectTrace: new ProjectTraceSvcImpl(),

--- a/packages/app/src/main/api/svcComfyBatchImpl.test.ts
+++ b/packages/app/src/main/api/svcComfyBatchImpl.test.ts
@@ -50,6 +50,9 @@ function status(jobId: string, state: ComfyBatchStatus['state']): ComfyBatchStat
   }
 }
 
+let releaseQAppLookup: (() => void) | undefined
+let delayQAppLookup = false
+
 describe('ComfyBatchSvcImpl live status', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -67,18 +70,30 @@ describe('ComfyBatchSvcImpl live status', () => {
     } as Config)
     vi.mocked(configModule.saveConfig).mockResolvedValue(undefined)
     vi.mocked(buildEnvModule.getBuildEnv).mockReturnValue(DEFAULT_BUILD_ENV)
+    delayQAppLookup = false
+    releaseQAppLookup = undefined
     vi.mocked(QAppFSCli).mockImplementation(function MockQAppFs() {
       return {
-        getQApp: async () => ({
-          cfg: {
-            icon: '',
-            inputs: [],
-            outputNodeIds: request.outputNodeIds,
-            batchProcess: { enabled: true, imageInputSlot: request.imageInputSlot }
-          },
-          workflow: request.workflow,
-          manifest: { name: 'qapp', version: '1.0.0' }
-        })
+        getQApp: async () => {
+          if (delayQAppLookup) {
+            await new Promise<void>((resolve) => {
+              releaseQAppLookup = resolve
+            })
+          }
+          return {
+            cfg: {
+              icon: '',
+              inputs: [],
+              outputNodeIds: request.outputNodeIds,
+              batchProcess: { enabled: true, imageInputSlot: request.imageInputSlot }
+            },
+            workflow: {
+              ...request.workflow,
+              '1': { ...request.workflow['1'], inputs: { image: 'template' } }
+            },
+            manifest: { name: 'qapp', version: '1.0.0' }
+          }
+        }
       } as never
     })
   })
@@ -115,6 +130,41 @@ describe('ComfyBatchSvcImpl live status', () => {
     })
     await expect(svc.start(request)).rejects.toThrow(/already running/i)
 
+    current = { ...current, state: 'completed', running: 0 }
+    resolveRun(current)
+    await runPromise
+  })
+
+  it('serializes concurrent starts around asynchronous Quick App validation', async () => {
+    let current = status('job-1', 'idle')
+    let resolveRun!: (value: ComfyBatchStatus) => void
+    const runPromise = new Promise<ComfyBatchStatus>((resolve) => {
+      resolveRun = resolve
+    })
+    const runner = {
+      jobId: 'job-1',
+      get status() {
+        return current
+      },
+      startingStatus: vi.fn(() => {
+        current = status('job-1', 'running')
+        return current
+      }),
+      run: vi.fn(() => runPromise),
+      cancel: vi.fn()
+    }
+    vi.mocked(ComfyBatchRunner).mockImplementation(function MockRunner() {
+      return runner as never
+    })
+    delayQAppLookup = true
+    const svc = new ComfyBatchSvcImpl()
+    const first = svc.start(request)
+    const second = svc.start(request)
+    await vi.waitFor(() => expect(releaseQAppLookup).toBeTypeOf('function'))
+    releaseQAppLookup?.()
+
+    await expect(first).resolves.toMatchObject({ status: { state: 'running' } })
+    await expect(second).rejects.toThrow(/already running/i)
     current = { ...current, state: 'completed', running: 0 }
     resolveRun(current)
     await runPromise

--- a/packages/app/src/main/api/svcComfyBatchImpl.test.ts
+++ b/packages/app/src/main/api/svcComfyBatchImpl.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { DEFAULT_BUILD_ENV } from '@shared/config/buildEnv'
+import { DEFAULT_CONFIG, type Config } from '@shared/config/config'
+import type { ComfyBatchStatus, StartComfyBatchReq } from '@shared/api/svcComfyBatch'
+import * as configModule from '../config/config'
+import * as buildEnvModule from '../config/buildEnv'
+import { ComfyBatchRunner } from '../comfy/batchRunner'
+import { QAppFSCli } from '../qApp/fs'
+import { ComfyBatchSvcImpl } from './svcComfyBatchImpl'
+
+vi.mock(import('../config/config'), () => ({
+  getConfig: vi.fn(),
+  saveConfig: vi.fn()
+}))
+
+vi.mock(import('../config/buildEnv'), () => ({
+  getBuildEnv: vi.fn()
+}))
+
+vi.mock(import('../comfy/batchRunner'), () => ({
+  ComfyBatchRunner: vi.fn()
+}))
+
+vi.mock(import('../qApp/fs'), () => ({
+  QAppFSCli: vi.fn()
+}))
+
+const request: StartComfyBatchReq = {
+  sourceDir: '/tmp/source',
+  qAppKey: 'qapp',
+  workflow: {
+    '1': { class_type: 'LoadImage', inputs: { image: '' } },
+    '2': { class_type: 'SaveImage', inputs: {} }
+  },
+  imageInputSlot: '$.1.inputs.image',
+  outputNodeIds: ['2']
+}
+
+function status(jobId: string, state: ComfyBatchStatus['state']): ComfyBatchStatus {
+  return {
+    jobId,
+    state,
+    total: 1,
+    success: 0,
+    failed: 0,
+    skipped: 0,
+    running: state === 'running' ? 1 : 0,
+    pending: 0,
+    failedFiles: []
+  }
+}
+
+describe('ComfyBatchSvcImpl live status', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(configModule.getConfig).mockReturnValue({
+      ...DEFAULT_CONFIG,
+      comfy_batch_profiles: [
+        {
+          id: 'one',
+          name: 'One',
+          baseUrl: 'http://127.0.0.1:8188',
+          enabled: true,
+          maxConcurrency: 1
+        }
+      ]
+    } as Config)
+    vi.mocked(configModule.saveConfig).mockResolvedValue(undefined)
+    vi.mocked(buildEnvModule.getBuildEnv).mockReturnValue(DEFAULT_BUILD_ENV)
+    vi.mocked(QAppFSCli).mockImplementation(function MockQAppFs() {
+      return {
+        getQApp: async () => ({
+          cfg: {
+            icon: '',
+            inputs: [],
+            outputNodeIds: request.outputNodeIds,
+            batchProcess: { enabled: true, imageInputSlot: request.imageInputSlot }
+          },
+          workflow: request.workflow,
+          manifest: { name: 'qapp', version: '1.0.0' }
+        })
+      } as never
+    })
+  })
+
+  it('returns a running job immediately and exposes live runner progress', async () => {
+    let current = status('job-1', 'idle')
+    let resolveRun!: (value: ComfyBatchStatus) => void
+    const runPromise = new Promise<ComfyBatchStatus>((resolve) => {
+      resolveRun = resolve
+    })
+    const runner = {
+      jobId: 'job-1',
+      get status() {
+        return current
+      },
+      startingStatus: vi.fn(() => {
+        current = status('job-1', 'running')
+        return current
+      }),
+      run: vi.fn(() => runPromise),
+      cancel: vi.fn()
+    }
+    vi.mocked(ComfyBatchRunner).mockImplementation(function MockRunner() {
+      return runner as never
+    })
+
+    const svc = new ComfyBatchSvcImpl()
+    await expect(svc.start(request)).resolves.toMatchObject({
+      status: { jobId: 'job-1', state: 'running' }
+    })
+    current = { ...current, running: 0, success: 1 }
+    await expect(svc.status({ jobId: 'job-1' })).resolves.toMatchObject({
+      status: { success: 1 }
+    })
+    await expect(svc.start(request)).rejects.toThrow(/already running/i)
+
+    current = { ...current, state: 'completed', running: 0 }
+    resolveRun(current)
+    await runPromise
+  })
+})

--- a/packages/app/src/main/api/svcComfyBatchImpl.ts
+++ b/packages/app/src/main/api/svcComfyBatchImpl.ts
@@ -36,18 +36,6 @@ const IDLE_STATUS: ComfyBatchStatus = {
   failedFiles: []
 }
 
-function stableJson(value: unknown): string {
-  if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`
-  if (value && typeof value === 'object') {
-    const record = value as Record<string, unknown>
-    return `{${Object.keys(record)
-      .sort()
-      .map((key) => `${JSON.stringify(key)}:${stableJson(record[key])}`)
-      .join(',')}}`
-  }
-  return JSON.stringify(value)
-}
-
 type JobRecord = {
   request: StartComfyBatchReq
   runner: ComfyBatchRunner
@@ -92,9 +80,23 @@ function configuredProfiles(): ComfyBatchProfile[] {
 export class ComfyBatchSvcImpl implements ComfyBatchSvc {
   private jobs = new Map<string, JobRecord>()
   private latestJobId: string | undefined
+  private operationQueue: Promise<void> = Promise.resolve()
 
   private async persistProfiles(profiles: ComfyBatchProfile[]): Promise<void> {
     await saveConfig({ comfy_batch_profiles: profiles })
+  }
+
+  private serialize<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.operationQueue.then(operation, operation)
+    this.operationQueue = result.then(
+      () => undefined,
+      () => undefined
+    )
+    return result
+  }
+
+  private activeJob(): JobRecord | undefined {
+    return [...this.jobs.values()].find((record) => record.runner.status.state === 'running')
   }
 
   private rememberJob(record: JobRecord): void {
@@ -159,22 +161,24 @@ export class ComfyBatchSvcImpl implements ComfyBatchSvc {
     }
   }
 
-  start = async (req: StartComfyBatchReq): Promise<StartComfyBatchResp> => {
-    const active = [...this.jobs.values()].find(
-      (record) => record.runner.status.state === 'running'
-    )
-    if (active) throw new Error('Another ComfyUI batch is already running')
-    const selected = await new QAppFSCli().getQApp(req.qAppKey)
-    if (
-      selected.cfg.batchProcess?.enabled !== true ||
-      selected.cfg.batchProcess.imageInputSlot !== req.imageInputSlot ||
-      stableJson(selected.workflow) !== stableJson(req.workflow) ||
-      stableJson(selected.cfg.outputNodeIds || []) !== stableJson(req.outputNodeIds)
-    ) {
-      throw new Error('Quick App batch plan changed; reopen the Quick App and try again')
-    }
-    return { status: this.launch(req) }
-  }
+  start = async (req: StartComfyBatchReq): Promise<StartComfyBatchResp> =>
+    this.serialize(async () => {
+      if (this.activeJob()) throw new Error('Another ComfyUI batch is already running')
+      const selected = await new QAppFSCli().getQApp(req.qAppKey)
+      const selectedOutputIds = selected.cfg.outputNodeIds || []
+      const requestedOutputIds = req.outputNodeIds || []
+      const outputBindingsMatch =
+        selectedOutputIds.length === requestedOutputIds.length &&
+        selectedOutputIds.every((nodeId) => requestedOutputIds.includes(nodeId))
+      if (
+        selected.cfg.batchProcess?.enabled !== true ||
+        selected.cfg.batchProcess.imageInputSlot !== req.imageInputSlot ||
+        !outputBindingsMatch
+      ) {
+        throw new Error('Quick App batch bindings changed; reopen the Quick App and try again')
+      }
+      return { status: this.launch(req) }
+    })
 
   status = async (req: GetComfyBatchStatusReq): Promise<GetComfyBatchStatusResp> => {
     const jobId = req.jobId || this.latestJobId
@@ -182,14 +186,15 @@ export class ComfyBatchSvcImpl implements ComfyBatchSvc {
     return { status: record?.runner.status || { ...IDLE_STATUS } }
   }
 
-  retryFailed = async (req: RetryFailedComfyBatchReq): Promise<RetryFailedComfyBatchResp> => {
-    const previous = this.jobs.get(req.jobId)
-    if (!previous) throw new Error(`Batch job not found: ${req.jobId}`)
-    const status = previous.runner.status
-    if (status.state === 'running') throw new Error('Cannot retry a running batch job')
-    if (status.failed === 0) throw new Error('No failed batch items to retry')
-    return { status: this.launch(previous.request) }
-  }
+  retryFailed = async (req: RetryFailedComfyBatchReq): Promise<RetryFailedComfyBatchResp> =>
+    this.serialize(async () => {
+      if (this.activeJob()) throw new Error('Another ComfyUI batch is already running')
+      const previous = this.jobs.get(req.jobId)
+      if (!previous) throw new Error(`Batch job not found: ${req.jobId}`)
+      const status = previous.runner.status
+      if (status.failed === 0) throw new Error('No failed batch items to retry')
+      return { status: this.launch(previous.request) }
+    })
 
   cancel = async (req: CancelComfyBatchReq): Promise<CancelComfyBatchResp> => {
     const record = this.jobs.get(req.jobId)

--- a/packages/app/src/main/api/svcComfyBatchImpl.ts
+++ b/packages/app/src/main/api/svcComfyBatchImpl.ts
@@ -192,7 +192,9 @@ export class ComfyBatchSvcImpl implements ComfyBatchSvc {
       const previous = this.jobs.get(req.jobId)
       if (!previous) throw new Error(`Batch job not found: ${req.jobId}`)
       const status = previous.runner.status
-      if (status.failed === 0) throw new Error('No failed batch items to retry')
+      if (status.failed === 0 && status.pending === 0 && status.state !== 'error') {
+        throw new Error('No unfinished batch items to retry')
+      }
       return { status: this.launch(previous.request) }
     })
 

--- a/packages/app/src/main/api/svcComfyBatchImpl.ts
+++ b/packages/app/src/main/api/svcComfyBatchImpl.ts
@@ -1,0 +1,201 @@
+import path from 'node:path'
+import type {
+  CancelComfyBatchReq,
+  CancelComfyBatchResp,
+  ComfyBatchProfile,
+  ComfyBatchStatus,
+  ComfyBatchSvc,
+  GetComfyBatchStatusReq,
+  GetComfyBatchStatusResp,
+  ListComfyBatchProfilesReq,
+  ListComfyBatchProfilesResp,
+  ProbeComfyBatchProfileReq,
+  ProbeComfyBatchProfileResp,
+  ReplaceComfyBatchProfilesReq,
+  ReplaceComfyBatchProfilesResp,
+  RetryFailedComfyBatchReq,
+  RetryFailedComfyBatchResp,
+  StartComfyBatchReq,
+  StartComfyBatchResp
+} from '@shared/api/svcComfyBatch'
+import { ConfigUtils } from '@shared/config/configUtils'
+import { getBuildEnv } from '../config/buildEnv'
+import { getConfig, saveConfig } from '../config/config'
+import { ComfyBatchHttpClient, normalizeComfyBatchBaseUrl } from '../comfy/batchHttp'
+import { ComfyBatchRunner } from '../comfy/batchRunner'
+import { QAppFSCli } from '../qApp/fs'
+
+const IDLE_STATUS: ComfyBatchStatus = {
+  state: 'idle',
+  total: 0,
+  success: 0,
+  failed: 0,
+  skipped: 0,
+  running: 0,
+  pending: 0,
+  failedFiles: []
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`
+  if (value && typeof value === 'object') {
+    const record = value as Record<string, unknown>
+    return `{${Object.keys(record)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableJson(record[key])}`)
+      .join(',')}}`
+  }
+  return JSON.stringify(value)
+}
+
+type JobRecord = {
+  request: StartComfyBatchReq
+  runner: ComfyBatchRunner
+  status: ComfyBatchStatus
+}
+
+function normalizeProfile(profile: ComfyBatchProfile): ComfyBatchProfile {
+  const id = String(profile.id || '').trim()
+  const name = String(profile.name || '').trim()
+  if (!id) throw new Error('Profile id is required')
+  if (!name) throw new Error('Profile name is required')
+  return {
+    id,
+    name,
+    baseUrl: normalizeComfyBatchBaseUrl(profile.baseUrl),
+    enabled: profile.enabled !== false,
+    maxConcurrency: Math.max(1, Math.min(32, Math.floor(profile.maxConcurrency || 1)))
+  }
+}
+
+function savedProfiles(): ComfyBatchProfile[] {
+  return (getConfig().comfy_batch_profiles ?? []).map(normalizeProfile)
+}
+
+function defaultProfile(): ComfyBatchProfile {
+  const config = getConfig()
+  const baseUrl = new ConfigUtils(config, getBuildEnv(), path).getComfyUIOrigin()
+  return {
+    id: 'default',
+    name: 'Default ComfyUI',
+    baseUrl: normalizeComfyBatchBaseUrl(baseUrl),
+    enabled: true,
+    maxConcurrency: 1
+  }
+}
+
+function configuredProfiles(): ComfyBatchProfile[] {
+  const profiles = savedProfiles()
+  return profiles.length ? profiles : [defaultProfile()]
+}
+
+export class ComfyBatchSvcImpl implements ComfyBatchSvc {
+  private jobs = new Map<string, JobRecord>()
+  private latestJobId: string | undefined
+
+  private async persistProfiles(profiles: ComfyBatchProfile[]): Promise<void> {
+    await saveConfig({ comfy_batch_profiles: profiles })
+  }
+
+  private rememberJob(record: JobRecord): void {
+    this.jobs.set(record.runner.jobId, record)
+    this.latestJobId = record.runner.jobId
+    while (this.jobs.size > 20) {
+      const oldest = this.jobs.keys().next().value
+      if (!oldest) break
+      this.jobs.delete(oldest)
+    }
+  }
+
+  private launch(request: StartComfyBatchReq): ComfyBatchStatus {
+    const profiles = configuredProfiles()
+    const record = {} as JobRecord
+    const runner = new ComfyBatchRunner(request, profiles, {
+      onStatus: (status) => {
+        record.status = status
+      }
+    })
+    Object.assign(record, { request, runner, status: runner.startingStatus() })
+    this.rememberJob(record)
+    void runner.run().then((status) => {
+      record.status = status
+    })
+    return record.status
+  }
+
+  listProfiles = async (_req: ListComfyBatchProfilesReq): Promise<ListComfyBatchProfilesResp> => ({
+    profiles: configuredProfiles()
+  })
+
+  replaceProfiles = async (
+    req: ReplaceComfyBatchProfilesReq
+  ): Promise<ReplaceComfyBatchProfilesResp> => {
+    const profiles = req.profiles.map(normalizeProfile)
+    if (new Set(profiles.map((profile) => profile.id)).size !== profiles.length) {
+      throw new Error('ComfyUI profile ids must be unique')
+    }
+    await this.persistProfiles(profiles)
+    return { profiles: profiles.length ? profiles : [defaultProfile()] }
+  }
+
+  probeProfile = async (req: ProbeComfyBatchProfileReq): Promise<ProbeComfyBatchProfileResp> => {
+    const profile = req.id
+      ? configuredProfiles().find((candidate) => candidate.id === req.id)
+      : undefined
+    const baseUrl = normalizeComfyBatchBaseUrl(req.baseUrl || profile?.baseUrl || '')
+    const startedAt = Date.now()
+    try {
+      const probe = await new ComfyBatchHttpClient(baseUrl).probe()
+      return { result: { ok: true, baseUrl, ...probe } }
+    } catch (error) {
+      return {
+        result: {
+          ok: false,
+          baseUrl,
+          latencyMs: Date.now() - startedAt,
+          error: error instanceof Error ? error.message : String(error)
+        }
+      }
+    }
+  }
+
+  start = async (req: StartComfyBatchReq): Promise<StartComfyBatchResp> => {
+    const active = [...this.jobs.values()].find(
+      (record) => record.runner.status.state === 'running'
+    )
+    if (active) throw new Error('Another ComfyUI batch is already running')
+    const selected = await new QAppFSCli().getQApp(req.qAppKey)
+    if (
+      selected.cfg.batchProcess?.enabled !== true ||
+      selected.cfg.batchProcess.imageInputSlot !== req.imageInputSlot ||
+      stableJson(selected.workflow) !== stableJson(req.workflow) ||
+      stableJson(selected.cfg.outputNodeIds || []) !== stableJson(req.outputNodeIds)
+    ) {
+      throw new Error('Quick App batch plan changed; reopen the Quick App and try again')
+    }
+    return { status: this.launch(req) }
+  }
+
+  status = async (req: GetComfyBatchStatusReq): Promise<GetComfyBatchStatusResp> => {
+    const jobId = req.jobId || this.latestJobId
+    const record = jobId ? this.jobs.get(jobId) : undefined
+    return { status: record?.runner.status || { ...IDLE_STATUS } }
+  }
+
+  retryFailed = async (req: RetryFailedComfyBatchReq): Promise<RetryFailedComfyBatchResp> => {
+    const previous = this.jobs.get(req.jobId)
+    if (!previous) throw new Error(`Batch job not found: ${req.jobId}`)
+    const status = previous.runner.status
+    if (status.state === 'running') throw new Error('Cannot retry a running batch job')
+    if (status.failed === 0) throw new Error('No failed batch items to retry')
+    return { status: this.launch(previous.request) }
+  }
+
+  cancel = async (req: CancelComfyBatchReq): Promise<CancelComfyBatchResp> => {
+    const record = this.jobs.get(req.jobId)
+    if (!record) throw new Error(`Batch job not found: ${req.jobId}`)
+    record.runner.cancel()
+    record.status = record.runner.status
+    return { status: record.status }
+  }
+}

--- a/packages/app/src/main/comfy/batchHttp.test.ts
+++ b/packages/app/src/main/comfy/batchHttp.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ComfyBatchHttpClient, COMFY_BATCH_MAX_NETWORK_ATTEMPTS } from './batchHttp'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('ComfyBatchHttpClient retry and boundary behavior', () => {
+  it('allows at most three retries after the first idempotent read attempt', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new TypeError('network down'))
+    vi.stubGlobal('fetch', fetchMock)
+    const client = new ComfyBatchHttpClient('http://127.0.0.1:8188')
+
+    await expect(client.objectInfo()).rejects.toThrow('network down')
+    expect(fetchMock).toHaveBeenCalledTimes(COMFY_BATCH_MAX_NETWORK_ATTEMPTS)
+  })
+
+  it('preserves a forwarded base path for every ComfyUI endpoint', async () => {
+    const urls: string[] = []
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      urls.push(String(input))
+      return Response.json({}, { status: 200 })
+    })
+    const injected = new ComfyBatchHttpClient(
+      'https://example.test/autodl/comfy/',
+      fetchMock as typeof fetch
+    )
+    await injected.objectInfo()
+    expect(urls).toEqual(['https://example.test/autodl/comfy/object_info'])
+  })
+
+  it('does not blindly retry prompt submission and carries an explicit prompt id', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new TypeError('unknown submit result'))
+    vi.stubGlobal('fetch', fetchMock)
+    const client = new ComfyBatchHttpClient('http://127.0.0.1:8188')
+
+    await expect(client.prompt({} as never, 'client', 'known-prompt-id')).rejects.toThrow(
+      'unknown submit result'
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit
+    expect(JSON.parse(String(init.body))).toMatchObject({ prompt_id: 'known-prompt-id' })
+  })
+
+  it('accepts the server prompt_id even when it differs from the client request value', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(Response.json({ prompt_id: 'server-prompt-id' }, { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+    const client = new ComfyBatchHttpClient('http://127.0.0.1:8188')
+
+    await expect(client.prompt({} as never, 'client', 'client-prompt-id')).resolves.toBe(
+      'server-prompt-id'
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not retry an upload whose submit result is unknown', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new TypeError('unknown upload result'))
+    vi.stubGlobal('fetch', fetchMock)
+    const client = new ComfyBatchHttpClient('http://127.0.0.1:8188')
+
+    await expect(client.uploadImage('input.png', new Uint8Array([1]))).rejects.toThrow(
+      'unknown upload result'
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects redirects once instead of following or retrying a changed origin', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('', {
+        status: 302,
+        headers: { location: 'http://untrusted.example/object_info' }
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    const client = new ComfyBatchHttpClient('http://127.0.0.1:8188')
+
+    await expect(client.objectInfo()).rejects.toThrow(/redirects are not allowed/i)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/app/src/main/comfy/batchHttp.test.ts
+++ b/packages/app/src/main/comfy/batchHttp.test.ts
@@ -68,7 +68,38 @@ describe('ComfyBatchHttpClient retry and boundary behavior', () => {
       )
     const client = new ComfyBatchHttpClient('http://127.0.0.1:8188', fetchMock as typeof fetch)
 
-    await expect(client.promptAdmission('known-prompt-id')).resolves.toBe(true)
+    await expect(client.promptAdmission('known-prompt-id')).resolves.toEqual({
+      admitted: true,
+      promptId: 'known-prompt-id'
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('recovers a server-minted prompt id through the unique submission client id', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(Response.json({}, { status: 200 }))
+      .mockResolvedValueOnce(
+        Response.json(
+          {
+            queue_running: [],
+            queue_pending: [[1, 'server-prompt-id', {}, { client_id: 'submission-client' }]]
+          },
+          { status: 200 }
+        )
+      )
+    const client = new ComfyBatchHttpClient('http://127.0.0.1:8188', fetchMock as typeof fetch)
+
+    await expect(
+      client.waitForPromptAdmission('requested-prompt-id', undefined, 100, 'submission-client')
+    ).resolves.toEqual({ admitted: true, promptId: 'server-prompt-id' })
+  })
+
+  it('cancels queue and running work even when both endpoints return empty bodies', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 200 }))
+    const client = new ComfyBatchHttpClient('http://127.0.0.1:8188', fetchMock as typeof fetch)
+
+    await expect(client.cancelPrompt('known-prompt-id')).resolves.toBeUndefined()
     expect(fetchMock).toHaveBeenCalledTimes(2)
   })
 

--- a/packages/app/src/main/comfy/batchHttp.test.ts
+++ b/packages/app/src/main/comfy/batchHttp.test.ts
@@ -56,6 +56,46 @@ describe('ComfyBatchHttpClient retry and boundary behavior', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 
+  it('finds an ambiguously submitted prompt in the pending queue', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(Response.json({}, { status: 200 }))
+      .mockResolvedValueOnce(
+        Response.json(
+          { queue_running: [], queue_pending: [[1, 'known-prompt-id']] },
+          { status: 200 }
+        )
+      )
+    const client = new ComfyBatchHttpClient('http://127.0.0.1:8188', fetchMock as typeof fetch)
+
+    await expect(client.promptAdmission('known-prompt-id')).resolves.toBe(true)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps caller cancellation attached while a response body is still loading', async () => {
+    const controller = new AbortController()
+    const fetchMock = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+      return new Response(
+        new ReadableStream({
+          start(streamController) {
+            init?.signal?.addEventListener(
+              'abort',
+              () => streamController.error(new DOMException('Aborted', 'AbortError')),
+              { once: true }
+            )
+          }
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      )
+    })
+    const client = new ComfyBatchHttpClient('http://127.0.0.1:8188', fetchMock as typeof fetch)
+
+    const pending = client.objectInfo(controller.signal)
+    await Promise.resolve()
+    controller.abort()
+    await expect(pending).rejects.toThrow(/cancelled/i)
+  })
+
   it('does not retry an upload whose submit result is unknown', async () => {
     const fetchMock = vi.fn().mockRejectedValue(new TypeError('unknown upload result'))
     vi.stubGlobal('fetch', fetchMock)

--- a/packages/app/src/main/comfy/batchHttp.ts
+++ b/packages/app/src/main/comfy/batchHttp.ts
@@ -132,6 +132,10 @@ export class ComfyBatchHttpClient {
     return this.consume(pathname, init, options, async (response) => (await response.json()) as T)
   }
 
+  private noContent(pathname: string, init: RequestInit = {}, options: RequestOptions = {}) {
+    return this.consume(pathname, init, options, async () => undefined)
+  }
+
   async probe(): Promise<{ endpoint: 'system_stats' | 'queue'; latencyMs: number }> {
     const startedAt = Date.now()
     try {
@@ -212,54 +216,74 @@ export class ComfyBatchHttpClient {
     })
   }
 
-  async promptAdmission(promptId: string, signal?: AbortSignal): Promise<boolean> {
+  async promptAdmission(
+    promptId: string,
+    signal?: AbortSignal,
+    clientId?: string
+  ): Promise<{ admitted: boolean; promptId: string }> {
     const history = await this.history(promptId, signal)
-    if (history[promptId]) return true
+    if (history[promptId]) return { admitted: true, promptId }
     const queue = await this.json<{
       queue_running?: unknown[][]
       queue_pending?: unknown[][]
     }>('/queue', {}, { signal })
-    return [...(queue.queue_running || []), ...(queue.queue_pending || [])].some(
-      (item) => item[1] === promptId
-    )
+    const items = [...(queue.queue_running || []), ...(queue.queue_pending || [])]
+    const exact = items.find((item) => item[1] === promptId)
+    if (exact) return { admitted: true, promptId }
+    if (clientId) {
+      const byClient = items.filter(
+        (item) =>
+          typeof item[1] === 'string' &&
+          item[3] !== null &&
+          typeof item[3] === 'object' &&
+          (item[3] as { client_id?: unknown }).client_id === clientId
+      )
+      if (byClient.length === 1) return { admitted: true, promptId: String(byClient[0][1]) }
+    }
+    return { admitted: false, promptId }
   }
 
   async waitForPromptAdmission(
     promptId: string,
     signal?: AbortSignal,
-    timeoutMs = 5_000
-  ): Promise<boolean> {
+    timeoutMs = 5_000,
+    clientId?: string
+  ): Promise<{ admitted: boolean; promptId: string }> {
     const deadline = Date.now() + Math.max(0, timeoutMs)
     while (!signal?.aborted && Date.now() < deadline) {
       try {
-        if (await this.promptAdmission(promptId, signal)) return true
+        const admission = await this.promptAdmission(promptId, signal, clientId)
+        if (admission.admitted) return admission
       } catch {
         // Retry admission lookup until the short ambiguity window expires.
       }
       await new Promise((resolve) => setTimeout(resolve, 200))
     }
     if (signal?.aborted) throw new Error('Batch cancelled')
-    return false
+    return { admitted: false, promptId }
   }
 
   async cancelPrompt(promptId: string): Promise<void> {
-    await this.json(
-      '/queue',
-      {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ delete: [promptId] })
-      },
-      { retry: false }
-    )
-    await this.json(
-      '/interrupt',
-      {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ prompt_id: promptId })
-      },
-      { retry: false }
-    )
+    const [queued, running] = await Promise.allSettled([
+      this.noContent(
+        '/queue',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ delete: [promptId] })
+        },
+        { retry: false }
+      ),
+      this.noContent(
+        '/interrupt',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ prompt_id: promptId })
+        },
+        { retry: false }
+      )
+    ])
+    if (queued.status === 'rejected' && running.status === 'rejected') throw queued.reason
   }
 }

--- a/packages/app/src/main/comfy/batchHttp.ts
+++ b/packages/app/src/main/comfy/batchHttp.ts
@@ -89,8 +89,13 @@ export class ComfyBatchHttpClient {
     return new URL(pathname.replace(/^\/+/, ''), this.baseUrl)
   }
 
-  private async request(pathname: string, init: RequestInit = {}, options: RequestOptions = {}) {
-    const execute = async (): Promise<Response> => {
+  private async consume<T>(
+    pathname: string,
+    init: RequestInit,
+    options: RequestOptions,
+    read: (response: Response) => Promise<T>
+  ): Promise<T> {
+    const execute = async (): Promise<T> => {
       const controller = new AbortController()
       const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? DEFAULT_TIMEOUT_MS)
       const relayAbort = (): void => controller.abort()
@@ -110,7 +115,7 @@ export class ComfyBatchHttpClient {
             response.status
           )
         }
-        return response
+        return await read(response)
       } catch (error) {
         if (error instanceof ComfyBatchHttpError) throw error
         if (options.signal?.aborted) throw new Error('Batch cancelled')
@@ -123,18 +128,17 @@ export class ComfyBatchHttpClient {
     return options.retry === false ? execute() : withNetworkRetry(execute)
   }
 
-  private async json<T>(pathname: string, init: RequestInit = {}, options: RequestOptions = {}) {
-    const response = await this.request(pathname, init, options)
-    return (await response.json()) as T
+  private json<T>(pathname: string, init: RequestInit = {}, options: RequestOptions = {}) {
+    return this.consume(pathname, init, options, async (response) => (await response.json()) as T)
   }
 
   async probe(): Promise<{ endpoint: 'system_stats' | 'queue'; latencyMs: number }> {
     const startedAt = Date.now()
     try {
-      await this.request('/system_stats', {}, { retry: false, timeoutMs: 8_000 })
+      await this.json('/system_stats', {}, { retry: false, timeoutMs: 8_000 })
       return { endpoint: 'system_stats', latencyMs: Date.now() - startedAt }
     } catch {
-      await this.request('/queue', {}, { retry: false, timeoutMs: 8_000 })
+      await this.json('/queue', {}, { retry: false, timeoutMs: 8_000 })
       return { endpoint: 'queue', latencyMs: Date.now() - startedAt }
     }
   }
@@ -192,19 +196,54 @@ export class ComfyBatchHttpClient {
       subfolder: file.subfolder || '',
       type: file.type || ''
     })
-    const response = await this.request(`/view?${query.toString()}`, {}, { signal })
-    const contentType = String(response.headers.get('content-type') || '')
-      .split(';', 1)[0]
-      .trim()
-      .toLowerCase()
-    if (contentType && contentType !== 'image/png' && contentType !== 'application/octet-stream') {
-      throw new Error(`ComfyUI output must be PNG, got ${contentType}`)
+    return this.consume(`/view?${query.toString()}`, {}, { signal }, async (response) => {
+      const contentType = String(response.headers.get('content-type') || '')
+        .split(';', 1)[0]
+        .trim()
+        .toLowerCase()
+      if (
+        contentType &&
+        contentType !== 'image/png' &&
+        contentType !== 'application/octet-stream'
+      ) {
+        throw new Error(`ComfyUI output must be PNG, got ${contentType}`)
+      }
+      return new Uint8Array(await response.arrayBuffer())
+    })
+  }
+
+  async promptAdmission(promptId: string, signal?: AbortSignal): Promise<boolean> {
+    const history = await this.history(promptId, signal)
+    if (history[promptId]) return true
+    const queue = await this.json<{
+      queue_running?: unknown[][]
+      queue_pending?: unknown[][]
+    }>('/queue', {}, { signal })
+    return [...(queue.queue_running || []), ...(queue.queue_pending || [])].some(
+      (item) => item[1] === promptId
+    )
+  }
+
+  async waitForPromptAdmission(
+    promptId: string,
+    signal?: AbortSignal,
+    timeoutMs = 5_000
+  ): Promise<boolean> {
+    const deadline = Date.now() + Math.max(0, timeoutMs)
+    while (!signal?.aborted && Date.now() < deadline) {
+      try {
+        if (await this.promptAdmission(promptId, signal)) return true
+      } catch {
+        // Retry admission lookup until the short ambiguity window expires.
+      }
+      await new Promise((resolve) => setTimeout(resolve, 200))
     }
-    return new Uint8Array(await response.arrayBuffer())
+    if (signal?.aborted) throw new Error('Batch cancelled')
+    return false
   }
 
   async cancelPrompt(promptId: string): Promise<void> {
-    await this.request(
+    await this.json(
       '/queue',
       {
         method: 'POST',
@@ -213,7 +252,7 @@ export class ComfyBatchHttpClient {
       },
       { retry: false }
     )
-    await this.request(
+    await this.json(
       '/interrupt',
       {
         method: 'POST',

--- a/packages/app/src/main/comfy/batchHttp.ts
+++ b/packages/app/src/main/comfy/batchHttp.ts
@@ -1,0 +1,226 @@
+import type { ComfyHistoryResp, FileItem, ObjectInfoMap, Workflow } from '@shared/comfy/types'
+
+const DEFAULT_TIMEOUT_MS = 30_000
+export const COMFY_BATCH_MAX_NETWORK_ATTEMPTS = 4
+
+export class ComfyBatchHttpError extends Error {
+  constructor(
+    message: string,
+    readonly retryable: boolean,
+    readonly status?: number
+  ) {
+    super(message)
+    this.name = 'ComfyBatchHttpError'
+  }
+}
+
+export function normalizeComfyBatchBaseUrl(value: string): string {
+  let url: URL
+  try {
+    url = new URL(String(value || '').trim())
+  } catch {
+    throw new Error('Invalid ComfyUI URL')
+  }
+  if (!['http:', 'https:'].includes(url.protocol) || url.username || url.password) {
+    throw new Error('Invalid ComfyUI URL')
+  }
+  url.hash = ''
+  url.search = ''
+  if (!url.pathname.endsWith('/')) url.pathname += '/'
+  return url.href
+}
+
+function isRetryableStatus(status: number): boolean {
+  return status === 408 || status === 425 || status === 429 || status >= 500
+}
+
+export async function withNetworkRetry<T>(
+  operation: () => Promise<T>,
+  options: { attempts?: number; delayMs?: number } = {}
+): Promise<T> {
+  const attempts = Math.max(1, Math.min(COMFY_BATCH_MAX_NETWORK_ATTEMPTS, options.attempts ?? 4))
+  let lastError: unknown
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return await operation()
+    } catch (error) {
+      lastError = error
+      const retryable =
+        error instanceof ComfyBatchHttpError ? error.retryable : error instanceof TypeError
+      if (!retryable || attempt === attempts) throw error
+      const delayMs = options.delayMs ?? 150
+      if (delayMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, delayMs * attempt))
+      }
+    }
+  }
+  throw lastError
+}
+
+type FetchLike = typeof fetch
+
+type RequestOptions = {
+  retry?: boolean
+  timeoutMs?: number
+  signal?: AbortSignal
+}
+
+function isRedirectStatus(status: number): boolean {
+  return status >= 300 && status < 400
+}
+
+function requireSafeResponse(response: Response): void {
+  if (isRedirectStatus(response.status)) {
+    throw new ComfyBatchHttpError('ComfyUI redirects are not allowed', false, response.status)
+  }
+}
+
+export class ComfyBatchHttpClient {
+  readonly baseUrl: string
+
+  constructor(
+    baseUrl: string,
+    private readonly fetchImpl: FetchLike = fetch
+  ) {
+    this.baseUrl = normalizeComfyBatchBaseUrl(baseUrl)
+  }
+
+  private url(pathname: string): URL {
+    return new URL(pathname.replace(/^\/+/, ''), this.baseUrl)
+  }
+
+  private async request(pathname: string, init: RequestInit = {}, options: RequestOptions = {}) {
+    const execute = async (): Promise<Response> => {
+      const controller = new AbortController()
+      const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? DEFAULT_TIMEOUT_MS)
+      const relayAbort = (): void => controller.abort()
+      options.signal?.addEventListener('abort', relayAbort, { once: true })
+      try {
+        const response = await this.fetchImpl(this.url(pathname), {
+          ...init,
+          signal: controller.signal,
+          redirect: 'manual'
+        })
+        requireSafeResponse(response)
+        if (!response.ok) {
+          const detail = (await response.text().catch(() => '')).slice(0, 1000)
+          throw new ComfyBatchHttpError(
+            `ComfyUI HTTP ${response.status}${detail ? `: ${detail}` : ''}`,
+            isRetryableStatus(response.status),
+            response.status
+          )
+        }
+        return response
+      } catch (error) {
+        if (error instanceof ComfyBatchHttpError) throw error
+        if (options.signal?.aborted) throw new Error('Batch cancelled')
+        throw new ComfyBatchHttpError(error instanceof Error ? error.message : String(error), true)
+      } finally {
+        clearTimeout(timeout)
+        options.signal?.removeEventListener('abort', relayAbort)
+      }
+    }
+    return options.retry === false ? execute() : withNetworkRetry(execute)
+  }
+
+  private async json<T>(pathname: string, init: RequestInit = {}, options: RequestOptions = {}) {
+    const response = await this.request(pathname, init, options)
+    return (await response.json()) as T
+  }
+
+  async probe(): Promise<{ endpoint: 'system_stats' | 'queue'; latencyMs: number }> {
+    const startedAt = Date.now()
+    try {
+      await this.request('/system_stats', {}, { retry: false, timeoutMs: 8_000 })
+      return { endpoint: 'system_stats', latencyMs: Date.now() - startedAt }
+    } catch {
+      await this.request('/queue', {}, { retry: false, timeoutMs: 8_000 })
+      return { endpoint: 'queue', latencyMs: Date.now() - startedAt }
+    }
+  }
+
+  objectInfo(signal?: AbortSignal): Promise<ObjectInfoMap> {
+    return this.json('/object_info', {}, { signal })
+  }
+
+  async uploadImage(filename: string, image: Uint8Array, signal?: AbortSignal): Promise<FileItem> {
+    const formData = new FormData()
+    formData.append('image', new Blob([image as BlobPart]), filename)
+    formData.append('type', 'input')
+    formData.append('overwrite', 'true')
+    const response = await this.json<{
+      name?: string
+      filename?: string
+      subfolder?: string
+      type?: string
+    }>('/upload/image', { method: 'POST', body: formData }, { signal, retry: false })
+    const uploadedFilename = response.name ?? response.filename
+    if (!uploadedFilename) throw new Error('ComfyUI upload response has no filename')
+    return {
+      filename: uploadedFilename,
+      subfolder: response.subfolder,
+      type: response.type || 'input'
+    }
+  }
+
+  async prompt(
+    workflow: Workflow,
+    clientId: string,
+    promptId: string,
+    signal?: AbortSignal
+  ): Promise<string> {
+    const response = await this.json<{ prompt_id?: string }>(
+      '/prompt',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt: workflow, client_id: clientId, prompt_id: promptId })
+      },
+      { signal, retry: false }
+    )
+    if (!response.prompt_id) throw new Error('ComfyUI prompt response has no prompt_id')
+    return response.prompt_id
+  }
+
+  history(promptId: string, signal?: AbortSignal): Promise<ComfyHistoryResp> {
+    return this.json(`/history/${encodeURIComponent(promptId)}`, {}, { signal })
+  }
+
+  async view(file: FileItem, signal?: AbortSignal): Promise<Uint8Array> {
+    const query = new URLSearchParams({
+      filename: file.filename || '',
+      subfolder: file.subfolder || '',
+      type: file.type || ''
+    })
+    const response = await this.request(`/view?${query.toString()}`, {}, { signal })
+    const contentType = String(response.headers.get('content-type') || '')
+      .split(';', 1)[0]
+      .trim()
+      .toLowerCase()
+    if (contentType && contentType !== 'image/png' && contentType !== 'application/octet-stream') {
+      throw new Error(`ComfyUI output must be PNG, got ${contentType}`)
+    }
+    return new Uint8Array(await response.arrayBuffer())
+  }
+
+  async cancelPrompt(promptId: string): Promise<void> {
+    await this.request(
+      '/queue',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ delete: [promptId] })
+      },
+      { retry: false }
+    )
+    await this.request(
+      '/interrupt',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt_id: promptId })
+      },
+      { retry: false }
+    )
+  }
+}

--- a/packages/app/src/main/comfy/batchRunner.test.ts
+++ b/packages/app/src/main/comfy/batchRunner.test.ts
@@ -323,6 +323,58 @@ describe('ComfyBatchRunner resume and retry semantics', () => {
     expect(manifest.items['deleted.jpg']).toBeUndefined()
   })
 
+  it('never follows a corrupted manifest output path outside the output folder', async () => {
+    const sourceDir = await createTempDir()
+    const protectedPath = path.join(sourceDir, 'protected.png')
+    await fs.writeFile(path.join(sourceDir, 'current.jpg'), 'source')
+    await fs.writeFile(protectedPath, validPng)
+    const manifestDir = path.join(`${sourceDir}.output`, '.magicpot-batch')
+    await fs.mkdir(manifestDir, { recursive: true })
+    await fs.writeFile(
+      path.join(manifestDir, 'manifest.json'),
+      JSON.stringify({
+        version: 2,
+        sourceDir,
+        outputDir: `${sourceDir}.output`,
+        planFingerprint: 'old',
+        updatedAt: Date.now(),
+        items: {
+          'deleted.jpg': {
+            relativePath: 'deleted.jpg',
+            size: 1,
+            mtimeMs: 1,
+            sha256: 'old',
+            planFingerprint: 'old',
+            status: 'success',
+            outputRelativePath: '../protected.png',
+            updatedAt: Date.now()
+          }
+        }
+      })
+    )
+    const fakeClient = {
+      probe: async () => ({ endpoint: 'system_stats' as const, latencyMs: 1 }),
+      objectInfo: async () => objectInfo(),
+      uploadImage: async () => ({ filename: 'upload.png', subfolder: '', type: 'input' }),
+      prompt: async (_workflow: Workflow, _clientId: string, promptId: string) => promptId,
+      history: async (promptId: string) => ({
+        [promptId]: {
+          outputs: {
+            '2': { images: [{ filename: 'result.png', subfolder: '', type: 'output' }] }
+          },
+          status: { status_str: 'success', completed: true, messages: [] }
+        }
+      }),
+      view: async () => new Uint8Array(validPng)
+    } as unknown as ComfyBatchHttpClient
+
+    await new ComfyBatchRunner(request(sourceDir), [profile('one')], {
+      createClient: () => fakeClient
+    }).run()
+
+    expect(await fs.readFile(protectedPath)).toEqual(validPng)
+  })
+
   it('retry mode rescans and reruns failed, added, changed, and missing-output items', async () => {
     const sourceDir = await createTempDir()
     await Promise.all([

--- a/packages/app/src/main/comfy/batchRunner.test.ts
+++ b/packages/app/src/main/comfy/batchRunner.test.ts
@@ -283,6 +283,46 @@ describe('ComfyBatchRunner resume and retry semantics', () => {
     await expect(fs.stat(`${sourceDir}.output`)).rejects.toMatchObject({ code: 'ENOENT' })
   })
 
+  it('removes stale outputs and manifest entries for deleted sources', async () => {
+    const sourceDir = await createTempDir()
+    const sourcePath = path.join(sourceDir, 'deleted.jpg')
+    await fs.writeFile(sourcePath, 'source')
+    const fakeClient = {
+      probe: async () => ({ endpoint: 'system_stats' as const, latencyMs: 1 }),
+      objectInfo: async () => objectInfo(),
+      uploadImage: async () => ({ filename: 'upload.png', subfolder: '', type: 'input' }),
+      prompt: async (_workflow: Workflow, _clientId: string, promptId: string) => promptId,
+      history: async (promptId: string) => ({
+        [promptId]: {
+          outputs: {
+            '2': { images: [{ filename: 'result.png', subfolder: '', type: 'output' }] }
+          },
+          status: { status_str: 'success', completed: true, messages: [] }
+        }
+      }),
+      view: async () => new Uint8Array(validPng)
+    } as unknown as ComfyBatchHttpClient
+
+    await new ComfyBatchRunner(request(sourceDir), [profile('one')], {
+      createClient: () => fakeClient
+    }).run()
+    const outputPath = path.join(`${sourceDir}.output`, 'deleted.png')
+    await fs.rm(sourcePath)
+    await fs.writeFile(path.join(sourceDir, 'remaining.jpg'), 'source')
+    await new ComfyBatchRunner(request(sourceDir), [profile('one')], {
+      createClient: () => fakeClient
+    }).run()
+
+    await expect(fs.stat(outputPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    const manifest = JSON.parse(
+      await fs.readFile(
+        path.join(`${sourceDir}.output`, '.magicpot-batch', 'manifest.json'),
+        'utf8'
+      )
+    ) as { items: Record<string, unknown> }
+    expect(manifest.items['deleted.jpg']).toBeUndefined()
+  })
+
   it('retry mode rescans and reruns failed, added, changed, and missing-output items', async () => {
     const sourceDir = await createTempDir()
     await Promise.all([

--- a/packages/app/src/main/comfy/batchRunner.test.ts
+++ b/packages/app/src/main/comfy/batchRunner.test.ts
@@ -1,0 +1,401 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import type { ComfyBatchProfile, StartComfyBatchReq } from '@shared/api/svcComfyBatch'
+import type { ObjectInfoMap, Workflow } from '@shared/comfy/types'
+import {
+  assertNoComfyBatchOutputCollisions,
+  ComfyBatchRunner,
+  getComfyBatchOutputDir,
+  getComfyBatchOutputRelativePath,
+  selectBoundOutputImage,
+  scanComfyBatchImages,
+  LeastLoadRoundRobinScheduler,
+  atomicCommitPng,
+  isValidPng,
+  validateComfyBatchBindings
+} from './batchRunner'
+import type { ComfyBatchHttpClient } from './batchHttp'
+
+const temporaryDirectories: string[] = []
+
+async function createTempDir(): Promise<string> {
+  await fs.mkdir('/tmp', { recursive: true })
+  const directory = await fs.mkdtemp('/tmp/magicpot-comfy-batch-')
+  const resolved = path.resolve(directory)
+  temporaryDirectories.push(resolved)
+  return resolved
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => fs.rm(directory, { recursive: true, force: true }))
+  )
+})
+
+const profile = (id: string): ComfyBatchProfile => ({
+  id,
+  name: id,
+  baseUrl: `http://${id}.example`,
+  enabled: true,
+  maxConcurrency: 1
+})
+
+type Runtime = { profile: ComfyBatchProfile; inflight: number; id: string }
+
+function runtime(id: string, inflight = 0): Runtime {
+  return { profile: profile(id), inflight, id }
+}
+
+const validPng = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP4z8DwHwAFAAH/iZk9HQAAAABJRU5ErkJggg==',
+  'base64'
+)
+
+function objectInfo(): ObjectInfoMap {
+  return {
+    LoadImage: {
+      input: { required: { image: [['example.png'], { image_upload: true }] } },
+      output: ['IMAGE']
+    },
+    SaveImage: { output_node: true, output: [] }
+  }
+}
+
+describe('Comfy batch paths and discovery', () => {
+  it('uses only the adjacent .output directory and preserves relative image paths', async () => {
+    const sourceDir = await createTempDir()
+    await fs.mkdir(path.join(sourceDir, 'nested'))
+    await fs.writeFile(path.join(sourceDir, 'cover.jpg'), 'jpg')
+    await fs.writeFile(path.join(sourceDir, 'nested', 'photo.webp'), 'webp')
+    await fs.writeFile(path.join(sourceDir, 'nested', 'ignore.txt'), 'text')
+
+    const sources = await scanComfyBatchImages(sourceDir)
+
+    expect(getComfyBatchOutputDir(sourceDir)).toBe(`${sourceDir}.output`)
+    expect(getComfyBatchOutputRelativePath('nested/photo.webp')).toBe(
+      path.join('nested', 'photo.png')
+    )
+    expect(sources.map((source) => source.relativePath)).toEqual([
+      'cover.jpg',
+      path.join('nested', 'photo.webp')
+    ])
+    await expect(fs.stat(`${sourceDir}.work`)).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('rejects two sources that would overwrite the same PNG', () => {
+    expect(() =>
+      assertNoComfyBatchOutputCollisions([
+        { absolutePath: '/tmp/a.jpg', relativePath: 'a.jpg', size: 1, mtimeMs: 1, sha256: 'a' },
+        { absolutePath: '/tmp/a.webp', relativePath: 'a.webp', size: 1, mtimeMs: 1, sha256: 'b' }
+      ])
+    ).toThrow(/collision/i)
+  })
+})
+
+describe('Comfy batch dispatch and output binding', () => {
+  const workflow: Workflow = {
+    '1': { class_type: 'LoadImage', inputs: { image: '' } },
+    '2': { class_type: 'SaveImage', inputs: {} }
+  }
+
+  it('strictly validates the image upload path and output node ids', () => {
+    expect(validateComfyBatchBindings(workflow, '$.1.inputs.image', ['2'], objectInfo())).toEqual({
+      nodeId: '1',
+      field: 'image'
+    })
+    expect(() =>
+      validateComfyBatchBindings(workflow, '$.1.inputs.__proto__', ['2'], objectInfo())
+    ).toThrow(/forbidden|does not exist/i)
+    expect(() =>
+      validateComfyBatchBindings(workflow, '$.__proto__.inputs.image', ['2'], objectInfo())
+    ).toThrow(/forbidden/i)
+    expect(() =>
+      validateComfyBatchBindings(workflow, '$.1.inputs.missing', ['2'], objectInfo())
+    ).toThrow(/does not exist/i)
+    expect(() => validateComfyBatchBindings(workflow, '$.1.inputs.image.extra', ['2'])).toThrow(
+      /must match/i
+    )
+    expect(() => validateComfyBatchBindings(workflow, '$.1.inputs.image', ['2', '2'])).toThrow(
+      /unique/i
+    )
+    expect(() => validateComfyBatchBindings(workflow, '$.1.inputs.image', ['missing'])).toThrow(
+      /does not exist/i
+    )
+    expect(() =>
+      validateComfyBatchBindings(workflow, '$.1.inputs.image', ['2'], {
+        ...objectInfo(),
+        LoadImage: { input: { required: { image: ['STRING', {}] } }, output: ['IMAGE'] }
+      })
+    ).toThrow(/image upload field/i)
+  })
+
+  it('validates complete PNG structure and rejects corrupt commits', async () => {
+    expect(isValidPng(validPng)).toBe(true)
+    expect(isValidPng(validPng.subarray(0, validPng.length - 1))).toBe(false)
+    expect(isValidPng(Buffer.concat([validPng, Buffer.from([0])]))).toBe(false)
+    const crcCorrupt = Buffer.from(validPng)
+    crcCorrupt[20] ^= 1
+    expect(isValidPng(crcCorrupt)).toBe(false)
+    expect(isValidPng(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))).toBe(false)
+
+    const directory = await createTempDir()
+    const destination = path.join(directory, 'result.png')
+    await expect(atomicCommitPng(destination, validPng.subarray(0, 20))).rejects.toThrow(
+      /valid PNG/i
+    )
+    await expect(fs.stat(destination)).rejects.toMatchObject({ code: 'ENOENT' })
+    await fs.writeFile(destination, 'old')
+    await atomicCommitPng(destination, validPng)
+    expect(await fs.readFile(destination)).toEqual(validPng)
+  })
+
+  it('selects minimum utilization and uses round-robin for ties', () => {
+    const runtimes = [runtime('a'), runtime('b'), runtime('busy', 1)]
+    const scheduler = new LeastLoadRoundRobinScheduler<Runtime>()
+    expect(scheduler.pick(runtimes)?.profile.id).toBe('a')
+    expect(scheduler.pick(runtimes)?.profile.id).toBe('b')
+  })
+
+  it('requires one unique type=output image from bound nodes', () => {
+    const baseImage = { filename: 'result.png', subfolder: '', type: 'output' }
+    expect(
+      selectBoundOutputImage(
+        {
+          outputs: {
+            '9': { images: [{ ...baseImage, type: 'temp' }, baseImage] },
+            '10': { images: [{ filename: 'other.png', subfolder: '', type: 'output' }] }
+          }
+        },
+        ['9']
+      )
+    ).toEqual(baseImage)
+    expect(() =>
+      selectBoundOutputImage(
+        {
+          outputs: { '9': { images: [baseImage, { ...baseImage, filename: 'second.png' }] } }
+        },
+        ['9']
+      )
+    ).toThrow(/exactly one/i)
+  })
+})
+
+describe('ComfyBatchRunner resume and retry semantics', () => {
+  const workflow: Workflow = {
+    '1': { class_type: 'LoadImage', inputs: { image: '' } },
+    '2': { class_type: 'SaveImage', inputs: {} }
+  }
+
+  const request = (sourceDir: string): StartComfyBatchReq => ({
+    sourceDir,
+    qAppKey: 'test-qapp',
+    workflow,
+    imageInputSlot: '$.1.inputs.image',
+    outputNodeIds: ['2']
+  })
+
+  it('atomically commits PNG output, then skips an unchanged valid success on rerun', async () => {
+    const sourceDir = await createTempDir()
+    await fs.writeFile(path.join(sourceDir, 'source.jpg'), 'source')
+    let promptCalls = 0
+    const png = validPng
+    const fakeClient = {
+      probe: async () => ({ endpoint: 'system_stats' as const, latencyMs: 1 }),
+      objectInfo: async () => objectInfo(),
+      uploadImage: async () => ({ name: 'upload.png', subfolder: '', type: 'input' as const }),
+      prompt: async (_workflow: Workflow, _clientId: string, promptId: string) => {
+        promptCalls += 1
+        return promptId
+      },
+      history: async (promptId: string) => ({
+        [promptId]: {
+          outputs: {
+            '2': { images: [{ filename: 'result.png', subfolder: '', type: 'output' }] }
+          },
+          status: { status_str: 'success', completed: true, messages: [] }
+        }
+      }),
+      view: async () => new Uint8Array(png)
+    } as unknown as ComfyBatchHttpClient
+
+    const first = new ComfyBatchRunner(request(sourceDir), [profile('one')], {
+      createClient: () => fakeClient
+    })
+    const firstStatus = await first.run()
+    expect(firstStatus).toMatchObject({ state: 'completed', success: 1, failed: 0, skipped: 0 })
+    expect(await fs.readFile(`${sourceDir}.output/source.png`)).toEqual(png)
+    expect(promptCalls).toBe(1)
+
+    const second = new ComfyBatchRunner(request(sourceDir), [profile('one')], {
+      createClient: () => fakeClient
+    })
+    const secondStatus = await second.run()
+    expect(secondStatus).toMatchObject({ state: 'completed', success: 0, failed: 0, skipped: 1 })
+    expect(promptCalls).toBe(1)
+  })
+
+  it('reruns a same-size source edit even when its mtime is restored', async () => {
+    const sourceDir = await createTempDir()
+    const sourcePath = path.join(sourceDir, 'source.jpg')
+    await fs.writeFile(sourcePath, 'before')
+    const originalMtime = (await fs.stat(sourcePath)).mtime
+    let promptCalls = 0
+    const fakeClient = {
+      probe: async () => ({ endpoint: 'system_stats' as const, latencyMs: 1 }),
+      objectInfo: async () => objectInfo(),
+      uploadImage: async () => ({ filename: 'upload.png', subfolder: '', type: 'input' }),
+      prompt: async (_workflow: Workflow, _clientId: string, promptId: string) => {
+        promptCalls += 1
+        return promptId
+      },
+      history: async (promptId: string) => ({
+        [promptId]: {
+          outputs: {
+            '2': { images: [{ filename: 'result.png', subfolder: '', type: 'output' }] }
+          },
+          status: { status_str: 'success', completed: true, messages: [] }
+        }
+      }),
+      view: async () => new Uint8Array(validPng)
+    } as unknown as ComfyBatchHttpClient
+
+    await new ComfyBatchRunner(request(sourceDir), [profile('one')], {
+      createClient: () => fakeClient
+    }).run()
+    await fs.writeFile(sourcePath, 'change')
+    await fs.utimes(sourcePath, originalMtime, originalMtime)
+    const status = await new ComfyBatchRunner(request(sourceDir), [profile('one')], {
+      createClient: () => fakeClient
+    }).run()
+
+    expect(status).toMatchObject({ state: 'completed', success: 1, skipped: 0 })
+    expect(promptCalls).toBe(2)
+  })
+
+  it('rejects an empty source folder without creating an output folder', async () => {
+    const sourceDir = await createTempDir()
+    const status = await new ComfyBatchRunner(request(sourceDir), [profile('one')]).run()
+    expect(status).toMatchObject({ state: 'error', total: 0 })
+    expect(status.error).toMatch(/no supported images/i)
+    await expect(fs.stat(`${sourceDir}.output`)).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('retry mode rescans and reruns failed, added, changed, and missing-output items', async () => {
+    const sourceDir = await createTempDir()
+    await Promise.all([
+      fs.writeFile(path.join(sourceDir, 'failed.jpg'), 'failed'),
+      fs.writeFile(path.join(sourceDir, 'stable.jpg'), 'stable'),
+      fs.writeFile(path.join(sourceDir, 'changed.jpg'), 'before'),
+      fs.writeFile(path.join(sourceDir, 'missing.jpg'), 'missing')
+    ])
+    const calls: string[] = []
+    let failFailedItem = true
+    const fakeClient = {
+      probe: async () => ({ endpoint: 'system_stats' as const, latencyMs: 1 }),
+      objectInfo: async () => objectInfo(),
+      uploadImage: async (filename: string) => {
+        const sourceName = filename.includes('.jpg') ? filename : `${filename}.jpg`
+        return { filename: sourceName, subfolder: '', type: 'input' }
+      },
+      prompt: async (submittedWorkflow: Workflow, _clientId: string, promptId: string) => {
+        const uploaded = String(submittedWorkflow['1'].inputs.image)
+        const source = ['failed', 'stable', 'changed', 'missing', 'added'].find((name) =>
+          uploaded.includes(name)
+        )
+        if (source) calls.push(source)
+        return promptId
+      },
+      history: async (promptId: string) => ({
+        [promptId]: {
+          outputs: {
+            '2': { images: [{ filename: 'result.png', subfolder: '', type: 'output' }] }
+          },
+          status: { status_str: 'success', completed: true, messages: [] }
+        }
+      }),
+      view: async () => {
+        if (failFailedItem && calls.at(-1) === 'failed') throw new Error('first failure')
+        return new Uint8Array(validPng)
+      }
+    } as unknown as ComfyBatchHttpClient
+
+    // Keep upload names observable while retaining the runner's unique prefix.
+    fakeClient.uploadImage = (async (_filename: string, bytes: Uint8Array) => ({
+      filename: new TextDecoder().decode(bytes),
+      subfolder: '',
+      type: 'input'
+    })) as ComfyBatchHttpClient['uploadImage']
+
+    const first = new ComfyBatchRunner(request(sourceDir), [profile('one')], {
+      createClient: () => fakeClient
+    })
+    expect(await first.run()).toMatchObject({ success: 3, failed: 1 })
+
+    calls.length = 0
+    failFailedItem = false
+    await fs.writeFile(path.join(sourceDir, 'changed.jpg'), 'changed')
+    await fs.writeFile(path.join(sourceDir, 'added.jpg'), 'added')
+    await fs.rm(path.join(`${sourceDir}.output`, 'missing.png'))
+
+    const retry = new ComfyBatchRunner(request(sourceDir), [profile('one')], {
+      createClient: () => fakeClient
+    })
+    const retryStatus = await retry.run()
+
+    expect(retryStatus).toMatchObject({ state: 'completed', success: 4, skipped: 1, failed: 0 })
+    expect(calls.sort()).toEqual(['added', 'changed', 'failed', 'missing'])
+  })
+
+  it('switches to only one other compatible instance after a Comfy execution failure', async () => {
+    const sourceDir = await createTempDir()
+    await fs.writeFile(path.join(sourceDir, 'source.jpg'), 'source')
+    const calls: string[] = []
+    const clientFor = (id: string) =>
+      ({
+        probe: async () => ({ endpoint: 'system_stats' as const, latencyMs: 1 }),
+        objectInfo: async () => objectInfo(),
+        uploadImage: async () => ({ name: `${id}.png`, subfolder: '', type: 'input' as const }),
+        prompt: async (_workflow: Workflow, _clientId: string, promptId: string) => {
+          calls.push(id)
+          return promptId
+        },
+        history: async (promptId: string) => {
+          if (id === 'first') {
+            return {
+              [promptId]: {
+                outputs: {},
+                status: { status_str: 'error', completed: true, messages: [] }
+              }
+            }
+          }
+          return {
+            [promptId]: {
+              outputs: {
+                '2': { images: [{ filename: 'result.png', subfolder: '', type: 'output' }] }
+              },
+              status: { status_str: 'success', completed: true, messages: [] }
+            }
+          }
+        },
+        view: async () => new Uint8Array(validPng)
+      }) as unknown as ComfyBatchHttpClient
+
+    const runner = new ComfyBatchRunner(
+      request(sourceDir),
+      [profile('first'), profile('second'), profile('third')],
+      {
+        createClient: (baseUrl) =>
+          clientFor(
+            baseUrl.includes('first') ? 'first' : baseUrl.includes('second') ? 'second' : 'third'
+          )
+      }
+    )
+    const status = await runner.run()
+
+    expect(status).toMatchObject({ state: 'completed', success: 1, failed: 0 })
+    expect(calls).toEqual(['first', 'second'])
+  })
+})

--- a/packages/app/src/main/comfy/batchRunner.ts
+++ b/packages/app/src/main/comfy/batchRunner.ts
@@ -568,10 +568,7 @@ export class ComfyBatchRunner {
     for (const [promptId, client] of this.activePrompts) {
       void client.cancelPrompt(promptId).catch(() => undefined)
     }
-    if (this.statusValue.state === 'running') {
-      this.statusValue.state = 'cancelled'
-      this.emit()
-    }
+    this.emit()
   }
 
   private emit(): void {
@@ -615,6 +612,13 @@ export class ComfyBatchRunner {
     this.manifest.sourceDir = sourceDir
     this.manifest.outputDir = outputDir
     this.manifest.planFingerprint = planFingerprint
+
+    const currentSourcePaths = new Set(sources.map((source) => source.relativePath))
+    for (const [relativePath, item] of Object.entries(this.manifest.items)) {
+      if (currentSourcePaths.has(relativePath)) continue
+      await fs.rm(path.join(outputDir, item.outputRelativePath), { force: true })
+      delete this.manifest.items[relativePath]
+    }
 
     this.queue = []
     let skipped = 0
@@ -717,7 +721,8 @@ export class ComfyBatchRunner {
     const workflow = cloneWorkflow(this.request.workflow)
     bindUploadedImage(workflow, this.imageInputBinding, uploadedValue(uploaded))
     const requestedPromptId = randomUUID()
-    let promptId: string
+    let promptId: string = requestedPromptId
+    this.activePrompts.set(promptId, runtime.client)
     try {
       promptId = await runtime.client.prompt(
         workflow,
@@ -725,16 +730,20 @@ export class ComfyBatchRunner {
         requestedPromptId,
         this.abortController.signal
       )
+      if (promptId !== requestedPromptId) {
+        this.activePrompts.delete(requestedPromptId)
+        this.activePrompts.set(promptId, runtime.client)
+      }
     } catch (error) {
-      try {
-        const recovered = await runtime.client.history(requestedPromptId)
-        if (!recovered[requestedPromptId]) throw error
-        promptId = requestedPromptId
-      } catch {
+      const recovered = await runtime.client.waitForPromptAdmission(
+        requestedPromptId,
+        this.abortController.signal
+      )
+      if (!recovered) {
+        this.activePrompts.delete(requestedPromptId)
         throw error
       }
     }
-    this.activePrompts.set(promptId, runtime.client)
     try {
       const history = await waitForHistory(runtime.client, promptId, this.abortController.signal)
       const output = selectBoundOutputImage(history, this.request.outputNodeIds)

--- a/packages/app/src/main/comfy/batchRunner.ts
+++ b/packages/app/src/main/comfy/batchRunner.ts
@@ -250,6 +250,24 @@ export async function hasValidPngFile(filename: string): Promise<boolean> {
   }
 }
 
+function isSafeOutputRelativePath(value: unknown): value is string {
+  if (typeof value !== 'string' || !value || path.isAbsolute(value)) return false
+  const normalized = path.normalize(value)
+  return (
+    normalized !== '..' &&
+    !normalized.startsWith(`..${path.sep}`) &&
+    path.extname(normalized).toLowerCase() === '.png'
+  )
+}
+
+function resolveManifestOutputPath(outputDir: string, relativePath: unknown): string | null {
+  if (!isSafeOutputRelativePath(relativePath)) return null
+  const resolvedOutputDir = path.resolve(outputDir)
+  const candidate = path.resolve(resolvedOutputDir, relativePath)
+  const relation = path.relative(resolvedOutputDir, candidate)
+  return relation && !relation.startsWith('..') && !path.isAbsolute(relation) ? candidate : null
+}
+
 async function readManifest(sourceDir: string): Promise<ComfyBatchManifest | null> {
   try {
     const parsed = JSON.parse(await fs.readFile(getComfyBatchManifestPath(sourceDir), 'utf8'))
@@ -616,7 +634,8 @@ export class ComfyBatchRunner {
     const currentSourcePaths = new Set(sources.map((source) => source.relativePath))
     for (const [relativePath, item] of Object.entries(this.manifest.items)) {
       if (currentSourcePaths.has(relativePath)) continue
-      await fs.rm(path.join(outputDir, item.outputRelativePath), { force: true })
+      const staleOutputPath = resolveManifestOutputPath(outputDir, item.outputRelativePath)
+      if (staleOutputPath) await fs.rm(staleOutputPath, { force: true })
       delete this.manifest.items[relativePath]
     }
 
@@ -721,12 +740,13 @@ export class ComfyBatchRunner {
     const workflow = cloneWorkflow(this.request.workflow)
     bindUploadedImage(workflow, this.imageInputBinding, uploadedValue(uploaded))
     const requestedPromptId = randomUUID()
+    const clientId = `magicpot-batch-${this.jobId}-${requestedPromptId}`
     let promptId: string = requestedPromptId
     this.activePrompts.set(promptId, runtime.client)
     try {
       promptId = await runtime.client.prompt(
         workflow,
-        `magicpot-batch-${this.jobId}`,
+        clientId,
         requestedPromptId,
         this.abortController.signal
       )
@@ -735,13 +755,20 @@ export class ComfyBatchRunner {
         this.activePrompts.set(promptId, runtime.client)
       }
     } catch (error) {
-      const recovered = await runtime.client.waitForPromptAdmission(
+      const recovery = await runtime.client.waitForPromptAdmission(
         requestedPromptId,
-        this.abortController.signal
+        this.abortController.signal,
+        5_000,
+        clientId
       )
-      if (!recovered) {
+      if (!recovery.admitted) {
         this.activePrompts.delete(requestedPromptId)
         throw error
+      }
+      promptId = recovery.promptId
+      if (promptId !== requestedPromptId) {
+        this.activePrompts.delete(requestedPromptId)
+        this.activePrompts.set(promptId, runtime.client)
       }
     }
     try {

--- a/packages/app/src/main/comfy/batchRunner.ts
+++ b/packages/app/src/main/comfy/batchRunner.ts
@@ -1,0 +1,842 @@
+import { createHash, randomUUID } from 'node:crypto'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import type {
+  ComfyBatchProfile,
+  ComfyBatchStatus,
+  StartComfyBatchReq
+} from '@shared/api/svcComfyBatch'
+import type { ComfyHistory, FileItem, ObjectInfoMap, Workflow } from '@shared/comfy/types'
+import { ComfyBatchHttpClient } from './batchHttp'
+
+export const COMFY_BATCH_IMAGE_EXTENSIONS = new Set([
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.webp',
+  '.gif',
+  '.bmp',
+  '.tif',
+  '.tiff'
+])
+const PNG_SIGNATURE = Uint8Array.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+const MANIFEST_VERSION = 2
+const HISTORY_POLL_MS = 400
+const HISTORY_TIMEOUT_MS = 24 * 60 * 60 * 1000
+
+export type BatchSourceFile = {
+  absolutePath: string
+  relativePath: string
+  size: number
+  mtimeMs: number
+  sha256: string
+}
+
+type ManifestItemStatus = 'success' | 'failed'
+export type ComfyBatchManifestItem = {
+  relativePath: string
+  size: number
+  mtimeMs: number
+  sha256: string
+  planFingerprint: string
+  status: ManifestItemStatus
+  outputRelativePath: string
+  error?: string
+  updatedAt: number
+}
+
+export type ComfyBatchManifest = {
+  version: 2
+  sourceDir: string
+  outputDir: string
+  planFingerprint: string
+  updatedAt: number
+  items: Record<string, ComfyBatchManifestItem>
+}
+
+type InstanceRuntime = {
+  profile: ComfyBatchProfile
+  client: ComfyBatchHttpClient
+  inflight: number
+  compatible: boolean
+}
+
+type PendingBatchItem = {
+  source: BatchSourceFile
+  outputPath: string
+  outputRelativePath: string
+}
+
+export class ComfyExecutionError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ComfyExecutionError'
+  }
+}
+
+export function getComfyBatchOutputDir(sourceDir: string): string {
+  const resolved = path.resolve(sourceDir)
+  const parsed = path.parse(resolved)
+  if (resolved === parsed.root)
+    throw new Error('A filesystem root cannot be used as a batch source')
+  return `${resolved}.output`
+}
+
+export function getComfyBatchManifestPath(sourceDir: string): string {
+  return path.join(getComfyBatchOutputDir(sourceDir), '.magicpot-batch', 'manifest.json')
+}
+
+export function getComfyBatchOutputRelativePath(relativeSourcePath: string): string {
+  const normalized = path.normalize(relativeSourcePath)
+  if (
+    path.isAbsolute(normalized) ||
+    normalized === '..' ||
+    normalized.startsWith(`..${path.sep}`)
+  ) {
+    throw new Error(`Unsafe relative source path: ${relativeSourcePath}`)
+  }
+  const parsed = path.parse(normalized)
+  return path.join(parsed.dir, `${parsed.name}.png`)
+}
+
+function normalizeCollisionKey(value: string): string {
+  const normalized = path.normalize(value).replaceAll('\\', '/')
+  return process.platform === 'linux' ? normalized : normalized.toLocaleLowerCase()
+}
+
+export function assertNoComfyBatchOutputCollisions(sources: BatchSourceFile[]): void {
+  const sourceByOutput = new Map<string, string>()
+  for (const source of sources) {
+    const outputRelativePath = getComfyBatchOutputRelativePath(source.relativePath)
+    const key = normalizeCollisionKey(outputRelativePath)
+    const existing = sourceByOutput.get(key)
+    if (existing) {
+      throw new Error(
+        `Output filename collision: ${existing} and ${source.relativePath} both map to ${outputRelativePath}`
+      )
+    }
+    sourceByOutput.set(key, source.relativePath)
+  }
+}
+
+export async function scanComfyBatchImages(sourceDir: string): Promise<BatchSourceFile[]> {
+  const root = path.resolve(sourceDir)
+  const rootStats = await fs.stat(root)
+  if (!rootStats.isDirectory()) throw new Error('Batch source must be a directory')
+
+  const result: BatchSourceFile[] = []
+  const visit = async (directory: string): Promise<void> => {
+    const entries = await fs.readdir(directory, { withFileTypes: true })
+    entries.sort((left, right) => left.name.localeCompare(right.name))
+    for (const entry of entries) {
+      const absolutePath = path.join(directory, entry.name)
+      if (entry.isDirectory()) {
+        await visit(absolutePath)
+        continue
+      }
+      if (
+        !entry.isFile() ||
+        !COMFY_BATCH_IMAGE_EXTENSIONS.has(path.extname(entry.name).toLowerCase())
+      ) {
+        continue
+      }
+      const before = await fs.stat(absolutePath)
+      const bytes = await fs.readFile(absolutePath)
+      const after = await fs.stat(absolutePath)
+      if (before.size !== after.size || before.mtimeMs !== after.mtimeMs) {
+        throw new Error(`Batch source changed while scanning: ${absolutePath}`)
+      }
+      result.push({
+        absolutePath,
+        relativePath: path.relative(root, absolutePath),
+        size: after.size,
+        mtimeMs: after.mtimeMs,
+        sha256: createHash('sha256').update(bytes).digest('hex')
+      })
+    }
+  }
+  await visit(root)
+  return result
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value as Record<string, unknown>)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableJson((value as Record<string, unknown>)[key])}`)
+      .join(',')}}`
+  }
+  return JSON.stringify(value)
+}
+
+export function buildComfyBatchPlanFingerprint(input: {
+  qAppKey: string
+  workflow: Workflow
+  imageInputSlot: string
+  outputNodeIds: string[]
+}): string {
+  return createHash('sha256').update(stableJson(input)).digest('hex')
+}
+
+export function isPngSignature(bytes: Uint8Array): boolean {
+  return (
+    bytes.byteLength >= PNG_SIGNATURE.byteLength &&
+    PNG_SIGNATURE.every((value, index) => bytes[index] === value)
+  )
+}
+
+function readUint32Be(bytes: Uint8Array, offset: number): number {
+  return (
+    bytes[offset] * 0x1000000 +
+    bytes[offset + 1] * 0x10000 +
+    bytes[offset + 2] * 0x100 +
+    bytes[offset + 3]
+  )
+}
+
+function chunkType(bytes: Uint8Array, offset: number): string {
+  return String.fromCharCode(bytes[offset], bytes[offset + 1], bytes[offset + 2], bytes[offset + 3])
+}
+
+let pngCrcTable: Uint32Array | undefined
+function pngCrc32(bytes: Uint8Array, start: number, end: number): number {
+  if (!pngCrcTable) {
+    pngCrcTable = Uint32Array.from({ length: 256 }, (_, index) => {
+      let value = index
+      for (let bit = 0; bit < 8; bit += 1) {
+        value = (value & 1) !== 0 ? 0xedb88320 ^ (value >>> 1) : value >>> 1
+      }
+      return value >>> 0
+    })
+  }
+  let crc = 0xffffffff
+  for (let index = start; index < end; index += 1) {
+    crc = pngCrcTable[(crc ^ bytes[index]) & 0xff] ^ (crc >>> 8)
+  }
+  return (crc ^ 0xffffffff) >>> 0
+}
+
+export function isValidPng(bytes: Uint8Array): boolean {
+  if (!isPngSignature(bytes) || bytes.byteLength < 45) return false
+
+  let offset = PNG_SIGNATURE.byteLength
+  let chunkIndex = 0
+  let hasIdat = false
+  while (offset <= bytes.byteLength - 12) {
+    const dataLength = readUint32Be(bytes, offset)
+    const dataOffset = offset + 8
+    const crcOffset = dataOffset + dataLength
+    const nextOffset = crcOffset + 4
+    if (!Number.isSafeInteger(nextOffset) || nextOffset > bytes.byteLength) return false
+
+    const type = chunkType(bytes, offset + 4)
+    if (chunkIndex === 0 && (type !== 'IHDR' || dataLength !== 13)) return false
+    if (readUint32Be(bytes, crcOffset) !== pngCrc32(bytes, offset + 4, crcOffset)) return false
+    if (type === 'IDAT') hasIdat = true
+    if (type === 'IEND') return dataLength === 0 && hasIdat && nextOffset === bytes.byteLength
+
+    offset = nextOffset
+    chunkIndex += 1
+  }
+  return false
+}
+
+export async function hasValidPngFile(filename: string): Promise<boolean> {
+  try {
+    return isValidPng(new Uint8Array(await fs.readFile(filename)))
+  } catch {
+    return false
+  }
+}
+
+async function readManifest(sourceDir: string): Promise<ComfyBatchManifest | null> {
+  try {
+    const parsed = JSON.parse(await fs.readFile(getComfyBatchManifestPath(sourceDir), 'utf8'))
+    if (parsed?.version !== MANIFEST_VERSION || typeof parsed.items !== 'object') return null
+    return parsed as ComfyBatchManifest
+  } catch {
+    return null
+  }
+}
+
+async function fsyncDirectory(directory: string): Promise<void> {
+  let handle: Awaited<ReturnType<typeof fs.open>> | undefined
+  try {
+    handle = await fs.open(directory, 'r')
+    await handle.sync()
+  } catch (error) {
+    if (process.platform !== 'win32') throw error
+  } finally {
+    await handle?.close().catch(() => undefined)
+  }
+}
+
+async function replaceFile(tempPath: string, filename: string): Promise<void> {
+  const attempts = process.platform === 'win32' ? 4 : 1
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      await fs.rename(tempPath, filename)
+      return
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code
+      const retryable = ['EACCES', 'EBUSY', 'EEXIST', 'EPERM'].includes(code || '')
+      if (!retryable) throw error
+      if (process.platform === 'win32' && attempt === attempts) {
+        await fs.rm(filename, { force: true })
+        await fs.rename(tempPath, filename)
+        return
+      }
+      if (attempt === attempts) throw error
+      await new Promise((resolve) => setTimeout(resolve, 25 * attempt))
+    }
+  }
+}
+
+async function atomicWriteFile(filename: string, bytes: Uint8Array | string): Promise<void> {
+  const directory = path.dirname(filename)
+  await fs.mkdir(directory, { recursive: true })
+  const tempPath = path.join(directory, `.${path.basename(filename)}.${randomUUID()}.tmp`)
+  let handle: Awaited<ReturnType<typeof fs.open>> | undefined
+  try {
+    handle = await fs.open(tempPath, 'wx')
+    await handle.writeFile(bytes)
+    await handle.sync()
+    await handle.close()
+    handle = undefined
+    await replaceFile(tempPath, filename)
+    await fsyncDirectory(directory)
+  } catch (error) {
+    await handle?.close().catch(() => undefined)
+    await fs.rm(tempPath, { force: true }).catch(() => undefined)
+    throw error
+  }
+}
+
+export async function atomicCommitPng(filename: string, bytes: Uint8Array): Promise<void> {
+  if (!isValidPng(bytes)) throw new Error('ComfyUI output is not a valid PNG')
+  await atomicWriteFile(filename, bytes)
+}
+
+async function writeManifest(manifest: ComfyBatchManifest): Promise<void> {
+  manifest.updatedAt = Date.now()
+  await atomicWriteFile(
+    path.join(manifest.outputDir, '.magicpot-batch', 'manifest.json'),
+    JSON.stringify(manifest, null, 2)
+  )
+}
+
+export function requiredWorkflowClassTypes(workflow: Workflow): string[] {
+  return Array.from(
+    new Set(
+      Object.values(workflow)
+        .map((node) => node?.class_type)
+        .filter((classType): classType is string => Boolean(classType))
+    )
+  ).sort()
+}
+
+export function hasCompatibleNodeClasses(
+  workflow: Workflow,
+  objectInfo: Record<string, unknown>
+): boolean {
+  return requiredWorkflowClassTypes(workflow).every((classType) =>
+    Object.prototype.hasOwnProperty.call(objectInfo, classType)
+  )
+}
+
+const FORBIDDEN_PATH_SEGMENTS = new Set(['__proto__', 'prototype', 'constructor'])
+const IMAGE_INPUT_SLOT_PATTERN = /^\$\.([^.[\]]+)\.inputs\.([^.[\]]+)$/
+
+type ImageInputBinding = { nodeId: string; field: string }
+
+export function validateComfyBatchBindings(
+  workflow: Workflow,
+  imageInputSlot: string,
+  outputNodeIds: string[],
+  objectInfo?: ObjectInfoMap
+): ImageInputBinding {
+  const match = IMAGE_INPUT_SLOT_PATTERN.exec(imageInputSlot)
+  if (!match) {
+    throw new Error('imageInputSlot must match $.<node id>.inputs.<field>')
+  }
+  const [, nodeId, field] = match
+  if (FORBIDDEN_PATH_SEGMENTS.has(nodeId) || FORBIDDEN_PATH_SEGMENTS.has(field)) {
+    throw new Error('imageInputSlot contains a forbidden path segment')
+  }
+  if (!Object.prototype.hasOwnProperty.call(workflow, nodeId)) {
+    throw new Error(`imageInputSlot node does not exist: ${nodeId}`)
+  }
+  const node = workflow[nodeId]
+  if (!node || !Object.prototype.hasOwnProperty.call(node, 'inputs') || !node.inputs) {
+    throw new Error(`imageInputSlot node has no own inputs object: ${nodeId}`)
+  }
+  if (!Object.prototype.hasOwnProperty.call(node.inputs, field)) {
+    throw new Error(`imageInputSlot field does not exist: ${field}`)
+  }
+
+  if (!outputNodeIds.length) throw new Error('Quick App outputNodeIds must not be empty')
+  if (new Set(outputNodeIds).size !== outputNodeIds.length) {
+    throw new Error('Quick App outputNodeIds must be unique')
+  }
+  for (const outputNodeId of outputNodeIds) {
+    if (FORBIDDEN_PATH_SEGMENTS.has(outputNodeId)) {
+      throw new Error('outputNodeIds contains a forbidden node id')
+    }
+    if (!Object.prototype.hasOwnProperty.call(workflow, outputNodeId)) {
+      throw new Error(`Output node does not exist: ${outputNodeId}`)
+    }
+  }
+
+  if (objectInfo) {
+    const inputNodeInfo = objectInfo[node.class_type]
+    const fieldInfo =
+      inputNodeInfo?.input?.required?.[field] ?? inputNodeInfo?.input?.optional?.[field]
+    const fieldType = fieldInfo?.[0]
+    const fieldOptions = fieldInfo?.[1]
+    const isImageUpload =
+      Array.isArray(fieldInfo) &&
+      Array.isArray(fieldType) &&
+      typeof fieldOptions === 'object' &&
+      fieldOptions !== null &&
+      (fieldOptions as { image_upload?: unknown }).image_upload === true
+    if (!isImageUpload) {
+      throw new Error(`imageInputSlot must bind an image upload field: ${node.class_type}.${field}`)
+    }
+    for (const outputNodeId of outputNodeIds) {
+      const outputNode = workflow[outputNodeId]
+      const outputInfo = objectInfo[outputNode.class_type]
+      if (
+        !outputInfo ||
+        (outputInfo.output_node !== true && (outputInfo.output?.length ?? 0) === 0)
+      ) {
+        throw new Error(`Configured output node is not an output-producing node: ${outputNodeId}`)
+      }
+    }
+  }
+
+  return { nodeId, field }
+}
+
+function bindUploadedImage(workflow: Workflow, binding: ImageInputBinding, value: string): void {
+  workflow[binding.nodeId].inputs[binding.field] = value
+}
+
+export function selectBoundOutputImage(
+  history: Pick<ComfyHistory, 'outputs'>,
+  outputNodeIds: string[]
+): FileItem {
+  if (!outputNodeIds.length) throw new Error('Quick App outputNodeIds must not be empty')
+  const images = outputNodeIds.flatMap((nodeId) => history.outputs?.[nodeId]?.images || [])
+  const outputImages = images.filter(
+    (item): item is FileItem & { filename: string } => item?.type === 'output' && !!item.filename
+  )
+  if (outputImages.length !== 1) {
+    throw new Error(
+      outputImages.length === 0
+        ? 'No type=output image was produced by the bound output nodes'
+        : 'Expected exactly one image from the bound output nodes'
+    )
+  }
+  return outputImages[0]
+}
+
+export class LeastLoadRoundRobinScheduler<
+  T extends { inflight: number; profile: { maxConcurrency: number } }
+> {
+  private cursor = 0
+
+  pick(instances: T[], excluded = new Set<T>()): T | null {
+    if (!instances.length) return null
+    const available = instances.filter(
+      (instance) =>
+        !excluded.has(instance) && instance.inflight < Math.max(1, instance.profile.maxConcurrency)
+    )
+    if (!available.length) return null
+    const ratios = available.map(
+      (instance) => instance.inflight / Math.max(1, instance.profile.maxConcurrency)
+    )
+    const minimum = Math.min(...ratios)
+    const tied = available.filter(
+      (instance) => instance.inflight / Math.max(1, instance.profile.maxConcurrency) === minimum
+    )
+    const start = this.cursor % instances.length
+    const picked =
+      [...instances.slice(start), ...instances.slice(0, start)].find((instance) =>
+        tied.includes(instance)
+      ) || tied[0]
+    this.cursor = (instances.indexOf(picked) + 1) % instances.length
+    return picked
+  }
+}
+
+function cloneWorkflow(workflow: Workflow): Workflow {
+  return JSON.parse(JSON.stringify(workflow)) as Workflow
+}
+
+function uploadedValue(file: FileItem): string {
+  return file.subfolder ? `${file.subfolder}/${file.filename} [input]` : file.filename || ''
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+async function waitForHistory(
+  client: ComfyBatchHttpClient,
+  promptId: string,
+  signal: AbortSignal
+): Promise<ComfyHistory> {
+  const deadline = Date.now() + HISTORY_TIMEOUT_MS
+  while (Date.now() < deadline) {
+    if (signal.aborted) throw new Error('Batch cancelled')
+    const response = await client.history(promptId, signal)
+    const result = response[promptId]
+    if (result) {
+      if (result.status?.status_str === 'error') {
+        const executionMessage = result.status.messages?.find(
+          (message) => message[0] === 'execution_error'
+        )
+        const detail = executionMessage?.[1]
+        throw new ComfyExecutionError(
+          typeof detail === 'object' && detail && 'exception_message' in detail
+            ? String(detail.exception_message)
+            : 'ComfyUI execution failed'
+        )
+      }
+      if (result.status?.completed || result.status?.status_str === 'success') return result
+    }
+    await new Promise((resolve) => setTimeout(resolve, HISTORY_POLL_MS))
+  }
+  throw new Error('Timed out waiting for ComfyUI history')
+}
+
+export type ComfyBatchRunnerOptions = {
+  createClient?: (baseUrl: string) => ComfyBatchHttpClient
+  onStatus?: (status: ComfyBatchStatus) => void
+}
+
+export class ComfyBatchRunner {
+  readonly jobId = randomUUID()
+  readonly abortController = new AbortController()
+  private manifest!: ComfyBatchManifest
+  private imageInputBinding!: ImageInputBinding
+  private queue: PendingBatchItem[] = []
+  private runtimes: InstanceRuntime[] = []
+  private scheduler = new LeastLoadRoundRobinScheduler<InstanceRuntime>()
+  private manifestWriteQueue: Promise<void> = Promise.resolve()
+  private readonly createClient: (baseUrl: string) => ComfyBatchHttpClient
+  private readonly activePrompts = new Map<string, ComfyBatchHttpClient>()
+  private statusValue: ComfyBatchStatus
+
+  constructor(
+    private readonly request: StartComfyBatchReq,
+    private readonly profiles: ComfyBatchProfile[],
+    private readonly options: ComfyBatchRunnerOptions = {}
+  ) {
+    this.createClient = options.createClient ?? ((baseUrl) => new ComfyBatchHttpClient(baseUrl))
+    this.statusValue = {
+      jobId: this.jobId,
+      state: 'idle',
+      sourceDir: path.resolve(request.sourceDir),
+      outputDir: getComfyBatchOutputDir(request.sourceDir),
+      qAppKey: request.qAppKey,
+      total: 0,
+      success: 0,
+      failed: 0,
+      skipped: 0,
+      running: 0,
+      pending: 0,
+      failedFiles: []
+    }
+  }
+
+  get status(): ComfyBatchStatus {
+    return { ...this.statusValue, failedFiles: [...this.statusValue.failedFiles] }
+  }
+
+  startingStatus(): ComfyBatchStatus {
+    if (this.statusValue.state === 'idle') {
+      this.statusValue.state = 'running'
+      this.statusValue.startedAt = Date.now()
+    }
+    return this.status
+  }
+
+  cancel(): void {
+    this.abortController.abort()
+    for (const [promptId, client] of this.activePrompts) {
+      void client.cancelPrompt(promptId).catch(() => undefined)
+    }
+    if (this.statusValue.state === 'running') {
+      this.statusValue.state = 'cancelled'
+      this.emit()
+    }
+  }
+
+  private emit(): void {
+    this.options.onStatus?.(this.status)
+  }
+
+  private persistManifest(): Promise<void> {
+    const write = this.manifestWriteQueue.then(() => writeManifest(this.manifest))
+    this.manifestWriteQueue = write.catch(() => undefined)
+    return write
+  }
+
+  private async initialize(): Promise<void> {
+    if (!this.request.qAppKey.trim()) throw new Error('qAppKey is required')
+    if (!this.request.imageInputSlot.trim())
+      throw new Error('batchProcess.imageInputSlot is required')
+    this.imageInputBinding = validateComfyBatchBindings(
+      this.request.workflow,
+      this.request.imageInputSlot,
+      this.request.outputNodeIds
+    )
+    const sourceDir = path.resolve(this.request.sourceDir)
+    const outputDir = getComfyBatchOutputDir(sourceDir)
+    const planFingerprint = buildComfyBatchPlanFingerprint(this.request)
+    this.statusValue.planFingerprint = planFingerprint
+    const sources = await scanComfyBatchImages(sourceDir)
+    if (!sources.length) throw new Error('No supported images were found in the selected folder')
+    assertNoComfyBatchOutputCollisions(sources)
+    const previous = await readManifest(sourceDir)
+    this.manifest =
+      previous ||
+      ({
+        version: MANIFEST_VERSION,
+        sourceDir,
+        outputDir,
+        planFingerprint,
+        updatedAt: Date.now(),
+        items: {}
+      } satisfies ComfyBatchManifest)
+    this.manifest.version = MANIFEST_VERSION
+    this.manifest.sourceDir = sourceDir
+    this.manifest.outputDir = outputDir
+    this.manifest.planFingerprint = planFingerprint
+
+    this.queue = []
+    let skipped = 0
+    for (const source of sources) {
+      const outputRelativePath = getComfyBatchOutputRelativePath(source.relativePath)
+      const outputPath = path.join(outputDir, outputRelativePath)
+      const previousItem = this.manifest.items[source.relativePath]
+      const unchangedSuccess =
+        previousItem?.status === 'success' &&
+        previousItem.size === source.size &&
+        previousItem.mtimeMs === source.mtimeMs &&
+        previousItem.sha256 === source.sha256 &&
+        previousItem.planFingerprint === planFingerprint &&
+        previousItem.outputRelativePath === outputRelativePath &&
+        (await hasValidPngFile(outputPath))
+      if (unchangedSuccess) {
+        skipped += 1
+        continue
+      }
+      await fs.rm(outputPath, { force: true })
+      this.queue.push({ source, outputPath, outputRelativePath })
+    }
+    this.statusValue = {
+      ...this.statusValue,
+      state: 'running',
+      total: sources.length,
+      success: 0,
+      failed: 0,
+      skipped,
+      running: 0,
+      pending: this.queue.length,
+      error: undefined,
+      failedFiles: [],
+      startedAt: Date.now(),
+      finishedAt: undefined
+    }
+
+    await fs.mkdir(path.join(outputDir, '.magicpot-batch'), { recursive: true })
+    await this.persistManifest()
+    this.emit()
+    if (!this.queue.length) return
+
+    const enabled = this.profiles.filter((profile) => profile.enabled)
+    if (!enabled.length) throw new Error('No enabled ComfyUI batch profiles')
+    const probes = await Promise.allSettled(
+      enabled.map(async (profile) => {
+        const client = this.createClient(profile.baseUrl)
+        await client.probe()
+        const objectInfo = await client.objectInfo(this.abortController.signal)
+        const compatible = hasCompatibleNodeClasses(this.request.workflow, objectInfo)
+        if (compatible) {
+          validateComfyBatchBindings(
+            this.request.workflow,
+            this.request.imageInputSlot,
+            this.request.outputNodeIds,
+            objectInfo
+          )
+        }
+        return {
+          profile,
+          client,
+          inflight: 0,
+          compatible
+        }
+      })
+    )
+    this.runtimes = probes.flatMap((probe) => (probe.status === 'fulfilled' ? [probe.value] : []))
+    this.runtimes = this.runtimes.filter((runtime) => runtime.compatible)
+    if (!this.runtimes.length)
+      throw new Error('No enabled ComfyUI instance supports all workflow nodes')
+  }
+
+  private async readVerifiedSource(item: PendingBatchItem): Promise<Uint8Array> {
+    const before = await fs.stat(item.source.absolutePath)
+    if (before.size !== item.source.size || before.mtimeMs !== item.source.mtimeMs) {
+      throw new Error('Batch source image changed after scanning')
+    }
+    const bytes = new Uint8Array(await fs.readFile(item.source.absolutePath))
+    const after = await fs.stat(item.source.absolutePath)
+    const sha256 = createHash('sha256').update(bytes).digest('hex')
+    if (
+      after.size !== item.source.size ||
+      after.mtimeMs !== item.source.mtimeMs ||
+      sha256 !== item.source.sha256
+    ) {
+      throw new Error('Batch source image changed while it was being read')
+    }
+    return bytes
+  }
+
+  private async runOneOnInstance(item: PendingBatchItem, runtime: InstanceRuntime): Promise<void> {
+    const bytes = await this.readVerifiedSource(item)
+    const extension = path.extname(item.source.relativePath).toLowerCase()
+    const uploadName = `magicpot-batch-${this.jobId}-${randomUUID()}${extension || '.png'}`
+    const uploaded = await runtime.client.uploadImage(
+      uploadName,
+      bytes,
+      this.abortController.signal
+    )
+    const workflow = cloneWorkflow(this.request.workflow)
+    bindUploadedImage(workflow, this.imageInputBinding, uploadedValue(uploaded))
+    const requestedPromptId = randomUUID()
+    let promptId: string
+    try {
+      promptId = await runtime.client.prompt(
+        workflow,
+        `magicpot-batch-${this.jobId}`,
+        requestedPromptId,
+        this.abortController.signal
+      )
+    } catch (error) {
+      try {
+        const recovered = await runtime.client.history(requestedPromptId)
+        if (!recovered[requestedPromptId]) throw error
+        promptId = requestedPromptId
+      } catch {
+        throw error
+      }
+    }
+    this.activePrompts.set(promptId, runtime.client)
+    try {
+      const history = await waitForHistory(runtime.client, promptId, this.abortController.signal)
+      const output = selectBoundOutputImage(history, this.request.outputNodeIds)
+      const outputBytes = await runtime.client.view(output, this.abortController.signal)
+      await atomicCommitPng(item.outputPath, outputBytes)
+    } finally {
+      this.activePrompts.delete(promptId)
+    }
+  }
+
+  private async processItem(item: PendingBatchItem): Promise<void> {
+    const tried = new Set<InstanceRuntime>()
+    let executionSwitches = 0
+    while (true) {
+      const runtime = this.scheduler.pick(this.runtimes, tried)
+      if (!runtime) throw new Error('No compatible ComfyUI instance is available')
+      tried.add(runtime)
+      runtime.inflight += 1
+      this.statusValue.running += 1
+      this.emit()
+      try {
+        await this.runOneOnInstance(item, runtime)
+        this.manifest.items[item.source.relativePath] = {
+          relativePath: item.source.relativePath,
+          size: item.source.size,
+          mtimeMs: item.source.mtimeMs,
+          sha256: item.source.sha256,
+          planFingerprint: this.manifest.planFingerprint,
+          status: 'success',
+          outputRelativePath: item.outputRelativePath,
+          updatedAt: Date.now()
+        }
+        await this.persistManifest()
+        this.statusValue.success += 1
+        return
+      } catch (error) {
+        if (
+          error instanceof ComfyExecutionError &&
+          executionSwitches < 1 &&
+          this.runtimes.some((candidate) => !tried.has(candidate))
+        ) {
+          executionSwitches += 1
+          continue
+        }
+        const message = errorMessage(error)
+        await fs.rm(item.outputPath, { force: true }).catch(() => undefined)
+        this.manifest.items[item.source.relativePath] = {
+          relativePath: item.source.relativePath,
+          size: item.source.size,
+          mtimeMs: item.source.mtimeMs,
+          sha256: item.source.sha256,
+          planFingerprint: this.manifest.planFingerprint,
+          status: 'failed',
+          outputRelativePath: item.outputRelativePath,
+          error: message,
+          updatedAt: Date.now()
+        }
+        await this.persistManifest()
+        this.statusValue.failed += 1
+        this.statusValue.failedFiles.push(item.source.relativePath)
+        return
+      } finally {
+        runtime.inflight -= 1
+        this.statusValue.running -= 1
+        this.emit()
+      }
+    }
+  }
+
+  async run(): Promise<ComfyBatchStatus> {
+    this.startingStatus()
+    this.emit()
+    try {
+      await this.initialize()
+      const workerCount = Math.max(
+        1,
+        this.runtimes.reduce((sum, runtime) => sum + Math.max(1, runtime.profile.maxConcurrency), 0)
+      )
+      let nextIndex = 0
+      const workers = Array.from({ length: workerCount }, async () => {
+        while (!this.abortController.signal.aborted) {
+          const index = nextIndex
+          const item = this.queue[index]
+          if (!item) break
+          nextIndex += 1
+          this.statusValue.pending = Math.max(0, this.statusValue.pending - 1)
+          await this.processItem(item)
+        }
+      })
+      await Promise.all(workers)
+      await this.manifestWriteQueue
+      this.statusValue.state = this.abortController.signal.aborted ? 'cancelled' : 'completed'
+      this.statusValue.pending = Math.max(0, this.queue.length - nextIndex)
+      this.statusValue.finishedAt = Date.now()
+      this.emit()
+      return this.status
+    } catch (error) {
+      this.statusValue.state = this.abortController.signal.aborted ? 'cancelled' : 'error'
+      this.statusValue.error = errorMessage(error)
+      this.statusValue.finishedAt = Date.now()
+      this.emit()
+      return this.status
+    }
+  }
+}

--- a/packages/app/src/renderer/src/components/ImageCanvas/WebGLImageBoard.tsx
+++ b/packages/app/src/renderer/src/components/ImageCanvas/WebGLImageBoard.tsx
@@ -48,10 +48,16 @@ function getContentBounds(items: WebGLImageBoardItem[]): ContentBounds | null {
     return null
   }
 
-  const minX = Math.min(...items.map((item) => item.x))
-  const minY = Math.min(...items.map((item) => item.y))
-  const maxX = Math.max(...items.map((item) => item.x + item.width))
-  const maxY = Math.max(...items.map((item) => item.y + item.height))
+  let minX = Number.POSITIVE_INFINITY
+  let minY = Number.POSITIVE_INFINITY
+  let maxX = Number.NEGATIVE_INFINITY
+  let maxY = Number.NEGATIVE_INFINITY
+  for (const item of items) {
+    minX = Math.min(minX, item.x)
+    minY = Math.min(minY, item.y)
+    maxX = Math.max(maxX, item.x + item.width)
+    maxY = Math.max(maxY, item.y + item.height)
+  }
   const width = maxX - minX
   const height = maxY - minY
 

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasRenderQuality.test.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasRenderQuality.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  PROJECT_CANVAS_ADAPTIVE_QUALITY_DOWNGRADE_DEBOUNCE_MS,
+  PROJECT_CANVAS_ADAPTIVE_QUALITY_RESTORE_DEBOUNCE_MS,
+  createProjectCanvasRenderQualityGovernor,
+  isProjectCanvasAdaptiveQualityEnabled,
+  resolveProjectCanvasRenderDpr,
+  type ProjectCanvasAdaptiveQualityGlobal
+} from './canvasRenderQuality'
+
+const adaptiveQualityGlobal = globalThis as ProjectCanvasAdaptiveQualityGlobal
+
+afterEach(() => {
+  delete adaptiveQualityGlobal.__MAGICPOT_PROJECT_CANVAS_ADAPTIVE_QUALITY__
+})
+
+describe('canvasRenderQuality', () => {
+  it('debounces quality reduction and uses a longer restore hysteresis', () => {
+    const governor = createProjectCanvasRenderQualityGovernor()
+
+    expect(governor.update({ now: 0, interactionActive: true })).toBe('full')
+    expect(
+      governor.update({
+        now: PROJECT_CANVAS_ADAPTIVE_QUALITY_DOWNGRADE_DEBOUNCE_MS - 1,
+        interactionActive: true
+      })
+    ).toBe('full')
+    expect(
+      governor.update({
+        now: PROJECT_CANVAS_ADAPTIVE_QUALITY_DOWNGRADE_DEBOUNCE_MS,
+        interactionActive: true
+      })
+    ).toBe('interactive')
+
+    expect(
+      governor.update({
+        now: PROJECT_CANVAS_ADAPTIVE_QUALITY_DOWNGRADE_DEBOUNCE_MS + 1,
+        interactionActive: false
+      })
+    ).toBe('interactive')
+    expect(
+      governor.update({
+        now:
+          PROJECT_CANVAS_ADAPTIVE_QUALITY_DOWNGRADE_DEBOUNCE_MS +
+          PROJECT_CANVAS_ADAPTIVE_QUALITY_RESTORE_DEBOUNCE_MS,
+        interactionActive: false
+      })
+    ).toBe('interactive')
+    expect(
+      governor.update({
+        now:
+          PROJECT_CANVAS_ADAPTIVE_QUALITY_DOWNGRADE_DEBOUNCE_MS +
+          PROJECT_CANVAS_ADAPTIVE_QUALITY_RESTORE_DEBOUNCE_MS +
+          1,
+        interactionActive: false
+      })
+    ).toBe('full')
+  })
+
+  it('keeps full quality when disabled or explicitly forced for capture/export work', () => {
+    const disabledGovernor = createProjectCanvasRenderQualityGovernor({
+      enabled: false,
+      downgradeDebounceMs: 0
+    })
+    expect(disabledGovernor.update({ now: 100, interactionActive: true })).toBe('full')
+
+    const governor = createProjectCanvasRenderQualityGovernor({ downgradeDebounceMs: 0 })
+    expect(governor.update({ now: 0, interactionActive: true })).toBe('interactive')
+    expect(governor.update({ now: 1, interactionActive: true, forceFull: true })).toBe('full')
+  })
+
+  it('caps only interactive rendering at DPR 1 and leaves full-quality DPR untouched', () => {
+    expect(resolveProjectCanvasRenderDpr(2, 'interactive')).toBe(1)
+    expect(resolveProjectCanvasRenderDpr(1, 'interactive')).toBe(1)
+    expect(resolveProjectCanvasRenderDpr(2, 'full')).toBe(2)
+    expect(resolveProjectCanvasRenderDpr(Number.NaN, 'full')).toBe(1)
+  })
+
+  it('supports a runtime kill switch without changing the default-on behavior', () => {
+    expect(isProjectCanvasAdaptiveQualityEnabled()).toBe(true)
+    adaptiveQualityGlobal.__MAGICPOT_PROJECT_CANVAS_ADAPTIVE_QUALITY__ = false
+    expect(isProjectCanvasAdaptiveQualityEnabled()).toBe(false)
+  })
+})

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasRenderQuality.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/canvasRenderQuality.ts
@@ -1,0 +1,92 @@
+export type ProjectCanvasRenderQuality = 'full' | 'interactive'
+
+export const PROJECT_CANVAS_ADAPTIVE_QUALITY_DOWNGRADE_DEBOUNCE_MS = 80
+export const PROJECT_CANVAS_ADAPTIVE_QUALITY_RESTORE_DEBOUNCE_MS = 180
+export const PROJECT_CANVAS_INTERACTIVE_DPR = 1
+
+export type ProjectCanvasAdaptiveQualityGlobal = typeof globalThis & {
+  __MAGICPOT_PROJECT_CANVAS_ADAPTIVE_QUALITY__?: boolean
+}
+
+export function isProjectCanvasAdaptiveQualityEnabled(): boolean {
+  const override = (globalThis as ProjectCanvasAdaptiveQualityGlobal)
+    .__MAGICPOT_PROJECT_CANVAS_ADAPTIVE_QUALITY__
+  return override !== false
+}
+
+export type ProjectCanvasRenderQualityGovernorOptions = {
+  enabled?: boolean
+  downgradeDebounceMs?: number
+  restoreDebounceMs?: number
+}
+
+export type ProjectCanvasRenderQualityGovernorUpdate = {
+  now: number
+  interactionActive: boolean
+  forceFull?: boolean
+}
+
+export function createProjectCanvasRenderQualityGovernor({
+  enabled = true,
+  downgradeDebounceMs = PROJECT_CANVAS_ADAPTIVE_QUALITY_DOWNGRADE_DEBOUNCE_MS,
+  restoreDebounceMs = PROJECT_CANVAS_ADAPTIVE_QUALITY_RESTORE_DEBOUNCE_MS
+}: ProjectCanvasRenderQualityGovernorOptions = {}) {
+  let quality: ProjectCanvasRenderQuality = 'full'
+  let interactionStartedAt: number | null = null
+  let interactionEndedAt: number | null = null
+
+  const reset = () => {
+    quality = 'full'
+    interactionStartedAt = null
+    interactionEndedAt = null
+  }
+
+  const update = ({
+    now,
+    interactionActive,
+    forceFull = false
+  }: ProjectCanvasRenderQualityGovernorUpdate) => {
+    if (!enabled || forceFull) {
+      reset()
+      return quality
+    }
+
+    if (interactionActive) {
+      interactionEndedAt = null
+      if (interactionStartedAt === null) {
+        interactionStartedAt = now
+      }
+      if (quality === 'full' && now - interactionStartedAt >= downgradeDebounceMs) {
+        quality = 'interactive'
+      }
+      return quality
+    }
+
+    interactionStartedAt = null
+    if (quality === 'interactive') {
+      if (interactionEndedAt === null) {
+        interactionEndedAt = now
+      }
+      if (now - interactionEndedAt >= restoreDebounceMs) {
+        quality = 'full'
+      }
+    } else {
+      interactionEndedAt = null
+    }
+    return quality
+  }
+
+  return {
+    getQuality: () => quality,
+    reset,
+    update
+  }
+}
+
+export function resolveProjectCanvasRenderDpr(
+  baseDpr: number,
+  quality: ProjectCanvasRenderQuality
+): number {
+  const safeDpr = Number.isFinite(baseDpr) ? Math.max(1, baseDpr) : 1
+  return quality === 'interactive' ? Math.min(safeDpr, PROJECT_CANVAS_INTERACTIVE_DPR) : safeDpr
+}

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasCanvas2DFallbackLayer.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasCanvas2DFallbackLayer.tsx
@@ -19,6 +19,10 @@ import {
 } from '../canvasSpatialIndex'
 import { getCanvasItemBounds } from '../projectCanvasPageShared'
 import { useCanvasSpatialIndexLifecycle } from '../useCanvasSpatialIndexLifecycle'
+import {
+  isProjectCanvasAdaptiveQualityEnabled,
+  resolveProjectCanvasRenderDpr
+} from '../canvasRenderQuality'
 
 export type ProjectCanvasCanvas2DFallbackLayerHandle = {
   syncItemPreview: (itemId: string, preview: ProjectCanvasImagePreview | null) => void
@@ -377,6 +381,7 @@ const ProjectCanvasCanvas2DFallbackLayer = forwardRef<
       visibilityIndex: currentVisibilityIndex,
       selectedIds: currentSelectedIds,
       stageSize: currentStageSize,
+      isPerformanceThrottled: currentIsPerformanceThrottled,
       maxDevicePixelRatio: currentMaxDpr,
       maxBackingPixels: currentMaxBackingPixels,
       overscanPx: currentOverscanPx,
@@ -389,7 +394,14 @@ const ProjectCanvasCanvas2DFallbackLayer = forwardRef<
     }
     const cssWidth = Math.max(1, Math.round(cssSize.width || 1))
     const cssHeight = Math.max(1, Math.round(cssSize.height || 1))
-    const dpr = getSafeDevicePixelRatio(currentMaxDpr, currentMaxBackingPixels, {
+    const adaptiveQualityActive =
+      isProjectCanvasAdaptiveQualityEnabled() &&
+      (currentIsPerformanceThrottled || viewportInteractingRef.current)
+    const qualityMaxDpr = resolveProjectCanvasRenderDpr(
+      currentMaxDpr,
+      adaptiveQualityActive ? 'interactive' : 'full'
+    )
+    const dpr = getSafeDevicePixelRatio(qualityMaxDpr, currentMaxBackingPixels, {
       width: cssWidth,
       height: cssHeight
     })

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasImageInteractionOverlay.test.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasImageInteractionOverlay.test.tsx
@@ -723,7 +723,7 @@ describe('ProjectCanvasImageInteractionOverlay', () => {
     expect(onDragEnd).toHaveBeenCalledWith('image-1', 140, 170, expect.any(Object))
   })
 
-  it('emits drag previews immediately so the WebGL image body follows the frame', () => {
+  it('batches drag previews once per frame and flushes the latest transform on pointerup', () => {
     const rafCallbacks = new Map<number, FrameRequestCallback>()
     let rafId = 0
     const requestAnimationFrameSpy = vi
@@ -785,9 +785,18 @@ describe('ProjectCanvasImageInteractionOverlay', () => {
       fireEvent.pointerMove(window, { pointerId: 15, clientX: 150, clientY: 190 })
       fireEvent.pointerMove(window, { pointerId: 15, clientX: 180, clientY: 210 })
 
-      expect(requestAnimationFrameSpy).toHaveBeenCalledTimes(baselineRafCallCount)
+      expect((overlay as HTMLElement).style.transform).toContain('translate3d(170px, 190px, 0)')
+      expect(requestAnimationFrameSpy).toHaveBeenCalledTimes(baselineRafCallCount + 1)
+      expect(rafCallbacks.size).toBe(1)
+      expect(onPreviewChange).not.toHaveBeenCalled()
+
+      const firstFrame = rafCallbacks.entries().next().value
+      expect(firstFrame).toBeDefined()
+      rafCallbacks.delete(firstFrame![0])
+      firstFrame![1](16)
+
       expect(rafCallbacks.size).toBe(0)
-      expect(onPreviewChange).toHaveBeenCalledTimes(2)
+      expect(onPreviewChange).toHaveBeenCalledTimes(1)
       expect(onPreviewChange).toHaveBeenLastCalledWith('image-1', {
         x: 170,
         y: 190,
@@ -798,23 +807,29 @@ describe('ProjectCanvasImageInteractionOverlay', () => {
         rotation: 0
       })
 
-      fireEvent.pointerUp(window, { pointerId: 15, clientX: 180, clientY: 210 })
+      fireEvent.pointerMove(window, { pointerId: 15, clientX: 200, clientY: 230 })
+      fireEvent.pointerMove(window, { pointerId: 15, clientX: 220, clientY: 250 })
 
-      expect(cancelAnimationFrameSpy.mock.calls.length).toBeGreaterThanOrEqual(
-        baselineCancelRafCallCount
-      )
+      expect((overlay as HTMLElement).style.transform).toContain('translate3d(210px, 230px, 0)')
+      expect(requestAnimationFrameSpy).toHaveBeenCalledTimes(baselineRafCallCount + 2)
+      expect(rafCallbacks.size).toBe(1)
+      expect(onPreviewChange).toHaveBeenCalledTimes(1)
+
+      fireEvent.pointerUp(window, { pointerId: 15, clientX: 220, clientY: 250 })
+
+      expect(cancelAnimationFrameSpy.mock.calls.length).toBeGreaterThan(baselineCancelRafCallCount)
       expect(rafCallbacks.size).toBe(0)
       expect(onPreviewChange).toHaveBeenCalledTimes(2)
       expect(onPreviewChange).toHaveBeenLastCalledWith('image-1', {
-        x: 170,
-        y: 190,
+        x: 210,
+        y: 230,
         width: 200,
         height: 120,
         scaleX: 1,
         scaleY: 1,
         rotation: 0
       })
-      expect(onDragEnd).toHaveBeenCalledWith('image-1', 170, 190, expect.any(Object))
+      expect(onDragEnd).toHaveBeenCalledWith('image-1', 210, 230, expect.any(Object))
       expect(syncListener).not.toHaveBeenCalled()
     } finally {
       window.removeEventListener('canvas-sync-image-1', syncListener)

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasImageInteractionOverlay.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasImageInteractionOverlay.tsx
@@ -605,6 +605,8 @@ const ProjectCanvasImageInteractionOverlay: React.FC<ProjectCanvasImageInteracti
   const elementRef = React.useRef<HTMLDivElement | null>(null)
   const sessionRef = React.useRef<InteractionSession | null>(null)
   const draftTransformRef = React.useRef<CanvasImageTransform | null>(null)
+  const previewChangeFrameRef = React.useRef<number | null>(null)
+  const pendingPreviewRef = React.useRef<ProjectCanvasImagePreview | null>(null)
   const lastEmittedPreviewKeyRef = React.useRef<string | null>(null)
   const pointerCanvasViewportRectRef = React.useRef<CanvasViewportRect | null>(null)
   const windowPointerMoveHandlerRef = React.useRef<(event: PointerEvent) => void>(() => {})
@@ -691,8 +693,19 @@ const ProjectCanvasImageInteractionOverlay: React.FC<ProjectCanvasImageInteracti
     [broadcastDomPreviewSync, item.id, onPreviewChange]
   )
 
+  const cancelPendingPreviewChange = React.useCallback(() => {
+    if (previewChangeFrameRef.current != null) {
+      window.cancelAnimationFrame(previewChangeFrameRef.current)
+      previewChangeFrameRef.current = null
+    }
+
+    pendingPreviewRef.current = null
+  }, [])
+
   const flushPendingPreviewChange = React.useCallback(
     (nextTransform: CanvasImageTransform) => {
+      cancelPendingPreviewChange()
+
       const preview = buildPreview(item, nextTransform)
       const previewKey = getProjectCanvasRenderTransformKey(preview)
       if (lastEmittedPreviewKeyRef.current === previewKey) {
@@ -701,12 +714,31 @@ const ProjectCanvasImageInteractionOverlay: React.FC<ProjectCanvasImageInteracti
 
       emitPreviewChangeNow(preview, { immediateSync: true })
     },
-    [emitPreviewChangeNow, item]
+    [cancelPendingPreviewChange, emitPreviewChangeNow, item]
   )
 
   const schedulePreviewChange = React.useCallback(
     (transform: CanvasImageTransform) => {
-      emitPreviewChangeNow(buildPreview(item, transform), { immediateSync: true })
+      pendingPreviewRef.current = buildPreview(item, transform)
+      if (previewChangeFrameRef.current != null) {
+        return
+      }
+
+      previewChangeFrameRef.current = window.requestAnimationFrame(() => {
+        previewChangeFrameRef.current = null
+        const preview = pendingPreviewRef.current
+        pendingPreviewRef.current = null
+        if (!preview) {
+          return
+        }
+
+        const previewKey = getProjectCanvasRenderTransformKey(preview)
+        if (lastEmittedPreviewKeyRef.current === previewKey) {
+          return
+        }
+
+        emitPreviewChangeNow(preview, { immediateSync: true })
+      })
     },
     [emitPreviewChangeNow, item]
   )
@@ -749,6 +781,7 @@ const ProjectCanvasImageInteractionOverlay: React.FC<ProjectCanvasImageInteracti
 
   React.useEffect(() => {
     return () => {
+      cancelPendingPreviewChange()
       lastEmittedPreviewKeyRef.current = null
       shouldSelectOnDragFinishRef.current = false
       clearPointerCanvasViewportRect()
@@ -759,6 +792,7 @@ const ProjectCanvasImageInteractionOverlay: React.FC<ProjectCanvasImageInteracti
     }
   }, [
     broadcastDomPreviewSync,
+    cancelPendingPreviewChange,
     clearPointerCanvasViewportRect,
     item.id,
     onPreviewChange,
@@ -805,8 +839,7 @@ const ProjectCanvasImageInteractionOverlay: React.FC<ProjectCanvasImageInteracti
         )
       const preferredPlacement =
         (toolbar.dataset.selectionToolbarPreferredPlacement as
-          | SelectionActionStackPlacement
-          | undefined) ?? 'auto'
+          SelectionActionStackPlacement | undefined) ?? 'auto'
       const toolbarPosition = resolveSelectionActionToolbarPosition(
         {
           minX: imageBounds.minX,
@@ -886,6 +919,7 @@ const ProjectCanvasImageInteractionOverlay: React.FC<ProjectCanvasImageInteracti
       }
 
       if (currentSession.kind === 'drag' && !currentSession.moved) {
+        cancelPendingPreviewChange()
         draftTransformRef.current = null
         flushPendingDraftTransformCommit(null)
         if (shouldSelectOnDragFinish) {
@@ -918,6 +952,7 @@ const ProjectCanvasImageInteractionOverlay: React.FC<ProjectCanvasImageInteracti
       }
     },
     [
+      cancelPendingPreviewChange,
       clearPointerCanvasViewportRect,
       detachWindowPointerListeners,
       committedTransform,

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasWebGLImageLayer.test.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasWebGLImageLayer.test.tsx
@@ -1552,6 +1552,53 @@ describe('ProjectCanvasWebGLImageLayer', () => {
     }
   }, 30000)
 
+  it('samples WebGL errors during repeated preview renders instead of checking every frame', async () => {
+    const { default: ProjectCanvasWebGLImageLayer } = await import('./ProjectCanvasWebGLImageLayer')
+    const ref = React.createRef<ProjectCanvasWebGLImageLayerHandle>()
+
+    render(
+      <ProjectCanvasWebGLImageLayer
+        ref={ref}
+        items={[createItem()]}
+        {...TEST_STAGE_VIEWPORT_1280_720}
+      />
+    )
+
+    await waitFor(
+      () => {
+        expect(ref.current).not.toBeNull()
+        expect(createdApplications).toHaveLength(1)
+        expect(createdSprites).toHaveLength(1)
+      },
+      { timeout: 15000 }
+    )
+
+    const app = createdApplications[0]
+    const initialRenderCount = app.render.mock.calls.length
+    const initialErrorCheckCount = app.renderer.gl.getError.mock.calls.length
+
+    for (let index = 0; index < 20; index += 1) {
+      act(() => {
+        ref.current?.syncItemPreview('image-1', {
+          x: 24 + index,
+          y: 36,
+          width: 200,
+          height: 120,
+          scaleX: 1,
+          scaleY: 1,
+          rotation: 0
+        })
+      })
+    }
+
+    const additionalRenderCount = app.render.mock.calls.length - initialRenderCount
+    const additionalErrorCheckCount =
+      app.renderer.gl.getError.mock.calls.length - initialErrorCheckCount
+    expect(additionalRenderCount).toBeGreaterThanOrEqual(20)
+    expect(additionalErrorCheckCount).toBeGreaterThanOrEqual(0)
+    expect(additionalErrorCheckCount).toBeLessThan(additionalRenderCount)
+  }, 30000)
+
   it('tears down the WebGL canvas and reports not-ready when Pixi rendering fails', async () => {
     const { default: ProjectCanvasWebGLImageLayer } = await import('./ProjectCanvasWebGLImageLayer')
     const ref = React.createRef<ProjectCanvasWebGLImageLayerHandle>()

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasWebGLImageLayer.test.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasWebGLImageLayer.test.tsx
@@ -866,8 +866,16 @@ describe('ProjectCanvasWebGLImageLayer', () => {
   it('recreates sprite state when the texture key changes', async () => {
     const { default: ProjectCanvasWebGLImageLayer } = await import('./ProjectCanvasWebGLImageLayer')
     const initialItem = createItem()
+    const metricsCalls: ProjectCanvasWebGLRuntimeMetrics[] = []
+    const onMetricsChange = (metrics: ProjectCanvasWebGLRuntimeMetrics) => {
+      metricsCalls.push(metrics)
+    }
     const { rerender } = render(
-      <ProjectCanvasWebGLImageLayer items={[initialItem]} {...TEST_STAGE_VIEWPORT_1280_720} />
+      <ProjectCanvasWebGLImageLayer
+        items={[initialItem]}
+        {...TEST_STAGE_VIEWPORT_1280_720}
+        onMetricsChange={onMetricsChange}
+      />
     )
 
     await waitFor(
@@ -888,6 +896,7 @@ describe('ProjectCanvasWebGLImageLayer', () => {
           })
         ]}
         {...TEST_STAGE_VIEWPORT_1280_720}
+        onMetricsChange={onMetricsChange}
       />
     )
 
@@ -905,6 +914,19 @@ describe('ProjectCanvasWebGLImageLayer', () => {
     expect(originalTexture.destroySourceCalled).toBe(true)
     expect(updatedSprite.scale.x).toBe(5)
     expect(updatedSprite.scale.y).toBe(6)
+    await waitFor(
+      () => {
+        expect(
+          metricsCalls.some(
+            (metrics) =>
+              metrics.lastSpriteReconcileCreatedCount === 1 &&
+              metrics.lastSpriteReconcileReusedCount === 0 &&
+              metrics.lastSpriteReconcileRemovedCount === 1
+          )
+        ).toBe(true)
+      },
+      { timeout: 15000 }
+    )
   }, 30000)
 
   it('does not reuse a stale texture when the same URL is refreshed with a new decoded object', async () => {
@@ -942,11 +964,16 @@ describe('ProjectCanvasWebGLImageLayer', () => {
       y: 60,
       zIndex: 2
     })
+    const metricsCalls: ProjectCanvasWebGLRuntimeMetrics[] = []
+    const onMetricsChange = (metrics: ProjectCanvasWebGLRuntimeMetrics) => {
+      metricsCalls.push(metrics)
+    }
 
     const { rerender } = render(
       <ProjectCanvasWebGLImageLayer
         items={[firstItem, secondItem]}
         {...TEST_STAGE_VIEWPORT_1280_720}
+        onMetricsChange={onMetricsChange}
       />
     )
 
@@ -961,11 +988,39 @@ describe('ProjectCanvasWebGLImageLayer', () => {
       'image-1',
       'image-2'
     ])
+    await waitFor(
+      () => {
+        expect(metricsCalls.at(-1)?.spriteSortCount ?? 0).toBeGreaterThanOrEqual(1)
+      },
+      { timeout: 15000 }
+    )
+    const initialSpriteSortCount = metricsCalls.at(-1)?.spriteSortCount ?? 0
+    const initialReconcilePassCount = metricsCalls.at(-1)?.spriteReconcilePassCount ?? 0
+    const movedFirstItem = { ...firstItem, x: firstItem.x + 12 }
 
     rerender(
       <ProjectCanvasWebGLImageLayer
-        items={[{ ...firstItem, zIndex: 3 }, secondItem]}
+        items={[movedFirstItem, secondItem]}
         {...TEST_STAGE_VIEWPORT_1280_720}
+        onMetricsChange={onMetricsChange}
+      />
+    )
+
+    await waitFor(
+      () => {
+        expect(metricsCalls.at(-1)?.spriteReconcilePassCount ?? 0).toBeGreaterThan(
+          initialReconcilePassCount
+        )
+      },
+      { timeout: 15000 }
+    )
+    expect(metricsCalls.at(-1)?.spriteSortCount).toBe(initialSpriteSortCount)
+
+    rerender(
+      <ProjectCanvasWebGLImageLayer
+        items={[{ ...movedFirstItem, zIndex: 3 }, secondItem]}
+        {...TEST_STAGE_VIEWPORT_1280_720}
+        onMetricsChange={onMetricsChange}
       />
     )
 
@@ -978,6 +1033,9 @@ describe('ProjectCanvasWebGLImageLayer', () => {
       },
       { timeout: 15000 }
     )
+    expect(metricsCalls.at(-1)?.spriteSortCount).toBeGreaterThan(initialSpriteSortCount)
+    expect(metricsCalls.at(-1)?.lastSpriteSortDurationMs).toEqual(expect.any(Number))
+    expect(metricsCalls.at(-1)?.lastSpriteSortDurationMs ?? -1).toBeGreaterThanOrEqual(0)
   }, 30000)
 
   it('keeps sprite order deterministic for equal zIndex items', async () => {
@@ -1175,6 +1233,8 @@ describe('ProjectCanvasWebGLImageLayer', () => {
       viewportCulledImageCount: 0,
       spriteReconcilePassCount: 0,
       lastSpriteReconcileDurationMs: null,
+      lastSpriteSortDurationMs: null,
+      spriteSortCount: 0,
       lastSpriteReconcileCandidateCount: 0,
       lastSpriteReconcileTargetCount: 0,
       lastSpriteReconcileCreatedCount: 0,

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasWebGLImageLayer.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasWebGLImageLayer.tsx
@@ -52,6 +52,7 @@ import {
   reprioritizeProjectCanvasWebGLPriorityQueueEntry,
   buildProjectCanvasWebGLItemReconcileSnapshot,
   areProjectCanvasWebGLItemReconcileSnapshotsEqual,
+  createProjectCanvasWebGLItemIndexesCache,
   createProjectCanvasWebGLSpatialTileStateMachine,
   type ProjectCanvasWebGLItemReconcileSnapshot,
   type ProjectCanvasWebGLPriorityQueueEntry,
@@ -168,6 +169,13 @@ type SpriteRecord = {
   lastUsedAt: number
   sawTinyPreview: boolean
   sharedTextureKey: string
+  reconcileGeneration: number
+  reconcileBaseline: boolean
+}
+
+type SpriteReconcileMutationStats = {
+  generation: number
+  removedBaselineCount: number
 }
 
 type SourceUpgradeQueueEntry = ProjectCanvasWebGLPriorityQueueEntry
@@ -1008,6 +1016,11 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
   const activeSourceUpgradeRequestTokenByIdRef = useRef(new Map<string, CanvasImageRequestToken>())
   const activeSourceUpgradeCountRef = useRef(0)
   const spriteRecordsRef = useRef(new Map<string, SpriteRecord>())
+  const spriteReconcileGenerationRef = useRef(0)
+  const spriteReconcileMutationStatsRef = useRef<SpriteReconcileMutationStats>({
+    generation: 0,
+    removedBaselineCount: 0
+  })
   const itemReconcileSnapshotByIdRef = useRef(
     new Map<string, ProjectCanvasWebGLItemReconcileSnapshot>()
   )
@@ -1042,10 +1055,10 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
   const previewStateRef = useRef(new Map<string, ProjectCanvasImagePreview>())
   const renderItemsRef = useRef(new Map<string, ProjectCanvasRenderableImage>())
   const currentItemsRef = useRef(items)
-  const currentItemByIdRef = useRef(
-    new Map<string, CanvasImageItem>(items.map((item) => [item.id, item]))
-  )
-  const currentItemIdsRef = useRef(new Set(items.map((item) => item.id)))
+  const currentItemIndexesRef = useRef(createProjectCanvasWebGLItemIndexesCache<CanvasImageItem>())
+  const currentItemIndexes = currentItemIndexesRef.current(items)
+  const currentItemByIdRef = useRef(currentItemIndexes.itemById)
+  const currentItemIdsRef = useRef(currentItemIndexes.itemIds)
   const spriteUsageCounterRef = useRef(0)
   const rafRef = useRef<number | null>(null)
   const renderThrottleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -1672,8 +1685,9 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
 
   useEffect(() => {
     currentItemsRef.current = items
-    currentItemByIdRef.current = new Map(items.map((item) => [item.id, item]))
-    currentItemIdsRef.current = new Set(items.map((item) => item.id))
+    const indexes = currentItemIndexesRef.current(items)
+    currentItemByIdRef.current = indexes.itemById
+    currentItemIdsRef.current = indexes.itemIds
   }, [items])
 
   const renderApp = useCallback(() => {
@@ -2025,6 +2039,14 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
         return
       }
 
+      const reconcileMutationStats = spriteReconcileMutationStatsRef.current
+      if (
+        record.reconcileGeneration === reconcileMutationStats.generation &&
+        record.reconcileBaseline
+      ) {
+        reconcileMutationStats.removedBaselineCount += 1
+      }
+
       destroyProjectCanvasSpriteRecord(record, () => {
         sharedTexturePoolRef.current.release(record.sharedTextureKey, (texture) =>
           destroyProjectCanvasTexture(texture, true)
@@ -2193,6 +2215,11 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
       lastAppliedViewportRef.current = null
       previewState.clear()
       renderItems.clear()
+      spriteReconcileGenerationRef.current += 1
+      spriteReconcileMutationStatsRef.current = {
+        generation: spriteReconcileGenerationRef.current,
+        removedBaselineCount: 0
+      }
       const releaseMetrics = releaseManagerRef.current.getMetricsSnapshot()
       reportMetrics(
         createProjectCanvasWebGLRuntimeMetrics({
@@ -2421,12 +2448,22 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
     }
 
     const spriteReconcileStartedAt = window.performance.now()
-    const previousSpriteRecords = new Map(spriteRecordsRef.current)
+    const spriteReconcileGeneration = spriteReconcileGenerationRef.current + 1
+    spriteReconcileGenerationRef.current = spriteReconcileGeneration
+    spriteReconcileMutationStatsRef.current = {
+      generation: spriteReconcileGeneration,
+      removedBaselineCount: 0
+    }
+    for (const record of spriteRecordsRef.current.values()) {
+      record.reconcileGeneration = spriteReconcileGeneration
+      record.reconcileBaseline = true
+    }
     activeItemCountRef.current = items.length
     if (currentItemsRef.current !== items) {
       currentItemsRef.current = items
-      currentItemByIdRef.current = new Map(items.map((item) => [item.id, item]))
-      currentItemIdsRef.current = new Set(items.map((item) => item.id))
+      const indexes = currentItemIndexesRef.current(items)
+      currentItemByIdRef.current = indexes.itemById
+      currentItemIdsRef.current = indexes.itemIds
     }
     const itemById = currentItemByIdRef.current
     const nextIds = currentItemIdsRef.current
@@ -3841,7 +3878,9 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
           textureByteSize,
           lastUsedAt: 0,
           sawTinyPreview: isProjectCanvasTinyPreview(transformState, stageScaleRef.current),
-          sharedTextureKey
+          sharedTextureKey,
+          reconcileGeneration: spriteReconcileGeneration,
+          reconcileBaseline: false
         })
         setTextureBudgetReservation({
           itemId: item.id,
@@ -3894,10 +3933,27 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
     })
 
     pumpSourceUpgradeQueue()
+    let lastSpriteSortDurationMs: number | null = null
+    let spriteSortCount = metricsRef.current.spriteSortCount ?? 0
     if (worldOrderDirty && world.children.length > 1) {
+      const spriteSortStartedAt = window.performance.now()
       world.sortChildren()
+      lastSpriteSortDurationMs = Math.max(0, window.performance.now() - spriteSortStartedAt)
+      spriteSortCount += 1
     }
     renderItemsRef.current = nextRenderItems
+    let createdSpriteCount = 0
+    let reusedSpriteCount = 0
+    for (const record of spriteRecordsRef.current.values()) {
+      if (record.reconcileGeneration !== spriteReconcileGeneration) {
+        continue
+      }
+      if (record.reconcileBaseline) {
+        reusedSpriteCount += 1
+      } else {
+        createdSpriteCount += 1
+      }
+    }
     if (reconciledSnapshotItems.size > 0) {
       const finalResidentTextureBytesForReconcileSnapshot = getResidentTextureBytes()
       reconciledSnapshotItems.forEach((item, itemId) => {
@@ -3909,24 +3965,7 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
         }
       })
     }
-    let createdSpriteCount = 0
-    let reusedSpriteCount = 0
-    let removedSpriteCount = 0
-    spriteRecordsRef.current.forEach((record, itemId) => {
-      const previousRecord = previousSpriteRecords.get(itemId)
-      if (!previousRecord) {
-        createdSpriteCount += 1
-      } else if (previousRecord === record) {
-        reusedSpriteCount += 1
-      } else {
-        createdSpriteCount += 1
-      }
-    })
-    previousSpriteRecords.forEach((previousRecord, itemId) => {
-      if (spriteRecordsRef.current.get(itemId) !== previousRecord) {
-        removedSpriteCount += 1
-      }
-    })
+    const removedSpriteCount = spriteReconcileMutationStatsRef.current.removedBaselineCount
     const spriteReconcileDurationMs = Math.max(
       0,
       window.performance.now() - spriteReconcileStartedAt
@@ -3950,6 +3989,8 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
         lastSpriteReconcileReusedCount: reusedSpriteCount,
         lastSpriteReconcileRemovedCount: removedSpriteCount,
         lastSpriteReconcileDeferredCount: deferredNewSpriteCount,
+        spriteSortCount,
+        ...(lastSpriteSortDurationMs === null ? {} : { lastSpriteSortDurationMs }),
         ...imageHealthCounts
       },
       'items',

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasWebGLImageLayer.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasWebGLImageLayer.tsx
@@ -228,6 +228,8 @@ const PROJECT_CANVAS_WEBGL_PERFORMANCE_THROTTLE_IMAGE_VERSION_MAX_DEFER_MS = 750
 const PROJECT_CANVAS_WEBGL_PERFORMANCE_THROTTLE_INITIAL_IMAGE_LOAD_CONCURRENCY = 2
 const PROJECT_CANVAS_WEBGL_PERFORMANCE_THROTTLE_SPRITE_RECONCILE_BATCH_SIZE = 4
 const PROJECT_CANVAS_WEBGL_METRICS_THROTTLE_MS = 250
+const PROJECT_CANVAS_WEBGL_ERROR_SAMPLE_RENDER_INTERVAL = 60
+const PROJECT_CANVAS_WEBGL_ERROR_SAMPLE_INTERVAL_MS = 1000
 export const PROJECT_CANVAS_WEBGL_SOURCE_TEXTURE_MAX_SIDE = 4096
 const PROJECT_CANVAS_WEBGL_SOURCE_UPGRADE_CONCURRENCY = 2
 const PROJECT_CANVAS_WEBGL_SOURCE_UPGRADE_VIEWPORT_IDLE_DELAY_MS = 80
@@ -1063,6 +1065,10 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
   const rafRef = useRef<number | null>(null)
   const renderThrottleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const lastRenderAtRef = useRef(0)
+  const webglRenderCountRef = useRef(0)
+  const webglErrorLastCheckedRenderRef = useRef(0)
+  const webglErrorLastCheckedAtRef = useRef(Number.NEGATIVE_INFINITY)
+  const webglErrorCheckRequestedRef = useRef(true)
   const activeItemCountRef = useRef(0)
   const stagePosRef = useRef(stagePos)
   const stageScaleRef = useRef(stageScale)
@@ -1696,6 +1702,8 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
       return
     }
 
+    const renderCount = webglRenderCountRef.current + 1
+    webglRenderCountRef.current = renderCount
     const startedAt = window.performance.now()
     try {
       app.render()
@@ -1704,13 +1712,26 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
       return
     }
 
-    const webglRuntimeFailure = getProjectCanvasWebGLRuntimeFailure(app)
-    if (webglRuntimeFailure) {
-      runtimeFailureHandlerRef.current?.(webglRuntimeFailure)
-      return
+    const finishedAt = window.performance.now()
+    const shouldCheckWebGLRuntimeError =
+      webglErrorCheckRequestedRef.current ||
+      renderCount === 1 ||
+      renderCount - webglErrorLastCheckedRenderRef.current >=
+        PROJECT_CANVAS_WEBGL_ERROR_SAMPLE_RENDER_INTERVAL ||
+      finishedAt - webglErrorLastCheckedAtRef.current >=
+        PROJECT_CANVAS_WEBGL_ERROR_SAMPLE_INTERVAL_MS
+    if (shouldCheckWebGLRuntimeError) {
+      webglErrorCheckRequestedRef.current = false
+      webglErrorLastCheckedRenderRef.current = renderCount
+      webglErrorLastCheckedAtRef.current = finishedAt
+      const webglRuntimeFailure = getProjectCanvasWebGLRuntimeFailure(app)
+      if (webglRuntimeFailure) {
+        runtimeFailureHandlerRef.current?.(webglRuntimeFailure)
+        return
+      }
     }
 
-    lastRenderAtRef.current = window.performance.now()
+    lastRenderAtRef.current = finishedAt
     const lastRenderDurationMs = Math.max(0, lastRenderAtRef.current - startedAt)
     if (isViewportInteractingRef.current) {
       metricsRef.current.renderCount += 1
@@ -2292,6 +2313,10 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
         app.stage.addChild(world)
         appRef.current = app
         worldRef.current = world
+        webglRenderCountRef.current = 0
+        webglErrorLastCheckedRenderRef.current = 0
+        webglErrorLastCheckedAtRef.current = Number.NEGATIVE_INFINITY
+        webglErrorCheckRequestedRef.current = true
         contextLostCanvas = canvas
         contextLostHandler = handleContextLost
         canvas.addEventListener('webglcontextlost', handleContextLost)
@@ -3836,9 +3861,14 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
       let baseTexture: Texture | null = null
       let texture: Texture | null = null
       try {
-        baseTexture = sharedTexturePoolRef.current.acquire(sharedTextureKey, () =>
-          createProjectCanvasTexture(image)
-        )
+        let createdSharedTexture = false
+        baseTexture = sharedTexturePoolRef.current.acquire(sharedTextureKey, () => {
+          createdSharedTexture = true
+          return createProjectCanvasTexture(image)
+        })
+        if (createdSharedTexture) {
+          webglErrorCheckRequestedRef.current = true
+        }
         sharedTextureByteTrackerRef.current.acquire(sharedTextureKey, textureByteSize)
         if (!baseTexture) {
           throw new Error('Pixi returned an empty texture.')

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasWebGLImageLayer.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/ProjectCanvasWebGLImageLayer.tsx
@@ -40,6 +40,14 @@ import {
 import { isCanvasThumbnailSetFresh, pickBestCanvasThumbnailLevel } from '../canvasThumbnailCache'
 import type { CanvasImageThumbnailLevel, CanvasImageThumbnailSet } from '../canvasThumbnailTypes'
 import { PROJECT_CANVAS_MIN_STAGE_SCALE } from '../projectCanvasViewportScale'
+import {
+  PROJECT_CANVAS_ADAPTIVE_QUALITY_DOWNGRADE_DEBOUNCE_MS,
+  PROJECT_CANVAS_ADAPTIVE_QUALITY_RESTORE_DEBOUNCE_MS,
+  createProjectCanvasRenderQualityGovernor,
+  isProjectCanvasAdaptiveQualityEnabled,
+  resolveProjectCanvasRenderDpr,
+  type ProjectCanvasRenderQuality
+} from '../canvasRenderQuality'
 import { useCanvasSpatialIndexLifecycle } from '../useCanvasSpatialIndexLifecycle'
 import {
   areProjectCanvasWebGLRuntimeMetricsEqual,
@@ -192,6 +200,7 @@ type ImageLoadQueueEntry = SourceUpgradeQueueEntry & {
 type ResizablePixiApplication = Application & {
   renderer?: {
     resize?: (width: number, height: number) => void
+    resolution?: number
   }
 }
 
@@ -529,10 +538,12 @@ function refreshProjectCanvasTextureAfterTinyPreview(
   record.sawTinyPreview = false
 }
 
-function getProjectCanvasRenderDeviceScale() {
-  return typeof window !== 'undefined' && Number.isFinite(window.devicePixelRatio)
-    ? Math.min(2, Math.max(1, window.devicePixelRatio || 1))
-    : 1
+function getProjectCanvasRenderDeviceScale(quality: ProjectCanvasRenderQuality = 'full') {
+  const baseDpr =
+    typeof window !== 'undefined' && Number.isFinite(window.devicePixelRatio)
+      ? Math.min(2, Math.max(1, window.devicePixelRatio || 1))
+      : 1
+  return resolveProjectCanvasRenderDpr(baseDpr, quality)
 }
 
 const areProjectCanvasWebGLMetricsEqual = areProjectCanvasWebGLRuntimeMetricsEqual
@@ -1064,6 +1075,9 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
   const spriteUsageCounterRef = useRef(0)
   const rafRef = useRef<number | null>(null)
   const renderThrottleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const qualityTransitionTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const renderQualityGovernorRef = useRef(createProjectCanvasRenderQualityGovernor())
+  const renderQualityRef = useRef<ProjectCanvasRenderQuality>('full')
   const lastRenderAtRef = useRef(0)
   const webglRenderCountRef = useRef(0)
   const webglErrorLastCheckedRenderRef = useRef(0)
@@ -1919,6 +1933,10 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
         clearTimeout(renderThrottleTimerRef.current)
         renderThrottleTimerRef.current = null
       }
+      if (qualityTransitionTimerRef.current != null) {
+        clearTimeout(qualityTransitionTimerRef.current)
+        qualityTransitionTimerRef.current = null
+      }
       if (sourceUpgradeIdleTimerRef.current != null) {
         clearTimeout(sourceUpgradeIdleTimerRef.current)
         sourceUpgradeIdleTimerRef.current = null
@@ -2001,8 +2019,14 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
       const rawHeight = preferredSize?.height ?? rect?.height ?? 0
       const width = Number.isFinite(rawWidth) && rawWidth > 0 ? Math.round(rawWidth) : 1
       const height = Number.isFinite(rawHeight) && rawHeight > 0 ? Math.round(rawHeight) : 1
+      const renderer = (app as ResizablePixiApplication).renderer
+      const nextResolution = getProjectCanvasRenderDeviceScale(renderQualityRef.current)
+      const resolutionChanged = Boolean(renderer && renderer.resolution !== nextResolution)
+      if (renderer && resolutionChanged) {
+        renderer.resolution = nextResolution
+      }
       const lastSize = rendererSizeRef.current
-      if (lastSize?.width === width && lastSize.height === height) {
+      if (lastSize?.width === width && lastSize.height === height && !resolutionChanged) {
         return
       }
 
@@ -2013,11 +2037,60 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
       canvas.style.display = 'block'
       canvas.style.width = '100%'
       canvas.style.height = '100%'
-      ;(app as ResizablePixiApplication).renderer?.resize?.(width, height)
+      renderer?.resize?.(width, height)
       renderImmediateOrSchedule()
     },
     [renderImmediateOrSchedule]
   )
+
+  const applyRenderQuality = useCallback(
+    (quality: ProjectCanvasRenderQuality) => {
+      const nextQuality = isProjectCanvasAdaptiveQualityEnabled() ? quality : 'full'
+      if (renderQualityRef.current === nextQuality) {
+        return
+      }
+      renderQualityRef.current = nextQuality
+      resizeRendererToStage(stageSizeRef.current)
+    },
+    [resizeRendererToStage]
+  )
+
+  useEffect(() => {
+    if (qualityTransitionTimerRef.current !== null) {
+      clearTimeout(qualityTransitionTimerRef.current)
+      qualityTransitionTimerRef.current = null
+    }
+
+    const governor = renderQualityGovernorRef.current
+    const interactionActive = isViewportInteracting || isPerformanceThrottled
+    const now = window.performance.now()
+    if (!isProjectCanvasAdaptiveQualityEnabled()) {
+      governor.reset()
+      applyRenderQuality('full')
+      return
+    }
+
+    applyRenderQuality(governor.update({ now, interactionActive }))
+    const transitionDelayMs = interactionActive
+      ? PROJECT_CANVAS_ADAPTIVE_QUALITY_DOWNGRADE_DEBOUNCE_MS
+      : PROJECT_CANVAS_ADAPTIVE_QUALITY_RESTORE_DEBOUNCE_MS
+    qualityTransitionTimerRef.current = setTimeout(() => {
+      qualityTransitionTimerRef.current = null
+      applyRenderQuality(
+        governor.update({
+          now: window.performance.now(),
+          interactionActive
+        })
+      )
+    }, transitionDelayMs)
+
+    return () => {
+      if (qualityTransitionTimerRef.current !== null) {
+        clearTimeout(qualityTransitionTimerRef.current)
+        qualityTransitionTimerRef.current = null
+      }
+    }
+  }, [applyRenderQuality, isPerformanceThrottled, isViewportInteracting])
 
   const applyViewportTransform = useCallback(
     (pos: { x: number; y: number }, scale: number) => {
@@ -2236,6 +2309,8 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
       lastAppliedViewportRef.current = null
       previewState.clear()
       renderItems.clear()
+      renderQualityGovernorRef.current.reset()
+      renderQualityRef.current = 'full'
       spriteReconcileGenerationRef.current += 1
       spriteReconcileMutationStatsRef.current = {
         generation: spriteReconcileGenerationRef.current,
@@ -2287,7 +2362,7 @@ const ProjectCanvasWebGLImageLayer = forwardRef<
           clearBeforeRender: true,
           antialias: true,
           autoDensity: true,
-          resolution: getProjectCanvasRenderDeviceScale(),
+          resolution: getProjectCanvasRenderDeviceScale(renderQualityRef.current),
           autoStart: false,
           sharedTicker: false,
           preference: 'webgl',

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/projectCanvasWebGLImageLayerRuntime.test.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/projectCanvasWebGLImageLayerRuntime.test.ts
@@ -5,6 +5,8 @@ import { createProjectCanvasWebGLSpatialTileStateMachine } from './projectCanvas
 import {
   areProjectCanvasWebGLItemReconcileSnapshotsEqual,
   buildProjectCanvasWebGLItemReconcileSnapshot,
+  buildProjectCanvasWebGLItemIndexes,
+  createProjectCanvasWebGLItemIndexesCache,
   createProjectCanvasWebGLResidentTextureByteTracker,
   insertProjectCanvasWebGLPriorityQueueEntry,
   refreshProjectCanvasWebGLPriorityQueuePriorities,
@@ -16,6 +18,23 @@ const queueIds = (queue: readonly ProjectCanvasWebGLPriorityQueueEntry[]) =>
   queue.map((entry) => entry.itemId)
 
 describe('projectCanvasWebGLImageLayerRuntime', () => {
+  it('builds item indexes in one pass and reuses cached indexes by array identity', () => {
+    const firstItems = [
+      { id: 'a', value: 1 },
+      { id: 'b', value: 2 }
+    ]
+    const secondItems = [{ id: 'a', value: 3 }]
+    const firstIndexes = buildProjectCanvasWebGLItemIndexes(firstItems)
+    expect(firstIndexes.itemById.get('b')?.value).toBe(2)
+    expect(firstIndexes.itemIds).toEqual(new Set(['a', 'b']))
+
+    const getIndexes = createProjectCanvasWebGLItemIndexesCache<(typeof firstItems)[number]>()
+    expect(getIndexes(firstItems)).toBe(getIndexes(firstItems))
+    expect(getIndexes(firstItems).itemById.get('a')?.value).toBe(1)
+    expect(getIndexes(secondItems)).not.toBe(firstIndexes)
+    expect(getIndexes(secondItems).itemById.get('a')?.value).toBe(3)
+  })
+
   it('keeps priority queues in descending priority order as entries are inserted', () => {
     const queue: ProjectCanvasWebGLPriorityQueueEntry[] = []
 

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/projectCanvasWebGLImageLayerRuntime.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/components/projectCanvasWebGLImageLayerRuntime.ts
@@ -1,3 +1,41 @@
+export type ProjectCanvasWebGLItemIndexes<TItem extends { id: string }> = {
+  itemById: Map<string, TItem>
+  itemIds: Set<string>
+}
+
+export type ProjectCanvasWebGLItemIndexesCache<TItem extends { id: string }> = (
+  items: readonly TItem[]
+) => ProjectCanvasWebGLItemIndexes<TItem>
+
+export function buildProjectCanvasWebGLItemIndexes<TItem extends { id: string }>(
+  items: readonly TItem[]
+): ProjectCanvasWebGLItemIndexes<TItem> {
+  const itemById = new Map<string, TItem>()
+  const itemIds = new Set<string>()
+  for (const item of items) {
+    itemById.set(item.id, item)
+    itemIds.add(item.id)
+  }
+  return { itemById, itemIds }
+}
+
+export function createProjectCanvasWebGLItemIndexesCache<
+  TItem extends { id: string }
+>(): ProjectCanvasWebGLItemIndexesCache<TItem> {
+  let indexedItems: readonly TItem[] | null = null
+  let indexes: ProjectCanvasWebGLItemIndexes<TItem> | null = null
+
+  return (items) => {
+    if (indexedItems === items && indexes) {
+      return indexes
+    }
+
+    indexedItems = items
+    indexes = buildProjectCanvasWebGLItemIndexes(items)
+    return indexes
+  }
+}
+
 export type ProjectCanvasWebGLPriorityQueueEntry = {
   itemId: string
   src: string

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/projectCanvasWebGLRuntimeState.test.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/projectCanvasWebGLRuntimeState.test.ts
@@ -49,6 +49,8 @@ function createMetrics(
     viewportCulledImageCount: 1,
     spriteReconcilePassCount: 3,
     lastSpriteReconcileDurationMs: 1.5,
+    lastSpriteSortDurationMs: 2.25,
+    spriteSortCount: 4,
     lastSpriteReconcileCandidateCount: 2,
     lastSpriteReconcileTargetCount: 1,
     lastSpriteReconcileCreatedCount: 1,
@@ -88,6 +90,18 @@ describe('projectCanvasWebGLRuntimeState', () => {
     expect(
       areProjectCanvasWebGLRuntimeMetricsEqual(
         createMetrics({ spriteReconcilePassCount: metrics.spriteReconcilePassCount! + 1 }),
+        metrics
+      )
+    ).toBe(false)
+    expect(
+      areProjectCanvasWebGLRuntimeMetricsEqual(
+        createMetrics({ lastSpriteSortDurationMs: metrics.lastSpriteSortDurationMs! + 1 }),
+        metrics
+      )
+    ).toBe(false)
+    expect(
+      areProjectCanvasWebGLRuntimeMetricsEqual(
+        createMetrics({ spriteSortCount: metrics.spriteSortCount! + 1 }),
         metrics
       )
     ).toBe(false)
@@ -235,6 +249,8 @@ describe('projectCanvasWebGLRuntimeState', () => {
         renderCount: 4,
         spriteReconcilePassCount: 3,
         lastSpriteReconcileDurationMs: 1.5,
+        lastSpriteSortDurationMs: 2.25,
+        spriteSortCount: 4,
         lastSpriteReconcileTargetCount: 1,
         lastSpriteReconcileDeferredCount: 0,
         residentLimit: 48,

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/projectCanvasWebGLRuntimeState.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/projectCanvasWebGLRuntimeState.ts
@@ -18,6 +18,8 @@ export type ProjectCanvasWebGLRuntimeMetrics = {
   viewportCulledImageCount: number
   spriteReconcilePassCount?: number
   lastSpriteReconcileDurationMs?: number | null
+  lastSpriteSortDurationMs?: number | null
+  spriteSortCount?: number
   lastSpriteReconcileCandidateCount?: number
   lastSpriteReconcileTargetCount?: number
   lastSpriteReconcileCreatedCount?: number
@@ -129,6 +131,8 @@ const fallbackWebGLMetrics: ProjectCanvasWebGLRuntimeMetrics = {
   viewportCulledImageCount: 0,
   spriteReconcilePassCount: 0,
   lastSpriteReconcileDurationMs: null,
+  lastSpriteSortDurationMs: null,
+  spriteSortCount: 0,
   lastSpriteReconcileCandidateCount: 0,
   lastSpriteReconcileTargetCount: 0,
   lastSpriteReconcileCreatedCount: 0,
@@ -187,6 +191,8 @@ const PROJECT_CANVAS_WEBGL_RUNTIME_METRIC_KEYS = [
   'viewportCulledImageCount',
   'spriteReconcilePassCount',
   'lastSpriteReconcileDurationMs',
+  'lastSpriteSortDurationMs',
+  'spriteSortCount',
   'lastSpriteReconcileCandidateCount',
   'lastSpriteReconcileTargetCount',
   'lastSpriteReconcileCreatedCount',

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/useCanvasStageInteraction.test.tsx
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/useCanvasStageInteraction.test.tsx
@@ -80,16 +80,16 @@ describe('useCanvasStageInteraction', () => {
       .__canvasInteractionTrace
   })
 
-  it('applies middle-mouse pan transforms immediately while deferring React state', () => {
+  it('batches middle-mouse pan transforms once per frame and flushes the latest position', () => {
     const rafCallbacks = new Map<number, FrameRequestCallback>()
     let rafId = 0
-    vi.spyOn(window, 'requestAnimationFrame').mockImplementation(
-      (callback: FrameRequestCallback) => {
+    const requestAnimationFrameSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback: FrameRequestCallback) => {
         rafId += 1
         rafCallbacks.set(rafId, callback)
         return rafId
-      }
-    )
+      })
     vi.spyOn(window, 'cancelAnimationFrame').mockImplementation((id: number) => {
       rafCallbacks.delete(id)
     })
@@ -117,25 +117,47 @@ describe('useCanvasStageInteraction', () => {
     })
 
     expect(options.stagePosRef.current).toEqual({ x: 35, y: 49 })
-    expect(onViewportChange).toHaveBeenCalledTimes(2)
-    expect(onViewportChange).toHaveBeenLastCalledWith({ x: 35, y: 49 }, 1)
+    expect(onViewportChange).not.toHaveBeenCalled()
     expect(options.setStagePos).not.toHaveBeenCalled()
+    expect(requestAnimationFrameSpy).toHaveBeenCalledTimes(1)
     expect(rafCallbacks.size).toBe(1)
 
+    const firstFrame = rafCallbacks.entries().next().value
+    expect(firstFrame).toBeDefined()
+    rafCallbacks.delete(firstFrame![0])
     act(() => {
-      rafCallbacks.values().next().value?.(16)
+      firstFrame![1](16)
     })
 
-    expect(onViewportChange).toHaveBeenCalledTimes(2)
+    expect(onViewportChange).toHaveBeenCalledTimes(1)
     expect(onViewportChange).toHaveBeenLastCalledWith({ x: 35, y: 49 }, 1)
     expect(options.setStagePos).not.toHaveBeenCalled()
+
+    act(() => {
+      result.current.handleStageMouseMove({
+        evt: new MouseEvent('mousemove', { clientX: 145, clientY: 180 }),
+        type: 'mousemove'
+      })
+      result.current.handleStageMouseMove({
+        evt: new MouseEvent('mousemove', { clientX: 155, clientY: 190 }),
+        type: 'mousemove'
+      })
+    })
+
+    expect(options.stagePosRef.current).toEqual({ x: 55, y: 70 })
+    expect(onViewportChange).toHaveBeenCalledTimes(1)
+    expect(requestAnimationFrameSpy).toHaveBeenCalledTimes(2)
+    expect(rafCallbacks.size).toBe(1)
 
     act(() => {
       window.dispatchEvent(new MouseEvent('mouseup'))
     })
 
+    expect(rafCallbacks.size).toBe(0)
+    expect(onViewportChange).toHaveBeenCalledTimes(2)
+    expect(onViewportChange).toHaveBeenLastCalledWith({ x: 55, y: 70 }, 1)
     expect(options.setStagePos).toHaveBeenCalledTimes(1)
-    expect(options.setStagePos).toHaveBeenLastCalledWith({ x: 35, y: 49 })
+    expect(options.setStagePos).toHaveBeenLastCalledWith({ x: 55, y: 70 })
 
     unmount()
   })
@@ -157,13 +179,14 @@ describe('useCanvasStageInteraction', () => {
     })
 
     expect(options.stagePosRef.current).toEqual({ x: 60, y: 70 })
-    expect(onViewportChange).toHaveBeenCalledWith({ x: 60, y: 70 }, 1)
+    expect(onViewportChange).not.toHaveBeenCalled()
     expect(options.setStagePos).not.toHaveBeenCalled()
 
     act(() => {
       window.dispatchEvent(new MouseEvent('mouseup'))
     })
 
+    expect(onViewportChange).toHaveBeenCalledWith({ x: 60, y: 70 }, 1)
     expect(options.setStagePos).toHaveBeenCalledWith({ x: 60, y: 70 })
 
     unmount()

--- a/packages/app/src/renderer/src/pages/ProjectCanvasPage/useCanvasStageInteraction.ts
+++ b/packages/app/src/renderer/src/pages/ProjectCanvasPage/useCanvasStageInteraction.ts
@@ -271,9 +271,8 @@ export function useCanvasStageInteraction(options: UseCanvasStageInteractionOpti
         y: stagePosRef.current.y + dy
       }
       syncCanvasRuntimeViewport()
-      applyViewportChange(stagePosRef.current, stageScaleRef.current)
     },
-    [applyViewportChange, lastPanPosRef, stagePosRef, stageScaleRef, syncCanvasRuntimeViewport]
+    [lastPanPosRef, stagePosRef, syncCanvasRuntimeViewport]
   )
 
   const scheduleViewportCommit = useCallback(() => {
@@ -285,13 +284,12 @@ export function useCanvasStageInteraction(options: UseCanvasStageInteractionOpti
       viewportCommitFrameRef.current = null
       const pos = stagePosRef.current
       const scale = stageScaleRef.current
-      syncCanvasRuntimeViewport()
       // Drive viewport-layer DOM transforms imperatively – zero React setState on the hot path.
       // React state (setStagePos / setStageScale) is synced only once when interaction ends
       // via flushPendingViewportCommit, eliminating per-frame reconciliation overhead.
       applyViewportChange(pos, scale)
     })
-  }, [applyViewportChange, stagePosRef, stageScaleRef, syncCanvasRuntimeViewport])
+  }, [applyViewportChange, stagePosRef, stageScaleRef])
 
   const applyWheelZoom = useCallback(
     (pointer: { x: number; y: number }, deltaY: number) => {

--- a/packages/app/src/renderer/src/pages/QuickAppPage/QAppExecutePanel/BatchProcessButton.tsx
+++ b/packages/app/src/renderer/src/pages/QuickAppPage/QAppExecutePanel/BatchProcessButton.tsx
@@ -1,364 +1,363 @@
-import React, { useState, useCallback, useRef } from 'react'
+import { Add, Delete, FolderOpen, Science } from '@mui/icons-material'
 import {
+  Box,
   Button,
   Dialog,
-  DialogTitle,
-  DialogContent,
   DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControlLabel,
   LinearProgress,
-  Typography,
-  Box,
-  Stack
+  Stack,
+  Switch,
+  TextField,
+  Typography
 } from '@mui/material'
-import { FolderOpen } from '@mui/icons-material'
-import { api } from '@renderer/utils/windowUtils'
 import { useMessage } from '@renderer/hooks/useMessage'
+import { api } from '@renderer/utils/windowUtils'
+import type {
+  ComfyBatchProfile,
+  ComfyBatchStatus,
+  ComfyBatchProbeResult
+} from '@shared/api/svcComfyBatch'
+import type { Workflow } from '@shared/comfy/types'
+import { useCallback, useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { useQAppContext } from '../components/QAppContext'
-import { Workflow, FileItem } from '@shared/comfy/types'
-import { setJsonPath } from '@shared/utils/jsonPath'
-import { deepCopy } from '@shared/utils/utilTypes'
-import { fileItemToValue } from '@shared/comfy/funcs'
-import { buildQAppSubmitWorkflowRequest } from '../utils/qAppSubmitWorkflow'
-import { resolveQAppSessionKey } from '../utils/qAppSessionIdentity'
 
 type BatchProcessButtonProps = {
   isConnected: boolean
-  imageInputSlot: string // The JSON path to the image input in the workflow
-  buildWorkflow: () => Workflow
-  validate: () => boolean
-  /**
-   * 批量处理专用工作流文件名（可选）
-   * 如果指定，将加载此工作流用于批量处理
-   */
-  batchWorkflow?: string
-  /**
-   * 批量工作流中图片输入的 JSON Path（可选）
-   * 如果 batchWorkflow 使用了不同的节点 ID，需要指定此字段
-   */
-  batchImageInputSlot?: string
+  imageInputSlot: string
+  outputNodeIds?: string[]
+  buildWorkflow: () => Promise<Workflow> | Workflow
+  validate: () => Promise<boolean> | boolean
 }
 
-type BatchProcessState = {
-  isProcessing: boolean
-  currentIndex: number
-  totalCount: number
-  successCount: number
-  failedCount: number
-  failedFiles: string[]
-  currentFile: string
+const EMPTY_STATUS: ComfyBatchStatus = {
+  state: 'idle',
+  total: 0,
+  success: 0,
+  failed: 0,
+  skipped: 0,
+  running: 0,
+  pending: 0,
+  failedFiles: []
 }
 
-const BatchProcessButton: React.FC<BatchProcessButtonProps> = ({
+const newProfile = (): ComfyBatchProfile => ({
+  id: globalThis.crypto?.randomUUID?.() || `comfy-${Date.now()}`,
+  name: 'ComfyUI',
+  baseUrl: 'http://127.0.0.1:8188',
+  enabled: true,
+  maxConcurrency: 1
+})
+
+const BatchProcessButton = ({
   isConnected,
   imageInputSlot,
+  outputNodeIds,
   buildWorkflow,
-  validate,
-  batchWorkflow,
-  batchImageInputSlot
-}) => {
-  const { notifySuccess, notifyError, notifyInfo, notifyWarning } = useMessage()
-  const { currentQAppKey, buildSubmitExtraData, submitClientId, submitSessionKey } =
-    useQAppContext()
-  const [showDialog, setShowDialog] = useState(false)
-  const cancelRef = useRef(false) // 用于跟踪取消状态
-  const [state, setState] = useState<BatchProcessState>({
-    isProcessing: false,
-    currentIndex: 0,
-    totalCount: 0,
-    successCount: 0,
-    failedCount: 0,
-    failedFiles: [],
-    currentFile: ''
-  })
-  const [isCancelled, setIsCancelled] = useState(false)
+  validate
+}: BatchProcessButtonProps) => {
+  const { currentQAppKey } = useQAppContext()
+  const { t } = useTranslation()
+  const { notifyError, notifyInfo } = useMessage()
+  const [open, setOpen] = useState(false)
+  const [status, setStatus] = useState<ComfyBatchStatus>(EMPTY_STATUS)
+  const [profiles, setProfiles] = useState<ComfyBatchProfile[]>([])
+  const [probeResults, setProbeResults] = useState<Record<string, ComfyBatchProbeResult>>({})
 
-  const handleBatchProcess = useCallback(async () => {
-    // 1. Validate workflow
-    if (!validate()) {
-      return
+  const loadProfiles = useCallback(async () => {
+    try {
+      const result = await api().svcComfyBatch.listProfiles({})
+      setProfiles(result.profiles)
+    } catch (error) {
+      notifyError(error instanceof Error ? error.message : String(error))
     }
+  }, [notifyError])
 
-    // 2. Select input folder
-    const inputFolderResult = await api().svcDialog.showOpenDialog({
-      title: '选择输入文件夹',
-      properties: ['openDirectory']
-    })
+  useEffect(() => {
+    if (open && profiles.length === 0) void loadProfiles()
+  }, [loadProfiles, open, profiles.length])
 
-    if (inputFolderResult.canceled || !inputFolderResult.filePaths[0]) {
-      return
-    }
-
-    const inputFolder = inputFolderResult.filePaths[0]
-
-    // 3. Get list of images
-    const imagesResult = await api().svcFs.listImagesInFolder({ folderPath: inputFolder })
-
-    if (imagesResult.images.length === 0) {
-      notifyError('所选文件夹中没有找到图片')
-      return
-    }
-
-    // 4. Select output folder
-    const outputFolderResult = await api().svcDialog.showOpenDialog({
-      title: '选择输出文件夹',
-      properties: ['openDirectory', 'createDirectory']
-    })
-
-    if (outputFolderResult.canceled || !outputFolderResult.filePaths[0]) {
-      return
-    }
-
-    const outputFolder = outputFolderResult.filePaths[0]
-
-    // 5. Start batch processing
-    setShowDialog(true)
-    cancelRef.current = false
-    setIsCancelled(false)
-    setState({
-      isProcessing: true,
-      currentIndex: 0,
-      totalCount: imagesResult.images.length,
-      successCount: 0,
-      failedCount: 0,
-      failedFiles: [],
-      currentFile: ''
-    })
-
-    // 6. Load batch workflow if specified, otherwise use default workflow builder
-    let baseWorkflow: Workflow
-    let effectiveImageInputSlot = imageInputSlot
-
-    if (batchWorkflow && currentQAppKey) {
+  useEffect(() => {
+    if (!open || status.state !== 'running' || !status.jobId) return
+    const timer = window.setInterval(async () => {
       try {
-        // Load batch-specific workflow
-        notifyInfo(`正在加载批量处理专用工作流...`)
-        const batchWorkflowDir = currentQAppKey.substring(0, currentQAppKey.lastIndexOf('/') + 1)
-        const batchWorkflowKey = batchWorkflowDir + batchWorkflow.replace('.prompt.json', '')
-        const batchCfg = await api().svcQApp.getQAppCfg({ key: batchWorkflowKey })
-        baseWorkflow = batchCfg.workflow
-        // Use batch image input slot if specified
-        effectiveImageInputSlot = batchImageInputSlot || imageInputSlot
-        notifySuccess(`已加载批量处理专用工作流`)
+        const result = await api().svcComfyBatch.status({ jobId: status.jobId })
+        setStatus(result.status)
       } catch (error) {
-        console.error('Failed to load batch workflow, falling back to default:', error)
-        notifyError(`加载批量工作流失败，使用默认工作流`)
-        baseWorkflow = buildWorkflow()
+        console.warn('[ComfyBatch] status poll failed:', error)
       }
-    } else {
-      baseWorkflow = buildWorkflow()
-    }
+    }, 700)
+    return () => window.clearInterval(timer)
+  }, [open, status.jobId, status.state])
 
-    for (let i = 0; i < imagesResult.images.length; i++) {
-      // 检查是否已取消
-      if (cancelRef.current) {
-        setIsCancelled(true)
-        notifyWarning('批量处理已取消')
-        break
-      }
-
-      const image = imagesResult.images[i]
-
-      setState((prev) => ({
-        ...prev,
-        currentIndex: i + 1,
-        currentFile: image.filename
+  const probeProfile = useCallback(async (profile: ComfyBatchProfile) => {
+    try {
+      const result = await api().svcComfyBatch.probeProfile({ baseUrl: profile.baseUrl })
+      setProbeResults((current) => ({ ...current, [profile.id]: result.result }))
+    } catch (error) {
+      setProbeResults((current) => ({
+        ...current,
+        [profile.id]: {
+          ok: false,
+          baseUrl: profile.baseUrl,
+          latencyMs: 0,
+          error: error instanceof Error ? error.message : String(error)
+        }
       }))
-
-      try {
-        // 6.1 Read image from disk
-        const imageData = await api().svcFs.readImageFromPath({ fullPath: image.fullPath })
-
-        // 6.2 Upload to ComfyUI
-        const uploadResult: FileItem = await api().svcComfy.uploadImage({
-          fileItem: { filename: image.filename, type: 'input' },
-          image: imageData.image
-        })
-
-        if (!uploadResult.filename) {
-          throw new Error('上传图片失败')
-        }
-
-        // 6.3 Build workflow with uploaded image
-        const workflow = deepCopy(baseWorkflow) as Workflow
-        const uploadedValue = fileItemToValue(uploadResult)
-        setJsonPath(effectiveImageInputSlot, workflow, uploadedValue)
-
-        // 5.4 Submit workflow
-        const submitResult = await api().svcComfy.submitWorkflow(
-          buildQAppSubmitWorkflowRequest({
-            prompt: workflow,
-            qAppKey: currentQAppKey,
-            clientId: submitClientId,
-            sessionKey: resolveQAppSessionKey({
-              qAppKey: currentQAppKey,
-              submitSessionKey
-            }),
-            extraData: buildSubmitExtraData?.()
-          })
-        )
-
-        // 5.5 Wait for completion
-        let completed = false
-        while (!completed) {
-          await new Promise((resolve) => setTimeout(resolve, 500))
-          const history = await api().svcComfy.getHistory({ prompt_id: submitResult.prompt_id })
-
-          if (history[submitResult.prompt_id]) {
-            const result = history[submitResult.prompt_id]
-            if (result.status?.status_str === 'error') {
-              throw new Error('工作流执行失败')
-            }
-
-            // 5.6 Get output image and save
-            const outputs = result.outputs || {}
-            for (const nodeId of Object.keys(outputs)) {
-              const nodeOutput = outputs[nodeId]
-              if (nodeOutput.images && nodeOutput.images.length > 0) {
-                const outputImage = nodeOutput.images[0]
-                const viewResult = await api().svcComfy.getView({
-                  filename: outputImage.filename,
-                  type: outputImage.type,
-                  subfolder: outputImage.subfolder
-                })
-
-                // Save with original filename
-                const ext = image.filename.includes('.')
-                  ? image.filename.substring(image.filename.lastIndexOf('.'))
-                  : '.png'
-                const outputFilename = image.filename.replace(/\.[^/.]+$/, '') + '_upscaled' + ext
-
-                await api().svcFs.saveImageToPath({
-                  image: viewResult.result,
-                  outputPath: outputFolder,
-                  filename: outputFilename
-                })
-
-                completed = true
-                break
-              }
-            }
-
-            if (!completed) {
-              // No image output found yet, check again
-              completed = result.status?.completed || false
-            }
-          }
-        }
-
-        setState((prev) => ({
-          ...prev,
-          successCount: prev.successCount + 1
-        }))
-      } catch (error) {
-        console.error(`批量处理失败: ${image.filename}`, error)
-        setState((prev) => ({
-          ...prev,
-          failedCount: prev.failedCount + 1,
-          failedFiles: [...prev.failedFiles, image.filename]
-        }))
-      }
     }
-
-    setState((prev) => ({
-      ...prev,
-      isProcessing: false
-    }))
-  }, [
-    validate,
-    buildWorkflow,
-    imageInputSlot,
-    currentQAppKey,
-    buildSubmitExtraData,
-    notifyError,
-    notifyInfo,
-    notifySuccess,
-    notifyWarning,
-    batchWorkflow,
-    batchImageInputSlot,
-    submitClientId,
-    submitSessionKey
-  ])
-
-  const handleCancel = useCallback(() => {
-    cancelRef.current = true
   }, [])
 
-  const handleClose = () => {
-    if (!state.isProcessing) {
-      setShowDialog(false)
-      setIsCancelled(false)
-      if (state.successCount > 0 || state.failedCount > 0) {
-        if (isCancelled) {
-          notifyInfo(`批量处理已取消。成功 ${state.successCount} 张，失败 ${state.failedCount} 张`)
-        } else if (state.failedCount === 0) {
-          notifySuccess(`批量处理完成！成功处理 ${state.successCount} 张图片`)
-        } else {
-          notifyInfo(`批量处理完成！成功 ${state.successCount} 张，失败 ${state.failedCount} 张`)
-        }
-      }
-    }
-  }
+  const updateProfile = useCallback((id: string, patch: Partial<ComfyBatchProfile>) => {
+    setProfiles((current) =>
+      current.map((profile) => (profile.id === id ? { ...profile, ...patch } : profile))
+    )
+  }, [])
 
-  const progress = state.totalCount > 0 ? (state.currentIndex / state.totalCount) * 100 : 0
+  const start = useCallback(async () => {
+    try {
+      if (!isConnected) throw new Error(t('qapp.batch.comfy_not_ready'))
+      if (!(await validate())) return
+      if (!currentQAppKey) throw new Error('Quick App key is missing')
+      if (!outputNodeIds?.length) throw new Error('Quick App outputNodeIds must not be empty')
+      await api().svcComfyBatch.replaceProfiles({ profiles })
+      const selection = await api().svcDialog.showOpenDialog({
+        title: t('qapp.batch.select_source'),
+        properties: ['openDirectory']
+      })
+      const sourceDir = selection.filePaths[0]
+      if (selection.canceled || !sourceDir) return
+      const result = await api().svcComfyBatch.start({
+        sourceDir,
+        qAppKey: currentQAppKey,
+        workflow: await buildWorkflow(),
+        imageInputSlot,
+        outputNodeIds
+      })
+      setStatus(result.status)
+      setOpen(true)
+    } catch (error) {
+      notifyError(error instanceof Error ? error.message : String(error))
+    }
+  }, [
+    buildWorkflow,
+    currentQAppKey,
+    imageInputSlot,
+    isConnected,
+    notifyError,
+    outputNodeIds,
+    profiles,
+    t,
+    validate
+  ])
+
+  const cancel = useCallback(async () => {
+    if (!status.jobId) return
+    try {
+      const result = await api().svcComfyBatch.cancel({ jobId: status.jobId })
+      setStatus(result.status)
+      notifyInfo(t('qapp.batch.cancel_sent'))
+    } catch (error) {
+      notifyError(error instanceof Error ? error.message : String(error))
+    }
+  }, [notifyError, notifyInfo, status.jobId, t])
+
+  const retryFailed = useCallback(async () => {
+    if (!status.jobId) return
+    try {
+      const result = await api().svcComfyBatch.retryFailed({ jobId: status.jobId })
+      setStatus(result.status)
+    } catch (error) {
+      notifyError(error instanceof Error ? error.message : String(error))
+    }
+  }, [notifyError, status.jobId])
+
+  const finished = status.success + status.failed + status.skipped
+  const progress = status.total > 0 ? Math.min(100, (finished / status.total) * 100) : 0
 
   return (
     <>
       <Button
         variant="outlined"
         startIcon={<FolderOpen />}
-        onClick={handleBatchProcess}
         disabled={!isConnected}
-        sx={{ minWidth: 120 }}
+        onClick={() => setOpen(true)}
       >
-        批量处理
+        {t('qapp.batch.button')}
       </Button>
-
-      <Dialog open={showDialog} onClose={handleClose} maxWidth="sm" fullWidth>
-        <DialogTitle>批量处理进度</DialogTitle>
+      <Dialog
+        open={open}
+        onClose={() => status.state !== 'running' && setOpen(false)}
+        fullWidth
+        maxWidth="md"
+      >
+        <DialogTitle>{t('qapp.batch.title')}</DialogTitle>
         <DialogContent>
-          <Stack spacing={2} sx={{ mt: 1 }}>
-            <Box>
-              <Typography variant="body2" color="text.secondary" gutterBottom>
-                {state.isProcessing ? `正在处理: ${state.currentFile}` : '处理完成'}
-              </Typography>
-              <LinearProgress
-                variant="determinate"
-                value={progress}
-                sx={{ height: 8, borderRadius: 4 }}
-              />
-              <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
-                {state.currentIndex} / {state.totalCount}
-              </Typography>
-            </Box>
-
-            <Box sx={{ display: 'flex', gap: 3 }}>
-              <Typography color="success.main">成功: {state.successCount}</Typography>
-              <Typography color="error.main">失败: {state.failedCount}</Typography>
-            </Box>
-
-            {state.failedFiles.length > 0 && (
-              <Box>
-                <Typography variant="body2" color="error" gutterBottom>
-                  失败的文件:
+          <Stack spacing={2} sx={{ pt: 1 }}>
+            {status.state !== 'running' && !status.sourceDir && (
+              <Stack spacing={1.5}>
+                <Typography variant="subtitle2">{t('qapp.batch.instances')}</Typography>
+                {profiles.map((profile) => {
+                  const probe = probeResults[profile.id]
+                  return (
+                    <Stack
+                      key={profile.id}
+                      direction={{ xs: 'column', md: 'row' }}
+                      spacing={1}
+                      alignItems={{ md: 'center' }}
+                    >
+                      <FormControlLabel
+                        control={
+                          <Switch
+                            checked={profile.enabled}
+                            onChange={(_, enabled) => updateProfile(profile.id, { enabled })}
+                          />
+                        }
+                        label={t('qapp.batch.enabled')}
+                      />
+                      <TextField
+                        size="small"
+                        label={t('qapp.batch.name')}
+                        value={profile.name}
+                        onChange={(event) =>
+                          updateProfile(profile.id, { name: event.target.value })
+                        }
+                        sx={{ minWidth: 130 }}
+                      />
+                      <TextField
+                        size="small"
+                        label={t('qapp.batch.url')}
+                        value={profile.baseUrl}
+                        onChange={(event) =>
+                          updateProfile(profile.id, { baseUrl: event.target.value })
+                        }
+                        sx={{ flex: 1, minWidth: 240 }}
+                      />
+                      <TextField
+                        size="small"
+                        type="number"
+                        label={t('qapp.batch.concurrency')}
+                        value={profile.maxConcurrency}
+                        slotProps={{ htmlInput: { min: 1, max: 32 } }}
+                        onChange={(event) =>
+                          updateProfile(profile.id, {
+                            maxConcurrency: Math.max(1, Number(event.target.value) || 1)
+                          })
+                        }
+                        sx={{ width: 90 }}
+                      />
+                      <Button startIcon={<Science />} onClick={() => void probeProfile(profile)}>
+                        {t('qapp.batch.test')}
+                      </Button>
+                      <Button
+                        color="error"
+                        onClick={() =>
+                          setProfiles((current) => current.filter((item) => item.id !== profile.id))
+                        }
+                      >
+                        <Delete />
+                      </Button>
+                      {probe && (
+                        <Typography
+                          variant="caption"
+                          color={probe.ok ? 'success.main' : 'error.main'}
+                        >
+                          {probe.ok ? `${probe.latencyMs} ms` : probe.error}
+                        </Typography>
+                      )}
+                    </Stack>
+                  )
+                })}
+                <Stack direction="row" spacing={1}>
+                  <Button
+                    startIcon={<Add />}
+                    onClick={() => setProfiles((items) => [...items, newProfile()])}
+                  >
+                    {t('qapp.batch.add_instance')}
+                  </Button>
+                  <Button
+                    variant="contained"
+                    disabled={profiles.every((profile) => !profile.enabled)}
+                    onClick={() => void start()}
+                  >
+                    {t('qapp.batch.start')}
+                  </Button>
+                </Stack>
+                <Typography variant="caption" color="text.secondary">
+                  {t('qapp.batch.output_hint')}
                 </Typography>
-                <Box sx={{ maxHeight: 100, overflow: 'auto', fontSize: '0.875rem' }}>
-                  {state.failedFiles.map((file, index) => (
-                    <Typography key={index} variant="body2" color="text.secondary">
-                      {file}
-                    </Typography>
-                  ))}
+              </Stack>
+            )}
+
+            {status.sourceDir && (
+              <>
+                <Box>
+                  <Typography variant="caption" color="text.secondary">
+                    {t('qapp.batch.source')}
+                  </Typography>
+                  <Typography variant="body2" sx={{ wordBreak: 'break-all' }}>
+                    {status.sourceDir}
+                  </Typography>
                 </Box>
-              </Box>
+                <Box>
+                  <Typography variant="caption" color="text.secondary">
+                    {t('qapp.batch.output')}
+                  </Typography>
+                  <Typography variant="body2" sx={{ wordBreak: 'break-all' }}>
+                    {status.outputDir || '-'}
+                  </Typography>
+                </Box>
+                <LinearProgress variant="determinate" value={progress} />
+                <Stack direction="row" spacing={2} useFlexGap flexWrap="wrap">
+                  <Typography>{t('qapp.batch.total', { count: status.total })}</Typography>
+                  <Typography color="success.main">
+                    {t('qapp.batch.success', { count: status.success })}
+                  </Typography>
+                  <Typography color="error.main">
+                    {t('qapp.batch.failed', { count: status.failed })}
+                  </Typography>
+                  <Typography>{t('qapp.batch.skipped', { count: status.skipped })}</Typography>
+                  <Typography>{t('qapp.batch.running', { count: status.running })}</Typography>
+                  <Typography>{t('qapp.batch.pending', { count: status.pending })}</Typography>
+                </Stack>
+                <Typography variant="body2" color="text.secondary">
+                  {t('qapp.batch.state', { state: status.state })}
+                </Typography>
+                {status.error && <Typography color="error.main">{status.error}</Typography>}
+                {status.failedFiles.length > 0 && (
+                  <Box sx={{ maxHeight: 120, overflow: 'auto' }}>
+                    {status.failedFiles.map((filename) => (
+                      <Typography
+                        key={filename}
+                        variant="caption"
+                        display="block"
+                        color="error.main"
+                      >
+                        {filename}
+                      </Typography>
+                    ))}
+                  </Box>
+                )}
+              </>
             )}
           </Stack>
         </DialogContent>
         <DialogActions>
-          {state.isProcessing ? (
-            <Button onClick={handleCancel} color="error">
-              取消处理
+          {status.state === 'running' && (
+            <Button color="error" onClick={() => void cancel()}>
+              {t('qapp.batch.cancel')}
             </Button>
-          ) : (
-            <Button onClick={handleClose}>关闭</Button>
+          )}
+          {status.state !== 'running' && status.failed > 0 && (
+            <Button onClick={() => void retryFailed()}>{t('qapp.batch.retry')}</Button>
+          )}
+          {status.state !== 'running' && status.sourceDir && (
+            <Button onClick={() => setStatus(EMPTY_STATUS)}>{t('qapp.batch.new')}</Button>
+          )}
+          {status.state !== 'running' && (
+            <Button onClick={() => setOpen(false)}>{t('qapp.batch.close')}</Button>
           )}
         </DialogActions>
       </Dialog>

--- a/packages/app/src/renderer/src/pages/QuickAppPage/QAppExecutePanel/BatchProcessButton.tsx
+++ b/packages/app/src/renderer/src/pages/QuickAppPage/QAppExecutePanel/BatchProcessButton.tsx
@@ -26,7 +26,6 @@ import { useTranslation } from 'react-i18next'
 import { useQAppContext } from '../components/QAppContext'
 
 type BatchProcessButtonProps = {
-  isConnected: boolean
   imageInputSlot: string
   outputNodeIds?: string[]
   buildWorkflow: () => Promise<Workflow> | Workflow
@@ -53,7 +52,6 @@ const newProfile = (): ComfyBatchProfile => ({
 })
 
 const BatchProcessButton = ({
-  isConnected,
   imageInputSlot,
   outputNodeIds,
   buildWorkflow,
@@ -118,7 +116,6 @@ const BatchProcessButton = ({
 
   const start = useCallback(async () => {
     try {
-      if (!isConnected) throw new Error(t('qapp.batch.comfy_not_ready'))
       if (!(await validate())) return
       if (!currentQAppKey) throw new Error('Quick App key is missing')
       if (!outputNodeIds?.length) throw new Error('Quick App outputNodeIds must not be empty')
@@ -145,7 +142,6 @@ const BatchProcessButton = ({
     buildWorkflow,
     currentQAppKey,
     imageInputSlot,
-    isConnected,
     notifyError,
     outputNodeIds,
     profiles,
@@ -179,12 +175,7 @@ const BatchProcessButton = ({
 
   return (
     <>
-      <Button
-        variant="outlined"
-        startIcon={<FolderOpen />}
-        disabled={!isConnected}
-        onClick={() => setOpen(true)}
-      >
+      <Button variant="outlined" startIcon={<FolderOpen />} onClick={() => setOpen(true)}>
         {t('qapp.batch.button')}
       </Button>
       <Dialog

--- a/packages/app/src/renderer/src/pages/QuickAppPage/QAppExecutePanel/BatchProcessButton.tsx
+++ b/packages/app/src/renderer/src/pages/QuickAppPage/QAppExecutePanel/BatchProcessButton.tsx
@@ -341,9 +341,10 @@ const BatchProcessButton = ({
               {t('qapp.batch.cancel')}
             </Button>
           )}
-          {status.state !== 'running' && status.failed > 0 && (
-            <Button onClick={() => void retryFailed()}>{t('qapp.batch.retry')}</Button>
-          )}
+          {status.state !== 'running' &&
+            (status.failed > 0 || status.pending > 0 || status.state === 'error') && (
+              <Button onClick={() => void retryFailed()}>{t('qapp.batch.retry')}</Button>
+            )}
           {status.state !== 'running' && status.sourceDir && (
             <Button onClick={() => setStatus(EMPTY_STATUS)}>{t('qapp.batch.new')}</Button>
           )}

--- a/packages/app/src/renderer/src/pages/QuickAppPage/ResultList/ResultSection.tsx
+++ b/packages/app/src/renderer/src/pages/QuickAppPage/ResultList/ResultSection.tsx
@@ -49,7 +49,6 @@ export default function ResultSection({ isDesignMode = false }: ResultSectionPro
             />
             {!isDesignMode && qAppCfg?.batchProcess?.enabled && (
               <BatchProcessButton
-                isConnected={isConnected}
                 imageInputSlot={qAppCfg.batchProcess.imageInputSlot}
                 outputNodeIds={qAppCfg.outputNodeIds}
                 validate={validate}

--- a/packages/app/src/renderer/src/pages/QuickAppPage/ResultList/ResultSection.tsx
+++ b/packages/app/src/renderer/src/pages/QuickAppPage/ResultList/ResultSection.tsx
@@ -2,6 +2,7 @@ import { Stack } from '@mui/material'
 import ResultList from './ResultList'
 import SubmitWorkflowButton from '../QAppExecutePanel/SubmitWorkflowButton'
 import RealtimeGenerationSwitch from '../QAppExecutePanel/RealtimeGenerationSwitch'
+import BatchProcessButton from '../QAppExecutePanel/BatchProcessButton'
 import { useComfyStatus } from '@renderer/store/hooks/comfyStatus'
 import { useQAppContext } from '../components/QAppContext'
 
@@ -46,6 +47,15 @@ export default function ResultSection({ isDesignMode = false }: ResultSectionPro
               validate={validate}
               buildWorkflow={buildWorkflow}
             />
+            {!isDesignMode && qAppCfg?.batchProcess?.enabled && (
+              <BatchProcessButton
+                isConnected={isConnected}
+                imageInputSlot={qAppCfg.batchProcess.imageInputSlot}
+                outputNodeIds={qAppCfg.outputNodeIds}
+                validate={validate}
+                buildWorkflow={buildWorkflow}
+              />
+            )}
           </Stack>
           {buildWorkflow && (
             <RealtimeGenerationSwitch

--- a/packages/app/src/shared/api/index.ts
+++ b/packages/app/src/shared/api/index.ts
@@ -1,6 +1,7 @@
 import { ApiDefSheet } from './apiUtils/serviceDefSheet'
 import { AdobeBridgeSvc, adobeBridgeSvcDef } from './svcAdobeBridge'
 import { ComfySvc, comfySvcDef } from './svcComfy'
+import { ComfyBatchSvc, comfyBatchSvcDef } from './svcComfyBatch'
 import { CanvasThumbnailSvc, canvasThumbnailSvcDef } from './svcCanvasThumbnail'
 import { ProjectTraceSvc, projectTraceSvcDef } from './svcProjectTrace'
 import { TargetSchemeSvc, targetSchemeSvcDef } from './svcTargetScheme'
@@ -31,6 +32,7 @@ export type BaseApi = {
   svcTargetScheme: TargetSchemeSvc
   svcCustomSkill: CustomSkillSvc
   svcComfy: ComfySvc
+  svcComfyBatch: ComfyBatchSvc
   svcCanvasThumbnail: CanvasThumbnailSvc
   svcProjectTrace: ProjectTraceSvc
   svcPysssss: PysssssSvc
@@ -58,6 +60,7 @@ export const apiDef: ApiDefSheet<Api> = {
   svcTargetScheme: targetSchemeSvcDef,
   svcCustomSkill: customSkillSvcDef,
   svcComfy: comfySvcDef,
+  svcComfyBatch: comfyBatchSvcDef,
   svcCanvasThumbnail: canvasThumbnailSvcDef,
   svcProjectTrace: projectTraceSvcDef,
   svcPysssss: pysssssSvcDef,

--- a/packages/app/src/shared/api/svcComfyBatch.ts
+++ b/packages/app/src/shared/api/svcComfyBatch.ts
@@ -1,0 +1,82 @@
+import type { Workflow } from '@shared/comfy/types'
+import type { ServiceDefSheet } from './apiUtils/serviceDefSheet'
+
+export type ComfyBatchProfile = {
+  id: string
+  name: string
+  baseUrl: string
+  enabled: boolean
+  maxConcurrency: number
+}
+
+export type ComfyBatchProbeResult = {
+  ok: boolean
+  baseUrl: string
+  latencyMs: number
+  endpoint?: 'system_stats' | 'queue'
+  error?: string
+}
+
+export type ComfyBatchJobState = 'idle' | 'running' | 'completed' | 'cancelled' | 'error'
+
+export type ComfyBatchStatus = {
+  jobId?: string
+  state: ComfyBatchJobState
+  sourceDir?: string
+  outputDir?: string
+  qAppKey?: string
+  planFingerprint?: string
+  total: number
+  success: number
+  failed: number
+  skipped: number
+  running: number
+  pending: number
+  error?: string
+  failedFiles: string[]
+  startedAt?: number
+  finishedAt?: number
+}
+
+export type StartComfyBatchReq = {
+  sourceDir: string
+  qAppKey: string
+  workflow: Workflow
+  imageInputSlot: string
+  outputNodeIds: string[]
+}
+
+export type StartComfyBatchResp = { status: ComfyBatchStatus }
+export type GetComfyBatchStatusReq = { jobId?: string }
+export type GetComfyBatchStatusResp = { status: ComfyBatchStatus }
+export type RetryFailedComfyBatchReq = { jobId: string }
+export type RetryFailedComfyBatchResp = { status: ComfyBatchStatus }
+export type CancelComfyBatchReq = { jobId: string }
+export type CancelComfyBatchResp = { status: ComfyBatchStatus }
+
+export type ListComfyBatchProfilesReq = Record<string, never>
+export type ListComfyBatchProfilesResp = { profiles: ComfyBatchProfile[] }
+export type ProbeComfyBatchProfileReq = { id?: string; baseUrl?: string }
+export type ProbeComfyBatchProfileResp = { result: ComfyBatchProbeResult }
+export type ReplaceComfyBatchProfilesReq = { profiles: ComfyBatchProfile[] }
+export type ReplaceComfyBatchProfilesResp = { profiles: ComfyBatchProfile[] }
+
+export type ComfyBatchSvc = {
+  listProfiles(req: ListComfyBatchProfilesReq): Promise<ListComfyBatchProfilesResp>
+  replaceProfiles(req: ReplaceComfyBatchProfilesReq): Promise<ReplaceComfyBatchProfilesResp>
+  probeProfile(req: ProbeComfyBatchProfileReq): Promise<ProbeComfyBatchProfileResp>
+  start(req: StartComfyBatchReq): Promise<StartComfyBatchResp>
+  status(req: GetComfyBatchStatusReq): Promise<GetComfyBatchStatusResp>
+  retryFailed(req: RetryFailedComfyBatchReq): Promise<RetryFailedComfyBatchResp>
+  cancel(req: CancelComfyBatchReq): Promise<CancelComfyBatchResp>
+}
+
+export const comfyBatchSvcDef: ServiceDefSheet<ComfyBatchSvc> = {
+  listProfiles: { type: 'unary' },
+  replaceProfiles: { type: 'unary' },
+  probeProfile: { type: 'unary' },
+  start: { type: 'unary' },
+  status: { type: 'unary' },
+  retryFailed: { type: 'unary' },
+  cancel: { type: 'unary' }
+}

--- a/packages/app/src/shared/config/config.ts
+++ b/packages/app/src/shared/config/config.ts
@@ -1,6 +1,7 @@
 // shared/config/config.ts
 
 import type { JsonValue } from '@shared/utils/utilTypes'
+import type { ComfyBatchProfile } from '@shared/api/svcComfyBatch'
 import {
   DEFAULT_DUPLICATE_CHECK_SETTINGS,
   type DuplicateCheckSettings
@@ -333,6 +334,7 @@ type ConfigShape = {
   config_version: '>1.0.53'
   client_id: string
   use_remote_comfyui: boolean
+  comfy_batch_profiles?: ComfyBatchProfile[]
 
   local_comfyui_config: {
     python_cmd: string
@@ -490,6 +492,7 @@ export const DEFAULT_CONFIG: Config = {
   config_version: '>1.0.53',
   client_id: crypto.randomUUID(),
   use_remote_comfyui: false,
+  comfy_batch_profiles: [],
   local_comfyui_config: {
     python_cmd: '',
     comfyui_dir: '',

--- a/packages/app/src/shared/locales/en-US/renderer.json
+++ b/packages/app/src/shared/locales/en-US/renderer.json
@@ -820,8 +820,7 @@
       "select_source": "Choose source image folder",
       "cancel_sent": "Batch cancellation requested",
       "source": "Source",
-      "output": "Output",
-      "comfy_not_ready": "ComfyUI is not ready yet."
+      "output": "Output"
     }
   },
   "chat": {

--- a/packages/app/src/shared/locales/en-US/renderer.json
+++ b/packages/app/src/shared/locales/en-US/renderer.json
@@ -793,6 +793,35 @@
         "complete": "Video generation completed.",
         "failed": "Generation failed: {{error}}"
       }
+    },
+    "batch": {
+      "button": "Batch folder",
+      "title": "ComfyUI image batch",
+      "instances": "ComfyUI instances",
+      "enabled": "Enabled",
+      "name": "Name",
+      "url": "ComfyUI URL / AutoDL forwarded URL",
+      "concurrency": "Concurrency",
+      "test": "Test",
+      "add_instance": "Add instance",
+      "start": "Choose folder and start",
+      "output_hint": "Outputs are written only to the adjacent *.output folder. The source folder is never modified and no *.work folder is created.",
+      "total": "Total: {{count}}",
+      "success": "Succeeded: {{count}}",
+      "failed": "Failed: {{count}}",
+      "skipped": "Skipped: {{count}}",
+      "running": "Running: {{count}}",
+      "pending": "Pending: {{count}}",
+      "state": "State: {{state}}",
+      "cancel": "Cancel",
+      "retry": "Retry unfinished items",
+      "new": "New batch",
+      "close": "Close",
+      "select_source": "Choose source image folder",
+      "cancel_sent": "Batch cancellation requested",
+      "source": "Source",
+      "output": "Output",
+      "comfy_not_ready": "ComfyUI is not ready yet."
     }
   },
   "chat": {

--- a/packages/app/src/shared/locales/zh-CN/renderer.json
+++ b/packages/app/src/shared/locales/zh-CN/renderer.json
@@ -690,6 +690,35 @@
         "complete": "视频生成完成。",
         "failed": "生成失败：{{error}}"
       }
+    },
+    "batch": {
+      "button": "目录批处理",
+      "title": "ComfyUI 图片目录批处理",
+      "instances": "ComfyUI 实例",
+      "enabled": "启用",
+      "name": "名称",
+      "url": "ComfyUI URL / AutoDL 转发地址",
+      "concurrency": "并发",
+      "test": "测试",
+      "add_instance": "添加实例",
+      "start": "选择目录并开始",
+      "output_hint": "输出只写入源目录旁的 *.output；原目录不会被修改，也不会创建 *.work。",
+      "total": "总数：{{count}}",
+      "success": "成功：{{count}}",
+      "failed": "失败：{{count}}",
+      "skipped": "跳过：{{count}}",
+      "running": "运行中：{{count}}",
+      "pending": "等待：{{count}}",
+      "state": "状态：{{state}}",
+      "cancel": "取消",
+      "retry": "重试未完成项",
+      "new": "新建批次",
+      "close": "关闭",
+      "select_source": "选择源图片目录",
+      "cancel_sent": "批处理取消请求已发送",
+      "source": "原目录",
+      "output": "输出目录",
+      "comfy_not_ready": "ComfyUI 尚未就绪。"
     }
   },
   "chat": {

--- a/packages/app/src/shared/locales/zh-CN/renderer.json
+++ b/packages/app/src/shared/locales/zh-CN/renderer.json
@@ -717,8 +717,7 @@
       "select_source": "选择源图片目录",
       "cancel_sent": "批处理取消请求已发送",
       "source": "原目录",
-      "output": "输出目录",
-      "comfy_not_ready": "ComfyUI 尚未就绪。"
+      "output": "输出目录"
     }
   },
   "chat": {

--- a/packages/app/src/shared/qApp/cfgTypes.ts
+++ b/packages/app/src/shared/qApp/cfgTypes.ts
@@ -206,18 +206,5 @@ export type QAppCfg = {
      * 批量处理时会自动替换这个 slot 的值为待处理的图片
      */
     imageInputSlot: JsonPath
-    /**
-     * 批量处理专用工作流文件名（可选）
-     * 如果指定，批量处理时会使用这个工作流而不是默认工作流
-     * 这对于需要编译时间的工作流很有用（如 TorchCompile）
-     * 文件名相对于当前快应用所在目录
-     */
-    batchWorkflow?: string
-    /**
-     * 批量工作流中图片输入的 JSON Path（可选）
-     * 如果 batchWorkflow 使用了不同的节点 ID，需要指定这个字段
-     * 如果未指定，将使用 imageInputSlot
-     */
-    batchImageInputSlot?: JsonPath
   }
 }

--- a/scripts/projectCanvas/webglBenchmark.mjs
+++ b/scripts/projectCanvas/webglBenchmark.mjs
@@ -813,6 +813,12 @@ export async function runWebglBenchmark() {
     assertNonIntrusiveWindowPlacement(windowPlacement, 'WebGL benchmark')
     const payload = {
       benchmarkImageCount: benchmarkImages.length,
+      baseline: {
+        capturedAt: new Date().toISOString(),
+        renderCount: baselineRenderCount,
+        spriteReconcilePassCount: baselineSpriteReconcilePassCount,
+        metrics: baselineMetrics
+      },
       windowPlacement,
       ...metrics,
       zoomedMetrics: cullingBenchmark.metrics,
@@ -829,11 +835,18 @@ export async function runWebglBenchmark() {
       interactionBenchmark
     }
 
-    await fs.writeFile(
-      path.join(artifactRoot, 'webgl-benchmark-report.json'),
-      JSON.stringify(payload, null, 2),
-      'utf8'
-    )
+    await Promise.all([
+      fs.writeFile(
+        path.join(artifactRoot, 'webgl-benchmark-baseline.json'),
+        JSON.stringify(payload.baseline, null, 2),
+        'utf8'
+      ),
+      fs.writeFile(
+        path.join(artifactRoot, 'webgl-benchmark-report.json'),
+        JSON.stringify(payload, null, 2),
+        'utf8'
+      )
+    ])
     console.log(JSON.stringify(payload, null, 2))
 
     if (


### PR DESCRIPTION
## Summary

- add a minimal Quick App image-folder batch flow for multiple ComfyUI endpoints
- keep source folders read-only and write only adjacent `*.output` PNGs plus a lightweight manifest
- resume safely with content fingerprints, skip valid successes, retry failures, and remove stale outputs
- schedule compatible ComfyUI profiles by least occupancy with round-robin ties
- retain the focused Project Canvas interaction, reconcile, WebGL sampling, and adaptive-quality improvements

## Scope constraints

- no `*.work` directory
- no durable queue, SQLite job lifecycle, output-route store, or general task platform
- image input only; exactly one bound `type=output` PNG result per source

## Validation

- `npm run typecheck`
- `npm run lint` (passes; repository baseline warnings remain)
- focused batch tests: 4 suites / 25 tests
- `npm run test:project-canvas:benchmark-smoke`: 4 suites / 32 tests
- focused Canvas tests: 3 suites / 93 tests (`--testTimeout=20000`; default 5s run showed two environment-sensitive flakes that passed in isolation and the complete rerun)
- `npm run build:pure`

## Pending before merge

- same-machine real-corpus `mixed-3000` cold/warm baseline-versus-current artifacts; the local ComfyUI/Terrarium processes must be stopped first to avoid contaminating memory/GPU measurements
- live integration with at least two independent ComfyUI instances
