### PR TITLE
fix(comfy): show probe errors and gate release PR

### DIFF
--- a/.github/workflows/nightly-bump-version.yml
+++ b/.github/workflows/nightly-bump-version.yml
@@ -124,12 +124,10 @@ jobs:
     permissions:
       actions: read
       contents: write
-      pull-requests: write
     outputs:
       tag_name: ${{ steps.tag-version.outputs.tag_name }}
       release_name: ${{ steps.tag-version.outputs.release_name }}
       ref: ${{ steps.commit-version-bump.outputs.ref }}
-      pr_number: ${{ steps.open-pr.outputs.pr_number }}
       commit_message: ${{ steps.commit-version-bump.outputs.commit_message }}
     steps:
       - name: Checkout code
@@ -181,50 +179,6 @@ jobs:
           echo "commit_message=$COMMIT_MESSAGE" >> "$GITHUB_OUTPUT"
           echo "ref=$COMMIT_SHA" >> "$GITHUB_OUTPUT"
 
-      - name: Create or update release PR
-        id: open-pr
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PR_NUMBER=$(gh pr list \
-            --base master \
-            --head "$RELEASE_BRANCH" \
-            --state open \
-            --json number \
-            --jq '.[0].number')
-
-          PR_BODY=$(cat <<EOF
-          Automated nightly release PR.
-
-          - Source branch: \`$RELEASE_BRANCH\`
-          - Release mode: \`${{ needs.check-commits.outputs.release_mode }}\`
-          - Triggered by: \`${{ github.workflow }}\`
-          - Run: \`${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\`
-          - Merge policy: this PR is merged only after the release package is built and uploaded successfully.
-          EOF
-          )
-
-          if [ -n "$PR_NUMBER" ]; then
-            gh pr edit "$PR_NUMBER" \
-              --title "${{ steps.commit-version-bump.outputs.commit_message }}" \
-              --body "$PR_BODY"
-          else
-            gh pr create \
-              --base master \
-              --head "$RELEASE_BRANCH" \
-              --title "${{ steps.commit-version-bump.outputs.commit_message }}" \
-              --body "$PR_BODY"
-
-            PR_NUMBER=$(gh pr list \
-              --base master \
-              --head "$RELEASE_BRANCH" \
-              --state open \
-              --json number \
-              --jq '.[0].number')
-          fi
-
-          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
-
   candidate-ci:
     needs: bump-version
     if: needs.bump-version.result == 'success'
@@ -252,6 +206,74 @@ jobs:
     with:
       ref: ${{ needs.bump-version.outputs.ref }}
 
+  open-release-pr:
+    needs:
+      - check-commits
+      - bump-version
+      - candidate-ci
+      - candidate-build
+      - candidate-embedded
+      - release
+    if: >-
+      needs.bump-version.result == 'success' &&
+      needs.candidate-ci.result == 'success' &&
+      needs.candidate-build.result == 'success' &&
+      needs.candidate-embedded.result == 'success' &&
+      needs.release.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      pr_number: ${{ steps.open-pr.outputs.pr_number }}
+    steps:
+      - name: Create or update release PR
+        id: open-pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          PR_NUMBER=$(gh pr list \
+            --base master \
+            --head "$RELEASE_BRANCH" \
+            --state open \
+            --json number \
+            --jq '.[0].number')
+
+          PR_BODY=$(cat <<EOF
+          Automated nightly release PR.
+
+          - Source branch: \`$RELEASE_BRANCH\`
+          - Release mode: \`${{ needs.check-commits.outputs.release_mode }}\`
+          - Triggered by: \`${{ github.workflow }}\`
+          - Run: \`${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\`
+          - Merge policy: this PR is created only after all candidate and release packages succeed.
+          EOF
+          )
+
+          if [ -n "$PR_NUMBER" ]; then
+            gh pr edit "$PR_NUMBER" \
+              --title "${{ needs.bump-version.outputs.commit_message }}" \
+              --body "$PR_BODY"
+          else
+            gh pr create \
+              --base master \
+              --head "$RELEASE_BRANCH" \
+              --title "${{ needs.bump-version.outputs.commit_message }}" \
+              --body "$PR_BODY"
+
+            PR_NUMBER=$(gh pr list \
+              --base master \
+              --head "$RELEASE_BRANCH" \
+              --state open \
+              --json number \
+              --jq '.[0].number')
+          fi
+
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
   release:
     needs:
       - bump-version
@@ -277,7 +299,10 @@ jobs:
     needs:
       - bump-version
       - release
-    if: needs.release.result == 'success'
+      - open-release-pr
+    if: >-
+      needs.release.result == 'success' &&
+      needs.open-release-pr.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -287,7 +312,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr merge "${{ needs.bump-version.outputs.pr_number }}" \
+          gh pr merge "${{ needs.open-release-pr.outputs.pr_number }}" \
             --repo "${{ github.repository }}" \
             --squash \
             --delete-branch=false \

--- a/packages/app/src/renderer/src/pages/QuickAppPage/QAppExecutePanel/ComfyBatchProfileEditor.tsx
+++ b/packages/app/src/renderer/src/pages/QuickAppPage/QAppExecutePanel/ComfyBatchProfileEditor.tsx
@@ -5,9 +5,9 @@ import { api } from '@renderer/utils/windowUtils'
 import type { ComfyBatchProfile, ComfyBatchProbeResult } from '@shared/api/svcComfyBatch'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { getComfyProfileStatusLabel } from './comfyBatchProfileDisplay'
 
 const profileText = {
-  enabled: 'Enabled',
   url: 'URL',
   concurrency: 'Concurrency',
   test: 'Test',
@@ -112,7 +112,11 @@ export default function ComfyBatchProfileEditor({
                     onChange={(_, enabled) => updateProfile(profile.id, { enabled })}
                   />
                 }
-                label={t('qapp.batch.enabled', profileText.enabled)}
+                label={
+                  <Typography variant="body2" color={probe?.ok ? 'success.main' : 'error.main'}>
+                    {getComfyProfileStatusLabel(probe)}
+                  </Typography>
+                }
               />
               <TextField
                 size="small"
@@ -147,11 +151,6 @@ export default function ComfyBatchProfileEditor({
                 <Delete />
               </Button>
             </Stack>
-            {probe && (
-              <Typography variant="caption" color={probe.ok ? 'success.main' : 'error.main'}>
-                {probe.ok ? `${probe.latencyMs} ms` : probe.error}
-              </Typography>
-            )}
           </Stack>
         )
       })}

--- a/packages/app/src/renderer/src/pages/QuickAppPage/QAppExecutePanel/comfyBatchProfileDisplay.test.ts
+++ b/packages/app/src/renderer/src/pages/QuickAppPage/QAppExecutePanel/comfyBatchProfileDisplay.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { getComfyProfileStatusLabel } from './comfyBatchProfileDisplay'
+
+describe('Comfy batch profile status label', () => {
+  it('formats successful probe latency for the startup switch', () => {
+    expect(getComfyProfileStatusLabel({ ok: true, latencyMs: 7 })).toBe('7 ms')
+  })
+
+  it('does not show a status label before a successful probe', () => {
+    expect(getComfyProfileStatusLabel()).toBe('')
+    expect(getComfyProfileStatusLabel({ ok: false, latencyMs: 0 })).toBe('')
+  })
+
+  it('shows probe errors beside the startup switch', () => {
+    expect(getComfyProfileStatusLabel({ ok: false, latencyMs: 0, error: 'fetch failed' })).toBe(
+      'fetch failed'
+    )
+  })
+})

--- a/packages/app/src/renderer/src/pages/QuickAppPage/QAppExecutePanel/comfyBatchProfileDisplay.ts
+++ b/packages/app/src/renderer/src/pages/QuickAppPage/QAppExecutePanel/comfyBatchProfileDisplay.ts
@@ -1,0 +1,8 @@
+import type { ComfyBatchProbeResult } from '@shared/api/svcComfyBatch'
+
+export function getComfyProfileStatusLabel(
+  probe?: Pick<ComfyBatchProbeResult, 'ok' | 'latencyMs' | 'error'>
+): string {
+  if (!probe) return ''
+  return probe.ok ? `${probe.latencyMs} ms` : (probe.error ?? '')
+}

--- a/packages/app/src/renderer/src/pages/SettingsPage/PanelEnvironment.test.tsx
+++ b/packages/app/src/renderer/src/pages/SettingsPage/PanelEnvironment.test.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { DEFAULT_CONFIG } from '@shared/config/config'
 import PanelEnvironment from './PanelEnvironment'
@@ -215,5 +215,31 @@ describe('PanelEnvironment', () => {
     expect(await screen.findByDisplayValue('https://comfy.example.com')).toBeTruthy()
     expect(screen.getByRole('button', { name: 'Add instance' })).toBeTruthy()
     expect(screen.queryByRole('heading', { name: 'ComfyUI Mode' })).toBeNull()
+  })
+
+  it('shows probe latency beside the ComfyUI startup switch instead of Enabled', async () => {
+    apiMock.svcComfyBatch.probeProfile.mockResolvedValueOnce({
+      result: {
+        ok: true,
+        baseUrl: 'https://comfy.example.com',
+        latencyMs: 7
+      }
+    })
+    render(<PanelEnvironment settingsValue={DEFAULT_CONFIG} saveSettings={vi.fn()} />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Test' }))
+
+    expect(await screen.findByRole('switch', { name: '7 ms' })).toBeTruthy()
+    expect(screen.queryByText('Enabled')).toBeNull()
+  })
+
+  it('shows probe errors beside the ComfyUI startup switch', async () => {
+    apiMock.svcComfyBatch.probeProfile.mockRejectedValueOnce(new Error('fetch failed'))
+    render(<PanelEnvironment settingsValue={DEFAULT_CONFIG} saveSettings={vi.fn()} />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Test' }))
+
+    expect(await screen.findByRole('switch', { name: 'fetch failed' })).toBeTruthy()
+    expect(screen.queryByText('Enabled')).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary
- show ComfyUI probe latency or errors beside the startup switch
- create the nightly release PR only after candidate and release packages succeed

## Verification
- npx vitest run --config config/vitest/vitest.web.config.mjs packages/app/src/renderer/src/pages/SettingsPage/PanelEnvironment.test.tsx packages/app/src/renderer/src/pages/QuickAppPage/QAppExecutePanel/comfyBatchProfileDisplay.test.ts --pool=forks --maxWorkers=1
- npm run typecheck:web
- Prettier and ESLint checks