### PR TITLE
fix(comfy): disable websocket compression

### DIFF
--- a/packages/app/src/main/comfy/http.test.ts
+++ b/packages/app/src/main/comfy/http.test.ts
@@ -174,7 +174,7 @@ describe('ComfyHttpCli', () => {
     expect(webSocketCtor).toHaveBeenCalledWith(
       expect.any(String),
       expect.objectContaining({
-        perMessageDeflate: true
+        perMessageDeflate: false
       })
     )
   })

--- a/packages/app/src/main/comfy/http.ts
+++ b/packages/app/src/main/comfy/http.ts
@@ -250,8 +250,10 @@ export class ComfyHttpCli {
     const schema = urlObj.protocol === 'https:' ? 'wss:' : 'ws:'
     urlObj.protocol = schema
     const url = urlObj.href
+    // Some remote ComfyUI reverse proxies accept the websocket handshake but
+    // immediately close connections that negotiate permessage-deflate.
     return new WebSocket(url, {
-      perMessageDeflate: true
+      perMessageDeflate: false
     })
   }
 


### PR DESCRIPTION
## Summary
- Disable WebSocket `permessage-deflate` negotiation for ComfyUI connections.
- Keep the regression assertion aligned with the transport behavior.

## Why
Some remote ComfyUI reverse proxies accept the WebSocket handshake and then immediately close connections when compression is negotiated, causing a continuous reconnect loop. The affected endpoint remains stable when compression is disabled.

## Validation
- `npx vitest run --config config/vitest/vitest.node.config.mjs packages/app/src/main/comfy/http.test.ts`
- `npm run typecheck:node`
- `npm run lint:main -- --no-cache` (existing warnings only)
