### PR TITLE
fix(release): remove stale embedded submodule

### DIFF
--- a/.github/workflows/nightly-bump-version.yml
+++ b/.github/workflows/nightly-bump-version.yml
@@ -30,6 +30,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.19.0'
+
       - name: Check for new commits
         id: check-commits
         env:
@@ -119,6 +124,11 @@ jobs:
           ref: refs/heads/master
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.19.0'
 
       - name: Prepare release branch
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@ config.json
 !/vendor/comfyui/comfyui_data/custom_nodes/ComfyUI_smZNodes
 !/vendor/comfyui/comfyui_data/custom_nodes/comfyui_LLM_party
 !/vendor/comfyui/comfyui_data/custom_nodes/comfyui_controlnet_aux
-!/vendor/comfyui/comfyui_data/custom_nodes/z-tipo-extension
 
 # ComfyUI junction directories (symlinks to comfyui_data/, fully ignored)
 /vendor/comfyui/ComfyUI/models

--- a/.gitmodules
+++ b/.gitmodules
@@ -38,9 +38,6 @@
 [submodule "vendor/comfyui/comfyui_data/custom_nodes/ComfyUI_smZNodes"]
 	path = vendor/comfyui/comfyui_data/custom_nodes/ComfyUI_smZNodes
 	url = https://github.com/shiimizu/ComfyUI_smZNodes.git
-[submodule "vendor/comfyui/comfyui_data/custom_nodes/z-tipo-extension"]
-	path = vendor/comfyui/comfyui_data/custom_nodes/z-tipo-extension
-	url = https://github.com/KohakuBlueleaf/z-tipo-extension.git
 [submodule "vendor/comfyui/comfyui_data/custom_nodes/ComfyUI-RGB-White-Matte"]
 	path = vendor/comfyui/comfyui_data/custom_nodes/ComfyUI-RGB-White-Matte
 	url = https://github.com/172908710/ComfyUI-RGB-White-Matte.git

--- a/scripts/comfy/embedded-sources.json
+++ b/scripts/comfy/embedded-sources.json
@@ -78,12 +78,6 @@
       "url": "https://github.com/shiimizu/ComfyUI_smZNodes.git",
       "commit": "9ef7c63acec6c09b2e8dfe26bbf9c9876857a004",
       "relativePath": "vendor/comfyui/comfyui_data/custom_nodes/ComfyUI_smZNodes"
-    },
-    {
-      "name": "z-tipo-extension",
-      "url": "https://github.com/KohakuBlueleaf/z-tipo-extension.git",
-      "commit": "6132862978021727284215bc2d5fe5257a872709",
-      "relativePath": "vendor/comfyui/comfyui_data/custom_nodes/z-tipo-extension"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Remove the deleted `z-tipo-extension` from the embedded source manifest, `.gitmodules`, and ignore allowlist.
- Pin nightly release preparation to Node.js 22.19.0.

## Validation
- Embedded staging tests: 3 passed.
- Nightly workflow tests: 2 passed.
- Package script test: passed.
- Embedded source manifest validation: 13 tracked sources; no stale submodule reference.